### PR TITLE
splitt felter i ufoeretrygdPeraMaaned i netto og brutto.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,7 @@ Kjør `docker compose up -d` i rot-katalogen til prosjektet.
 ### Debugge pdf-bygger lokalt
 Pdf-byggeren er avhengig av ulike pakker for å kompilere LaTeX til pdf.
 Derfor må man kjøre pdf-bygger java applikasjonen inne i containeren for at den skal fungere.
-For å debugge pdf-byggeren må man derfor sette opp remote debug mot applikasjonen som kjører inne i containeren.
-
-1. Lag en ny run configuration i Intellij av typen Dockerfile.
-   * Sett bind ports til `8081:8080 5005:5005`
-   * Sett en environment variabel `JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005`
-     Om denne verdien er forskjellig i neste steg, erstatt den.
-   
-2. Lag en ny run configuration av typen remote jvm debug. Under before launch legg til "Run another configuration" og velg
-    docker compose konfigurasjonen vi lagde i forrige steg. 
-3. Kjør remote jvm debug konfigurasjonen.
-
+Når man kjører lokalt med docker compose er den allerede satt opp til remote debug på port 5016 ([se docker-compose.yml](docker-compose.yml)).
 
 ### Ytelsestesting med locust
 
@@ -45,6 +35,50 @@ class HelloWorldUser(HttpUser):
 ```
 </details>
 
-2. Start docker compose med locust profil `docker compose --profile locust up`
-3. Gå inn på locust grensesnittet via http://localhost:8089/ og skriv inn url til endepunktet du ønsker å ytelses-teste.
+1. Start docker compose med locust profil `docker compose --profile locust up`
+2. Gå inn på locust grensesnittet via http://localhost:8089/ og skriv inn url til endepunktet du ønsker å ytelses-teste.
 [Se dokumentasjon fra locust for mer info om bruk.](http://docs.locust.io/en/stable/quickstart.html#locust-s-web-interface)
+
+## Endring av obligatoriske felter i API-model
+
+Brevbakeren bruker pensjon-brevbaker-api-model for bestilling av brev.
+Api modellen eksporteres som artifakt og brukes av eksterne systemer for å fylle ut informasjon som kreves ved bestilling av brev.
+
+Vi må kunne endre på obligatoriske felter i api modellen uten å ødelegge pågående brevbestillinger i produksjon.
+For å oppnå dette må man ha en overgangsperiode hvor brevbakeren er kompatibel med gammel og ny versjon av api modellen.
+Vi kan ikke bytte direkte over til ny versjon uten å gjøre avsender inkompatibel med mottaker(brevbaker), noe som vil kreve nedetid.
+
+### Lage duplikate felter i en overgangsperiode
+
+La oss si at vi skal erstatte ett felt annetBeloep med barnetillegg:
+
+```
+// før
+data class PensjonsBrevDto(
+    val annetBeloep: Int,
+)
+
+// etter
+data class PensjonsBrevDto(
+    val barnetillegg: Kroner,
+)
+```
+
+En strategi for overgangen kan se slik ut:
+1. Påkrev begge versjoner av feltene samtidig og bruk denne modellen på avsender-siden. 
+   Brevbakeren er satt opp til å ignorere ukjente felter(fail on unknown properties=false), så den vil fortsette å lese annetBeloep i dette tilfellet.
+    ```
+    // overgangsperiode
+    data class PensjonsBrevDto(
+        val barnetillegg: Kroner,
+        val annetBeloep: Int,
+    )
+    ```
+2. Ta i bruk de nye feltene i Brevbakeren. Nå vil brevbakeren ignorere det gamle feltet og bruke det nye:
+   ```
+   // 
+   data class PensjonsBrevDto(
+       val barnetillegg: Kroner,
+   )
+    ```
+3. Ta i bruk den nye versjonen i avsender systemet.

--- a/pensjon-brevbaker-api-model/build.gradle.kts
+++ b/pensjon-brevbaker-api-model/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "no.nav.pensjon.brev"
-version = "3.5.2"
+version = "3.5.3"
 
 java {
     withSourcesJar()

--- a/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/vedlegg/MaanedligUfoeretrygdFoerSkatt.kt
+++ b/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/vedlegg/MaanedligUfoeretrygdFoerSkatt.kt
@@ -10,18 +10,27 @@ data class MaanedligUfoeretrygdFoerSkattDto(
 ) {
     data class UfoeretrygdPerMaaned(
         val annetBelop: Kroner,
-        val barnetillegg: BeloepMedAvkortning?,
+        @Deprecated("Use separate brutto/netto values") val barnetillegg: BeloepMedAvkortning?, // TODO remove in next version
+        val barnetilleggBrutto: Kroner?,
+        val barnetilleggNetto: Kroner?,
         val dekningFasteUtgifter: Kroner?,
-        val garantitilleggNordisk27: BeloepMedAvkortning?,
+        val erAvkortet: Boolean,
+        @Deprecated("Use separate brutto/netto values") val garantitilleggNordisk27: BeloepMedAvkortning?, // TODO remove in next version
+        val garantitilleggNordisk27Brutto: Kroner?,
+        val garantitilleggNordisk27Netto: Kroner?,
         val grunnbeloep: Kroner,
-        val ordinaerUTBeloep: BeloepMedAvkortning,
-        val totalUTBeloep: BeloepMedAvkortning,
+        @Deprecated("Use separate brutto/netto values") val ordinaerUTBeloep: BeloepMedAvkortning, // TODO remove in next version
+        val ordinaerUTBeloepBrutto: Kroner,
+        val ordinaerUTBeloepNetto: Kroner,
+        @Deprecated("Use separate brutto/netto values") val totalUTBeloep: BeloepMedAvkortning, // TODO remove in next version
+        val totalUTBeloepBrutto: Kroner?, //TODO make mandatory in next version
+        val totalUTBeloepNetto: Kroner?, //TODO make mandatory in next version
         val virkningFraOgMed: LocalDate,
         val virkningTilOgMed: LocalDate?,
-        val erAvkortet: Boolean,
     ) {
 
-        data class BeloepMedAvkortning(
+        @Deprecated("Use separate brutto/netto values")
+        data class BeloepMedAvkortning(// TODO remove in next version
             val netto: Kroner,
             val brutto: Kroner,
         )

--- a/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/vedlegg/MaanedligUfoeretrygdFoerSkatt.kt
+++ b/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/vedlegg/MaanedligUfoeretrygdFoerSkatt.kt
@@ -10,27 +10,27 @@ data class MaanedligUfoeretrygdFoerSkattDto(
 ) {
     data class UfoeretrygdPerMaaned(
         val annetBelop: Kroner,
-        @Deprecated("Use separate brutto/netto values") val barnetillegg: BeloepMedAvkortning?, // TODO remove in next version
+        val barnetillegg: BeloepMedAvkortning?, // TODO remove in next version
         val barnetilleggBrutto: Kroner?,
         val barnetilleggNetto: Kroner?,
         val dekningFasteUtgifter: Kroner?,
         val erAvkortet: Boolean,
-        @Deprecated("Use separate brutto/netto values") val garantitilleggNordisk27: BeloepMedAvkortning?, // TODO remove in next version
+        val garantitilleggNordisk27: BeloepMedAvkortning?, // TODO remove in next version
         val garantitilleggNordisk27Brutto: Kroner?,
         val garantitilleggNordisk27Netto: Kroner?,
         val grunnbeloep: Kroner,
-        @Deprecated("Use separate brutto/netto values") val ordinaerUTBeloep: BeloepMedAvkortning, // TODO remove in next version
+        val ordinaerUTBeloep: BeloepMedAvkortning, // TODO remove in next version
         val ordinaerUTBeloepBrutto: Kroner,
         val ordinaerUTBeloepNetto: Kroner,
-        @Deprecated("Use separate brutto/netto values") val totalUTBeloep: BeloepMedAvkortning, // TODO remove in next version
-        val totalUTBeloepBrutto: Kroner?, //TODO make mandatory in next version
-        val totalUTBeloepNetto: Kroner?, //TODO make mandatory in next version
+        val totalUTBeloep: BeloepMedAvkortning, // TODO remove in next version
+        val totalUTBeloepBrutto: Kroner,
+        val totalUTBeloepNetto: Kroner,
         val virkningFraOgMed: LocalDate,
         val virkningTilOgMed: LocalDate?,
     ) {
 
-        @Deprecated("Use separate brutto/netto values")
-        data class BeloepMedAvkortning(// TODO remove in next version
+        // TODO remove in next version
+        data class BeloepMedAvkortning(
             val netto: Kroner,
             val brutto: Kroner,
         )


### PR DESCRIPTION
splitt felter i ufoeretrygdPeraMaaned i netto og brutto for å kunne gjenbruke eksisterende tolkninger i pesys.