### PR TITLE
Feature/pl 5796

### DIFF
--- a/pensjon-brevbaker-api-model/build.gradle.kts
+++ b/pensjon-brevbaker-api-model/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "no.nav.pensjon.brev"
-version = "3.5.5"
+version = "3.5.5-SNAPSHOT"
 
 java {
     withSourcesJar()

--- a/pensjon-brevbaker-api-model/build.gradle.kts
+++ b/pensjon-brevbaker-api-model/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "no.nav.pensjon.brev"
-version = "3.5.4"
+version = "3.5.5"
 
 java {
     withSourcesJar()

--- a/pensjon-brevbaker-api-model/build.gradle.kts
+++ b/pensjon-brevbaker-api-model/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "no.nav.pensjon.brev"
-version = "3.5.5-SNAPSHOT"
+version = "3.5.5"
 
 java {
     withSourcesJar()

--- a/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/UfoerOmregningEnslig.kt
+++ b/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/UfoerOmregningEnslig.kt
@@ -58,7 +58,6 @@ data class UfoerOmregningEnsligDto(
         val erRedusertMotTak: Boolean,
         val prosentsatsGradertOverInntektFoerUfoer: Int,
         val gradertOverInntektFoerUfoer: Kroner,
-        val erIkkeUtbetaltPgaTak: Boolean,
         val beloepFoerReduksjon: Kroner,
         val beloepEtterReduksjon: Kroner,
     )

--- a/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/UfoerOmregningEnslig.kt
+++ b/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/UfoerOmregningEnslig.kt
@@ -55,7 +55,6 @@ data class UfoerOmregningEnsligDto(
     )
 
     data class BarnetilleggGrunnlagVedVirk(
-        val erRedusertMotTak: Boolean,
         val prosentsatsGradertOverInntektFoerUfoer: Int,
         val gradertOverInntektFoerUfoer: Kroner,
         val beloepFoerReduksjon: Kroner,

--- a/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/vedlegg/OpplysningerBruktIBeregning.kt
+++ b/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/vedlegg/OpplysningerBruktIBeregning.kt
@@ -29,8 +29,6 @@ data class OpplysningerBruktIBeregningUTDto(
         val saerkullsbarn: Saerkullsbarn?
     ) {
         data class Grunnlag(
-            val erIkkeUtbetaltpgaTak: Boolean,
-            val erRedusertMotTak: Boolean,
             val gradertOIFU: Kroner,
             val prosentsatsGradertOIFU: Int,
             val totaltAntallBarn: Int,

--- a/pensjon-brevbaker/build.gradle.kts
+++ b/pensjon-brevbaker/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
-    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.5-SNAPSHOT")
+    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.5")
     // Necessary for java.time.LocalDate
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3")
     // Metrics

--- a/pensjon-brevbaker/build.gradle.kts
+++ b/pensjon-brevbaker/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
-    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.4")
+    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.5")
     // Necessary for java.time.LocalDate
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3")
     // Metrics

--- a/pensjon-brevbaker/build.gradle.kts
+++ b/pensjon-brevbaker/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
-    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.5")
+    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.5-SNAPSHOT")
     // Necessary for java.time.LocalDate
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3")
     // Metrics

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
@@ -142,7 +142,6 @@ object UfoerOmregningEnslig : VedtaksbrevTemplate {
 
                 val barnetilleggForSaerkullsbarnVedvirkErRedusertMotInntekt = tillegg.map { it.erRedusertMotInntekt }
                 val barnetilleggErRedusertMotTak = grunnlag.map { it.erRedusertMotTak }
-                val barnetilleggErIkkeUtbetPgaTak = grunnlag.map { it.erIkkeUtbetaltPgaTak }
                 val harNettoBeloep = tillegg.map { it.beloep.value > 0 }
                 val barnetilleggForSaerkullsbarnVedvirk_HarjusteringsBeloepAr = tillegg.map { it.justeringsbeloepAar.value != 0 }
 

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
@@ -141,7 +141,6 @@ object UfoerOmregningEnslig : VedtaksbrevTemplate {
             ) { tillegg, grunnlag ->
 
                 val barnetilleggForSaerkullsbarnVedvirkErRedusertMotInntekt = tillegg.map { it.erRedusertMotInntekt }
-                val barnetilleggErRedusertMotTak = grunnlag.map { it.erRedusertMotTak }
                 val harNettoBeloep = tillegg.map { it.beloep.value > 0 }
                 val barnetilleggForSaerkullsbarnVedvirk_HarjusteringsBeloepAr = tillegg.map { it.justeringsbeloepAar.value != 0 }
 
@@ -156,7 +155,7 @@ object UfoerOmregningEnslig : VedtaksbrevTemplate {
                     }
 
                     showIf(
-                        harbarnSomTidligerVarSaerkullsbarn and (inntektFoerUfoereErSannsynligEndret or harMinsteytelseVedVirk) and (barnetilleggForSaerkullsbarnVedvirkErRedusertMotInntekt or barnetilleggErRedusertMotTak)
+                        harbarnSomTidligerVarSaerkullsbarn and (inntektFoerUfoereErSannsynligEndret or harMinsteytelseVedVirk) and barnetilleggForSaerkullsbarnVedvirkErRedusertMotInntekt
                     ) {
                         includePhrase(infoTidligereSBOgEndretUT_001, tillegg.map { it.barnTidligereSaerkullsbarn })
                     }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
@@ -173,36 +173,6 @@ object UfoerOmregningEnslig : VedtaksbrevTemplate {
                     harBarnOverfoertTilSaerkullsbarn or (harBarnetilleggForSaerkullsbarnVedVirk and (harMinsteytelseVedVirk or inntektFoerUfoereErSannsynligEndret or ektefelleTilleggOpphoert))
                 ) {
 
-                    showIf(not(barnetilleggErRedusertMotTak)) {
-                        includePhrase(ikkeRedusBTPgaTak_001, grunnlag.map {
-                            IkkeRedusBTPgaTak_001Dto(
-                                it.prosentsatsGradertOverInntektFoerUfoer,
-                                it.gradertOverInntektFoerUfoer,
-                            )
-                        })
-                    }
-
-                    showIf(barnetilleggErRedusertMotTak and not(barnetilleggErIkkeUtbetPgaTak)) {
-                        includePhrase(redusBTPgaTak_001, grunnlag.map {
-                            RedusBTPgaTak_001Dto(
-                                it.prosentsatsGradertOverInntektFoerUfoer,
-                                it.gradertOverInntektFoerUfoer,
-                                it.beloepFoerReduksjon,
-                                it.beloepEtterReduksjon,
-                            )
-                        })
-                    }
-
-                    showIf(barnetilleggErIkkeUtbetPgaTak) {
-                        includePhrase(ikkeUtbetaltBTPgaTak_001, grunnlag.map {
-                            IkkeUtbetaltBTPgaTak_001Dto(
-                                it.prosentsatsGradertOverInntektFoerUfoer,
-                                it.gradertOverInntektFoerUfoer,
-                            )
-                        })
-                    }
-
-
                     showIf(not(harBarnOverfoertTilSaerkullsbarn) and not(barnetilleggErIkkeUtbetPgaTak)) {
                         includePhrase(infoBTSBInntekt_001)
                     }
@@ -254,19 +224,10 @@ object UfoerOmregningEnslig : VedtaksbrevTemplate {
                         includePhrase(hjemmelBT_001)
                     }
 
-
-                    showIf(not(barnetilleggForSaerkullsbarnVedvirkErRedusertMotInntekt) and grunnlag.map { it.prosentsatsGradertOverInntektFoerUfoer <= 95 }) {
-                        includePhrase(hjemmelBTOvergangsregler_001)
-                    }
-
                     showIf(
                         barnetilleggForSaerkullsbarnVedvirkErRedusertMotInntekt and not(grunnlag.map { it.prosentsatsGradertOverInntektFoerUfoer <= 95 })
                     ) {
                         includePhrase(hjemmelBTRedus_001)
-                    }
-
-                    showIf(barnetilleggForSaerkullsbarnVedvirkErRedusertMotInntekt and grunnlag.map { it.prosentsatsGradertOverInntektFoerUfoer <= 95 }) {
-                        includePhrase(hjemmelBTRedusOvergangsregler_001)
                     }
 
                     showIf(barnetilleggForSaerkullsbarnGjeldende_ErRedusertMotInntekt) {

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
@@ -173,16 +173,15 @@ object UfoerOmregningEnslig : VedtaksbrevTemplate {
                     harBarnOverfoertTilSaerkullsbarn or (harBarnetilleggForSaerkullsbarnVedVirk and (harMinsteytelseVedVirk or inntektFoerUfoereErSannsynligEndret or ektefelleTilleggOpphoert))
                 ) {
 
-                    showIf(not(harBarnOverfoertTilSaerkullsbarn) and not(barnetilleggErIkkeUtbetPgaTak)) {
-                        includePhrase(infoBTSBInntekt_001)
+                    showIf(not(harBarnOverfoertTilSaerkullsbarn)) { includePhrase(infoBTSBInntekt_001)
                     }
 
-                    showIf(harBarnOverfoertTilSaerkullsbarn and not(barnetilleggErIkkeUtbetPgaTak)) {
+                    showIf(harBarnOverfoertTilSaerkullsbarn) {
                         includePhrase(infoBTOverfortTilSBInntekt_001)
                     }
 
                     showIf(
-                        not(barnetilleggForSaerkullsbarnVedvirkErRedusertMotInntekt) and not(barnetilleggErIkkeUtbetPgaTak)
+                        not(barnetilleggForSaerkullsbarnVedvirkErRedusertMotInntekt)
                     ) {
                         includePhrase(ikkeRedusBTSBPgaInntekt_001, tillegg.map { tillegg ->
                             IkkeRedusBTSBPgaInntekt_001Dto(

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/UfoerOmregningEnslig.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/UfoerOmregningEnslig.kt
@@ -464,106 +464,6 @@ val endringUTpavirkerBTOverskrift_001 = OutlinePhrase<LangBokmalNynorskEnglish, 
     }
 }
 
-data class IkkeRedusBTPgaTak_001Dto(
-    val barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk: Int,
-    val barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk: Kroner,
-)
-
-val ikkeRedusBTPgaTak_001 = OutlinePhrase<LangBokmalNynorskEnglish, IkkeRedusBTPgaTak_001Dto> {
-    val barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk =
-        it.select(IkkeRedusBTPgaTak_001Dto::barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk)
-    val barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk =
-        it.select(IkkeRedusBTPgaTak_001Dto::barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk)
-    paragraph {
-        textExpr(
-            Bokmal to "Uføretrygden og barnetillegget ditt kan til sammen ikke utgjøre mer enn ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av inntekten din før du ble ufør. ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av den inntekten du hadde før du ble ufør tilsvarer i dag ".expr()
-                    + barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " kroner. Uføretrygden og barnetillegget ditt er til sammen lavere enn dette. Derfor er barnetillegget fastsatt til 40 prosent av folketrygdens grunnbeløp for hvert barn.".expr(),
-            Nynorsk to "Uføretrygda di og barnetillegget ditt kan til saman ikkje utgjere meir enn ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av inntekta di før du blei ufør. ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av den inntekta du hadde før du blei ufør, svarer i dag til ".expr()
-                    + barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " kroner. Uføretrygda di og barnetillegget ditt er til saman lågare enn dette. Derfor er barnetillegget fastsett til 40 prosent av grunnbeløpet i folketrygda for kvart barn.".expr(),
-            English to "Your disability benefit and child supplement together cannot exceed more than ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " percent of your income before you became disabled. ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " percent of the income you had before you became disabled is equivalent today to an income of NOK ".expr()
-                    + barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk.format() + ". Your disability benefit and child supplement together are lower than this. Therefore, your child supplement has been determined to be 40 percent of the National Insurance basic amount for each child.".expr()
-        )
-    }
-
-
-}
-
-data class RedusBTPgaTak_001Dto(
-    val barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk: Int,
-    val barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk: Kroner,
-    val barnetillegg_beloep_foer_reduksjon_vedvirk: Kroner,
-    val barnetillegg_saerkullsbarn_beloep_etter_reduksjon_vedvirk: Kroner,
-)
-
-val redusBTPgaTak_001 = OutlinePhrase<LangBokmalNynorskEnglish, RedusBTPgaTak_001Dto> { dto ->
-    val barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk =
-        dto.map { it.barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk }
-    val barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk =
-        dto.map { it.barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk }
-    val barnetillegg_beloep_foer_reduksjon_vedvirk =
-        dto.map { it.barnetillegg_beloep_foer_reduksjon_vedvirk }
-    val barnetillegg_saerkullsbarn_beloep_etter_reduksjon_vedvirk =
-        dto.map { it.barnetillegg_saerkullsbarn_beloep_etter_reduksjon_vedvirk }
-    paragraph {
-        textExpr(
-            Bokmal to "Uføretrygden og barnetillegget ditt kan til sammen ikke utgjøre mer enn ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av inntekten din før du ble ufør. ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av den inntekten du hadde før du ble ufør tilsvarer i dag ".expr()
-                    + barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " kroner. Uføretrygden og barnetillegget ditt er til sammen høyere enn dette. Derfor er barnetillegget redusert fra ".expr()
-                    + barnetillegg_beloep_foer_reduksjon_vedvirk.format() + " kroner til ".expr()
-                    + barnetillegg_saerkullsbarn_beloep_etter_reduksjon_vedvirk.format() + " kroner.".expr(),
-            Nynorsk to "Uføretrygda di og barnetillegget ditt kan til saman ikkje utgjere meir enn ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av inntekta di før du blei ufør. ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av den inntekta du hadde før du blei ufør, svarer i dag til ".expr()
-                    + barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " kroner. Uføretrygda og barnetillegget ditt er til saman høgare enn dette. Derfor er barnetillegget redusert frå ".expr()
-                    + barnetillegg_beloep_foer_reduksjon_vedvirk.format() + " kroner til ".expr()
-                    + barnetillegg_saerkullsbarn_beloep_etter_reduksjon_vedvirk.format() + " kroner.".expr(),
-            English to "Your disability benefit and child supplement together cannot exceed more than ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " percent of your income before you became disabled. ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " percent of the income you had prior to disability is equivalent today to an income of NOK ".expr()
-                    + barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk.format() + ". Your disability benefit and child supplement together are higher than this. Therefore, your child supplement has been reduced from NOK ".expr()
-                    + barnetillegg_beloep_foer_reduksjon_vedvirk.format() + " to NOK ".expr()
-                    + barnetillegg_saerkullsbarn_beloep_etter_reduksjon_vedvirk.format() + ".".expr()
-        )
-    }
-
-
-}
-
-data class IkkeUtbetaltBTPgaTak_001Dto(
-    val barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk: Int,
-    val barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk: Kroner,
-)
-
-val ikkeUtbetaltBTPgaTak_001 = OutlinePhrase<LangBokmalNynorskEnglish, IkkeUtbetaltBTPgaTak_001Dto> {
-    val barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk =
-        it.select(IkkeUtbetaltBTPgaTak_001Dto::barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk)
-    val barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk =
-        it.select(IkkeUtbetaltBTPgaTak_001Dto::barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk)
-    paragraph {
-        textExpr(
-            Bokmal to "Uføretrygden og barnetillegget ditt kan til sammen ikke utgjøre mer enn ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av inntekten din før du ble ufør. ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av den inntekten du hadde før du ble ufør tilsvarer i dag ".expr()
-                    + barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " kroner. Uføretrygden og barnetillegget ditt er til sammen høyere enn dette. Derfor får du ikke utbetalt barnetillegg.".expr(),
-            Nynorsk to "Uføretrygda di og barnetillegget ditt kan til saman ikkje utgjere meir enn ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av inntekta di før du blei ufør. ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " prosent av den inntekta du hadde før du blei ufør, svarer i dag til ".expr()
-                    + barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " kroner. Uføretrygda og barnetillegget ditt er til saman høgare enn dette. Derfor får du ikkje utbetalt barnetillegg.".expr(),
-            English to "Your disability benefit and child supplement together cannot exceed more than ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " percent of your income before you became disabled. ".expr()
-                    + barnetillegg_prosentsats_gradert_over_inntekt_foer_ufoer_vedvirk.format() + " percent of the income you had prior to disability is equivalent today to an income of NOK ".expr()
-                    + barnetillegg_gradert_over_inntekt_foer_ufoer_vedvirk.format() + ". Your disability benefit and child supplement together are higher than this. Therefore, you will not receive child supplement.".expr()
-        )
-    }
-}
-
 val infoBTSBInntekt_001 = OutlinePhrase<LangBokmalNynorskEnglish, Unit> {
     paragraph {
         text(
@@ -716,32 +616,12 @@ val hjemmelBT_001 = OutlinePhrase<LangBokmalNynorskEnglish, Unit> {
     }
 }
 
-val hjemmelBTOvergangsregler_001 = OutlinePhrase<LangBokmalNynorskEnglish, Unit> {
-    paragraph {
-        text(
-            Bokmal to "Vedtaket er gjort etter folketrygdloven § 12-15 og forskrift om overgangsregler for barnetillegg i uføretrygden.",
-            Nynorsk to "Vedtaket er gjort etter folketrygdlova § 12-15 og forskrift om overgangsreglar for barnetillegg i uføretrygda.",
-            English to "This decision was made pursuant to the provisions of § 12-15 of the National Insurance Act and of the Regulation on transitional rules for child supplement in disability benefit."
-        )
-    }
-}
-
 val hjemmelBTRedus_001 = OutlinePhrase<LangBokmalNynorskEnglish, Unit> {
     paragraph {
         text(
             Bokmal to "Vedtaket er gjort etter folketrygdloven §§ 12-15 og 12-16.",
             Nynorsk to "Vedtaket er gjort etter folketrygdlova §§ 12-15 og 12-16.",
             English to "This decision was made pursuant to the provisions of §§ 12-15 and 12-16 of the National Insurance Act."
-        )
-    }
-}
-
-val hjemmelBTRedusOvergangsregler_001 = OutlinePhrase<LangBokmalNynorskEnglish, Unit> {
-    paragraph {
-        text(
-            Bokmal to "Vedtaket er gjort etter folketrygdloven §§ 12-15 og 12-16 og forskrift om overgangsregler for barnetillegg i uføretrygden.",
-            Nynorsk to "Vedtaket er gjort etter folketrygdlova §§ 12-15 og 12-16 og forskrift om overgangsreglar for barnetillegg i uføretrygda.",
-            English to "This decision was made pursuant to the provisions of §§ 12-15 and 12-16 of the National Insurance Act and of the Regulation on transitional rules for child supplement in disability benefit."
         )
     }
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerBruktIBeregningUT.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerBruktIBeregningUT.kt
@@ -638,22 +638,6 @@ val opplysningerBruktIBeregningUT = createAttachment<LangBokmalNynorskEnglish, O
                 }
             }
 
-            showIf(barnetillegg.map { it.grunnlag.erRedusertMotTak }) {
-                row {
-                    cell {
-                        val prosentsatsGradertOIFU = barnetillegg.map { it.grunnlag.prosentsatsGradertOIFU }.format()
-                        textExpr(
-                            Bokmal to prosentsatsGradertOIFU + " % av inntekt før uførhet (justert for endringer i grunnbeløpet)",
-                            Nynorsk to prosentsatsGradertOIFU + " % av inntekt før uførleik (justert for endringar i grunnbeløpet)",
-                            English to prosentsatsGradertOIFU + " % of income before disability, adjusted for changes in the basic amount"
-                        )
-                    }
-                    cell {
-                        includePhrase(kroner, barnetillegg.map { it.grunnlag.gradertOIFU })
-                    }
-                }
-            }
-
             ifNotNull(barnetillegg.map { it.saerkullsbarn }) { saerkullsbarn ->
                 showIf(saerkullsbarn.map { it.beloep.value > 0 }) {
                     row {
@@ -749,7 +733,6 @@ val opplysningerBruktIBeregningUT = createAttachment<LangBokmalNynorskEnglish, O
     ) { grunnlag, saerkullTillegg ->
         val erRedusertMotInntekt = saerkullTillegg.map { it.erRedusertMotinntekt }
         val fribeloepEllerInntektErPeriodisert = saerkullTillegg.map { it.fribeloepEllerInntektErPeriodisert }
-        val erIkkeUtbetaltPgaTak = grunnlag.map { it.erIkkeUtbetaltpgaTak }
         val harYrkesskadeGrad = argument().map {
             it.yrkesskadeGjeldende?.let { skade -> skade.yrkesskadegrad > 0 } ?: false
         }
@@ -757,11 +740,8 @@ val opplysningerBruktIBeregningUT = createAttachment<LangBokmalNynorskEnglish, O
         val justeringsBeloepAr = saerkullTillegg.map { it.justeringsbeloepAar }
 
         showIf(saerkullTillegg.map { it.erRedusertMotinntekt }) {
-
-            showIf(erIkkeUtbetaltPgaTak) {
                 includePhrase(slikBeregnBTOverskrift_001)
                 includePhrase(vedleggBeregnUTInfoBTSB_001)
-            }.orShow {
                 includePhrase(vedleggBeregnUTInnlednBT_001)
             }
 
@@ -805,11 +785,12 @@ val opplysningerBruktIBeregningUT = createAttachment<LangBokmalNynorskEnglish, O
                     saerkullTillegg.map { it.justeringsbeloepAar }
                 )
             }
-        }
+
 
 
 // TABLE 2 - start
-            showIf(erRedusertMotInntekt and erIkkeUtbetaltPgaTak) {
+
+    showIf(erRedusertMotInntekt) {
                 title1 {
                     text(
                         Bokmal to "Reduksjon av barnetillegg for særkullsbarn før skatt",
@@ -849,7 +830,7 @@ val opplysningerBruktIBeregningUT = createAttachment<LangBokmalNynorskEnglish, O
                             }
                         }
                     }
-                    showIf(erRedusertMotInntekt and erIkkeUtbetaltPgaTak) {
+                    showIf(erRedusertMotInntekt) {
                         row {
                             cell {
                                 text(

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/IntegrationTestUtils.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/IntegrationTestUtils.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -22,6 +23,9 @@ object TestTags {
     const val PDF_BYGGER = "pdf-bygger"
 }
 val httpClient = HttpClient(CIO) {
+    install(HttpTimeout){
+        requestTimeoutMillis = 40000
+    }
     install(ContentNegotiation) {
         jackson {
             registerModule(JavaTimeModule())

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/fixtures/OpplysningerBruktIBeregningUTDto.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/fixtures/OpplysningerBruktIBeregningUTDto.kt
@@ -27,8 +27,6 @@ fun createOpplysningerBruktIBeregningUTDtoBarnetilleggGjeldende() =
 
 fun createOpplysningerBruktIBeregningUTDtoBarnetilleggGjeldendeGrunnlag() =
     OpplysningerBruktIBeregningUTDto.BarnetilleggGjeldende.Grunnlag(
-        erIkkeUtbetaltpgaTak = false,
-        erRedusertMotTak = false,
         gradertOIFU = Kroner(0),
         prosentsatsGradertOIFU = 0,
         totaltAntallBarn = 0,

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/fixtures/UfoerOmregningEnsligDto.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/fixtures/UfoerOmregningEnsligDto.kt
@@ -56,7 +56,6 @@ fun createUfoerOmregningEnsligDto() =
                 ),
             ),
             barnetilleggGrunnlag = UfoerOmregningEnsligDto.BarnetilleggGrunnlagVedVirk(
-                erRedusertMotTak = false,
                 prosentsatsGradertOverInntektFoerUfoer = 0,
                 gradertOverInntektFoerUfoer = Kroner(0),
                 beloepFoerReduksjon = Kroner(0),

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/fixtures/UfoerOmregningEnsligDto.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/fixtures/UfoerOmregningEnsligDto.kt
@@ -59,7 +59,6 @@ fun createUfoerOmregningEnsligDto() =
                 erRedusertMotTak = false,
                 prosentsatsGradertOverInntektFoerUfoer = 0,
                 gradertOverInntektFoerUfoer = Kroner(0),
-                erIkkeUtbetaltPgaTak = false,
                 beloepFoerReduksjon = Kroner(0),
                 beloepEtterReduksjon = Kroner(0),
             )


### PR DESCRIPTION
Updated 000073 template in Brevbaker with the changes implemented in the Doksys version:
I forbindelse med fjerning av 95 prosenttaket, fjernes fraser:  ikkeRedusBTPgaTak_001, redusBTPgaTak_001, ikkeUtbetaltBTPgaTak_001, hjemmelBTOvergangsregler_001, hjemmelBTRedusOvergangsregler_001.

Endret logikk: Fjernet <barnetilleggGrunnlaVedVirk.erIkkeUtbetPgaTak> fra infoBTSBInntekt_001, infoBTOverfortTilSBInntekt_001, ikkeRedusBTSBPgaInntekt_001