### PR TITLE
Fiks problem hvor createTemplate tillot feil deklarering av språk

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/EksempelBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/EksempelBrev.kt
@@ -2,11 +2,11 @@ package no.nav.pensjon.brev.maler
 
 import no.nav.pensjon.brev.api.model.LetterMetadata
 import no.nav.pensjon.brev.api.model.maler.EksempelBrevDto
+import no.nav.pensjon.brev.template.*
 import no.nav.pensjon.brev.template.Element.Table.RowColour.GRAY
 import no.nav.pensjon.brev.template.Element.Text.FontType.BOLD
 import no.nav.pensjon.brev.template.Element.Text.FontType.ITALIC
 import no.nav.pensjon.brev.template.Language.Bokmal
-import no.nav.pensjon.brev.template.StaticTemplate
 import no.nav.pensjon.brev.template.base.PensjonLatex
 import no.nav.pensjon.brev.template.dsl.createTemplate
 import no.nav.pensjon.brev.template.dsl.expression.map
@@ -26,9 +26,6 @@ object EksempelBrev : StaticTemplate {
 
         // Unik datagrunnlag/DTO for brevet
         letterDataType = EksempelBrevDto::class,
-
-        // Hvilke språk brevet støtter
-        lang = languages(Bokmal),
 
         // Hovedtittel inne i brevet
         title = newText(Bokmal to "Eksempelbrev"),

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OmsorgEgenAuto.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OmsorgEgenAuto.kt
@@ -16,7 +16,6 @@ object OmsorgEgenAuto : StaticTemplate {
         name = "OMSORG_EGEN_AUTO",
         base = PensjonLatex,
         letterDataType = OmsorgEgenAutoDto::class,
-        lang = languages(Bokmal, Nynorsk, English),
         title = newText(
             Bokmal to "Du må sende oss egenerklæring om pleie- og omsorgsarbeid",
             Nynorsk to "Du må sende oss eigenmelding om pleie- og omsorgsarbeid",

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/LetterTemplate.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/LetterTemplate.kt
@@ -119,6 +119,7 @@ sealed class Element<out Lang : LanguageSupport> {
     sealed class Text<out Lang : LanguageSupport> : Element<Lang>() {
         data class Literal<out Lang : LanguageSupport> private constructor(
             private val text: Map<Language, String>,
+            val languages: Lang,
             val fontType: FontType
         ) : Text<Lang>() {
 
@@ -130,20 +131,32 @@ sealed class Element<out Lang : LanguageSupport> {
                 fun <Lang1 : Language> create(
                     lang1: Pair<Lang1, String>,
                     fontType: FontType = FontType.PLAIN
-                ) = Literal<LanguageSupport.Single<Lang1>>(mapOf(lang1), fontType)
+                ) = Literal<LanguageSupport.Single<Lang1>>(
+                    text = mapOf(lang1),
+                    languages = LanguageCombination.Single(lang1.first),
+                    fontType = fontType
+                )
 
                 fun <Lang1 : Language, Lang2 : Language> create(
                     lang1: Pair<Lang1, String>,
                     lang2: Pair<Lang2, String>,
                     fontType: FontType = FontType.PLAIN,
-                ) = Literal<LanguageSupport.Double<Lang1, Lang2>>(mapOf(lang1, lang2), fontType)
+                ) = Literal<LanguageSupport.Double<Lang1, Lang2>>(
+                    text = mapOf(lang1, lang2),
+                    languages = LanguageCombination.Double(lang1.first, lang2.first),
+                    fontType = fontType
+                )
 
                 fun <Lang1 : Language, Lang2 : Language, Lang3 : Language> create(
                     lang1: Pair<Lang1, String>,
                     lang2: Pair<Lang2, String>,
                     lang3: Pair<Lang3, String>,
                     fontType: FontType = FontType.PLAIN,
-                ) = Literal<LanguageSupport.Triple<Lang1, Lang2, Lang3>>(mapOf(lang1, lang2, lang3), fontType)
+                ) = Literal<LanguageSupport.Triple<Lang1, Lang2, Lang3>>(
+                    text = mapOf(lang1, lang2, lang3),
+                    languages = LanguageCombination.Triple(lang1.first, lang2.first, lang3.first),
+                    fontType = fontType
+                )
             }
         }
 

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/dsl/Template.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/dsl/Template.kt
@@ -12,13 +12,12 @@ fun <Lang : LanguageSupport, LetterData : Any> createTemplate(
     name: String,
     base: BaseTemplate,
     letterDataType: KClass<LetterData>,
-    lang: Lang,
     title: Element.Text.Literal<Lang>,
     letterMetadata: LetterMetadata,
     init: TemplateRootScope<Lang, LetterData>.() -> Unit
 ): LetterTemplate<Lang, LetterData> =
     with(TemplateRootScope<Lang, LetterData>().apply(init)) {
-        return LetterTemplate(name, title, base, letterDataType, lang, outline, attachments, letterMetadata)
+        return LetterTemplate(name, title, base, letterDataType, title.languages, outline, attachments, letterMetadata)
     }
 
 

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/LanguageTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/LanguageTest.kt
@@ -10,7 +10,7 @@ class LanguageTest {
         val baseLang = LanguageCombination.Triple(Language.Bokmal, Language.Nynorsk, Language.English)
 
         // Verifies that BaseLanguages contains all supported languages (won't compile)
-        val verify: BaseLanguages = baseLang
+        @Suppress("UNUSED_VARIABLE") val verify: BaseLanguages = baseLang
 
         assertEquals(Language::class.findSealedObjects(), with(baseLang) { setOf(first, second, third) })
     }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/base/PensjonLatexITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/base/PensjonLatexITest.kt
@@ -29,7 +29,6 @@ class PensjonLatexITest {
             name = "test-template",
             base = PensjonLatex,
             letterDataType = TestTemplateDto::class,
-            lang = languages(Bokmal),
             title = newText(Bokmal to "En fin tittel"),
             letterMetadata = LetterMetadata(
                 displayTitle = "En fin display tittel",
@@ -94,7 +93,6 @@ class PensjonLatexITest {
                 name = "test-template",
                 base = PensjonLatex,
                 letterDataType = TestTemplateDto::class,
-                lang = languages(Bokmal),
                 title = newText(Bokmal to "En fin tittel"),
                 letterMetadata = LetterMetadata(
                     displayTitle = "En fin display tittel",

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/dsl/ShowIfTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/dsl/ShowIfTest.kt
@@ -31,7 +31,6 @@ class ShowIfTest {
             name = "test",
             base = PensjonLatex,
             letterDataType = SomeDto::class,
-            lang = languages(Language.Nynorsk),
             title = nynorskTittel,
             letterMetadata = testLetterMetadata,
         ) {
@@ -76,7 +75,6 @@ class ShowIfTest {
             name = "test",
             base = PensjonLatex,
             letterDataType = SomeDto::class,
-            lang = languages(Language.Nynorsk),
             title = nynorskTittel,
             letterMetadata = testLetterMetadata,
         ) {
@@ -121,7 +119,6 @@ class ShowIfTest {
             name = "test",
             base = PensjonLatex,
             letterDataType = SomeDto::class,
-            lang = languages(Language.Nynorsk),
             title = nynorskTittel,
             letterMetadata = testLetterMetadata,
         ) {

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/dsl/TemplateTableTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/dsl/TemplateTableTest.kt
@@ -15,7 +15,6 @@ class TemplateTableTest {
             name = "test",
             base = PensjonLatex,
             letterDataType = Unit::class,
-            lang = languages(Language.Bokmal),
             title = bokmalTittel,
             letterMetadata = testLetterMetadata,
         ) {
@@ -62,7 +61,6 @@ class TemplateTableTest {
                 name = "test",
                 base = PensjonLatex,
                 letterDataType = Unit::class,
-                lang = languages(Language.Bokmal),
                 title = bokmalTittel,
                 letterMetadata = testLetterMetadata,
             ) {
@@ -94,7 +92,6 @@ class TemplateTableTest {
                 name = "test",
                 base = PensjonLatex,
                 letterDataType = Unit::class,
-                lang = languages(Language.Bokmal),
                 title = bokmalTittel,
                 letterMetadata = testLetterMetadata,
             ) {

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/dsl/TemplateTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/dsl/TemplateTest.kt
@@ -19,7 +19,6 @@ class TemplateTest {
             name = "test",
             base = PensjonLatex,
             letterDataType = Unit::class,
-            lang = languages(Language.Bokmal),
             title = bokmalTittel,
             letterMetadata = testLetterMetadata,
         ) {
@@ -71,7 +70,6 @@ class TemplateTest {
             name = "test",
             base = PensjonLatex,
             letterDataType = SomeDto::class,
-            lang = languages(Language.Bokmal),
             title = bokmalTittel,
             letterMetadata = testLetterMetadata,
         ) {
@@ -138,7 +136,6 @@ class TemplateTest {
             name = "test",
             base = PensjonLatex,
             letterDataType = Unit::class,
-            lang = languages(Language.Bokmal),
             title = bokmalTittel,
             letterMetadata = testLetterMetadata,
         ) {
@@ -166,7 +163,6 @@ class TemplateTest {
             name = "test",
             base = PensjonLatex,
             letterDataType = Unit::class,
-            lang = languages(Language.Bokmal),
             title = bokmalTittel,
             letterMetadata = testLetterMetadata,
         ) {
@@ -201,7 +197,6 @@ class TemplateTest {
             name = "test",
             base = PensjonLatex,
             letterDataType = SomeDto::class,
-            lang = languages(Language.Bokmal),
             title = bokmalTittel,
             letterMetadata = testLetterMetadata,
         ) {


### PR DESCRIPTION
Pga. endringen hvor type-parameteren Lang er kovariant så tillot createTemplate funksjonen at man sender inn `lang = languages(Bokmal, Nynorsk), title = newText(Bokmal to "")`. Da vil typen til malen bli LangBokmal, men LanguageCombination objektet vil svare runtime at malen er LangBokmalNynorsk.
