### PR TITLE
Legg til collection mapping og lokalistert opplisting

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/Operations.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/Operations.kt
@@ -49,6 +49,10 @@ sealed class UnaryOperation<In, out Out> : Operation() {
     object Not : UnaryOperation<Boolean, Boolean>() {
         override fun apply(input: Boolean): Boolean = input.not()
     }
+
+    data class MapCollection<In, Out>(val mapper: UnaryOperation<In, Out>): UnaryOperation<Collection<In>, Collection<Out>>() {
+        override fun apply(input: Collection<In>): Collection<Out> = input.map { mapper.apply(it) }
+    }
 }
 
 abstract class BinaryOperation<in In1, in In2, out Out> : Operation() {
@@ -114,6 +118,26 @@ abstract class BinaryOperation<in In1, in In2, out Out> : Operation() {
                 .format(first)
     }
 
+    object LocalizedCollectionFormat : BinaryOperation<Collection<String>, Language, String>() {
+        override fun apply(first: Collection<String>, second: Language): String {
+            return if (first.size == 1) {
+                first.first()
+            } else {
+                val lastSeparator = when (second) {
+                    Language.Bokmal -> " og "
+                    Language.Nynorsk -> " og "
+                    Language.English -> " and "
+                }
+                first.take(first.size - 1).joinToString(", ") + lastSeparator + first.last()
+            }
+        }
+
+    }
+
+    data class MapCollection<In1, In2, Out>(val mapper: BinaryOperation<In1, In2, Out>): BinaryOperation<Collection<In1>, In2, Collection<Out>>() {
+        override fun apply(first: Collection<In1>, second: In2): Collection<Out> = first.map { mapper.apply(it, second) }
+    }
+
     class EnumInList<EnumType : Enum<*>> : BinaryOperation<EnumType, List<EnumType>, Boolean>() {
         override fun apply(first: EnumType, second: List<EnumType>): Boolean = second.contains(first)
     }
@@ -128,6 +152,10 @@ abstract class BinaryOperation<in In1, in In2, out Out> : Operation() {
 
     class ValidatePredicate<T> : BinaryOperation<Predicate<T>, T, Boolean>() {
         override fun apply(first: Predicate<T>, second: T): Boolean = first.validate(second)
+    }
+
+    data class Flip<In1, In2, Out>(val operation: BinaryOperation<In2, In1, Out>): BinaryOperation<In1, In2, Out>() {
+        override fun apply(first: In1, second: In2): Out = operation.apply(second, first)
     }
 
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/dsl/expression/Collection.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/dsl/expression/Collection.kt
@@ -20,6 +20,39 @@ fun <T> Expression<Collection<T>>.isEmpty(): Expression<Boolean> =
 fun <T> Expression<Collection<T>>.isNotEmpty(): Expression<Boolean> =
     not(this.isEmpty())
 
+fun <T: Any, R> Expression<Collection<T>>.map(selector: TemplateModelSelector<T, R>): Expression<Collection<R>> =
+    map(UnaryOperation.Select(selector))
+
+fun <T, R> Expression<Collection<T>>.map(mapper: UnaryOperation<T, R>): Expression<Collection<R>> =
+    Expression.UnaryInvoke(
+        value = this,
+        operation = UnaryOperation.MapCollection(mapper),
+    )
+
+fun <In1, In2, Out> Expression<Collection<In1>>.map(mapper: BinaryOperation<In1, In2, Out>, second: Expression<In2>): Expression<Collection<Out>> =
+    Expression.BinaryInvoke(
+        first = this,
+        second = second,
+        operation = BinaryOperation.MapCollection(mapper)
+    )
+
+fun <In1, In2, Out> Expression<Collection<In2>>.map(first: Expression<In1>, mapper: BinaryOperation<In1, In2, Out>): Expression<Collection<Out>> =
+    Expression.BinaryInvoke(
+        first = this,
+        second = first,
+        operation = BinaryOperation.MapCollection(BinaryOperation.Flip(mapper))
+    )
+
+fun <In> Expression<Collection<In>>.map(mapper: BinaryOperation<In, Language, String>): Expression<Collection<String>> =
+    map(mapper, Expression.FromScope(ExpressionScope<Any, *>::language))
+
+fun Expression<Collection<String>>.format(): StringExpression =
+    Expression.BinaryInvoke(
+        first = this,
+        second = Expression.FromScope(ExpressionScope<Any, *>::language),
+        operation = BinaryOperation.LocalizedCollectionFormat
+    )
+
 /**
  * Collection contains at least one of the listed items.
  */

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/OperationsTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/OperationsTest.kt
@@ -15,4 +15,31 @@ class OperationsTest {
     fun `different operations are not considered equal`() {
         assertNotEquals(BinaryOperation.Equal<Int>(), UnaryOperation.ToString<String>())
     }
+
+    @Test
+    fun `LocalizedCollectionFormat uses comma and localized separator before last item`() {
+        val list = listOf("Alexander", "Jeremy", "Håkon", "Agne")
+
+        assertEquals("Alexander, Jeremy, Håkon og Agne", BinaryOperation.LocalizedCollectionFormat.apply(list, Language.Bokmal))
+        assertEquals("Alexander, Jeremy, Håkon og Agne", BinaryOperation.LocalizedCollectionFormat.apply(list, Language.Nynorsk))
+        assertEquals("Alexander, Jeremy, Håkon and Agne", BinaryOperation.LocalizedCollectionFormat.apply(list, Language.English))
+    }
+
+    @Test
+    fun `LocalizedCollectionFormat has no separator for only one item`() {
+        val list = listOf("Agne")
+
+        assertEquals("Agne", BinaryOperation.LocalizedCollectionFormat.apply(list, Language.Bokmal))
+        assertEquals("Agne", BinaryOperation.LocalizedCollectionFormat.apply(list, Language.Nynorsk))
+        assertEquals("Agne", BinaryOperation.LocalizedCollectionFormat.apply(list, Language.English))
+    }
+
+    @Test
+    fun `LocalizedCollectionFormat has no comma for only two items`() {
+        val list = listOf("Agne", "Jeremy")
+
+        assertEquals("Agne og Jeremy", BinaryOperation.LocalizedCollectionFormat.apply(list, Language.Bokmal))
+        assertEquals("Agne og Jeremy", BinaryOperation.LocalizedCollectionFormat.apply(list, Language.Nynorsk))
+        assertEquals("Agne and Jeremy", BinaryOperation.LocalizedCollectionFormat.apply(list, Language.English))
+    }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/dsl/expression/CollectionTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/dsl/expression/CollectionTest.kt
@@ -1,9 +1,11 @@
 package no.nav.pensjon.brev.template.dsl.expression
 
 import no.nav.pensjon.brev.Fixtures
+import no.nav.pensjon.brev.api.model.Foedselsnummer
+import no.nav.pensjon.brev.api.model.FoedselsnummerSelectors.valueSelector
 import no.nav.pensjon.brev.template.*
-import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 class CollectionTest {
 
@@ -118,6 +120,27 @@ class CollectionTest {
             anyOf(4, 5)
         }
         assertFalse(containsExclusively.eval(emptyScope))
+    }
+
+    @Test
+    fun `map transforms collection items`() {
+        val fnrs = listOf(1, 5, 6, 2, 4, 7).map { Foedselsnummer(it.toString()) }
+
+        assertEquals(fnrs.map { it.value }, fnrs.expr().map(UnaryOperation.Select(valueSelector)).eval(emptyScope))
+        assertEquals(fnrs.map { it.value }, fnrs.expr().map(valueSelector).eval(emptyScope))
+    }
+
+    @Test
+    fun `format transforms collection to a string`() {
+        val fnrs = listOf(1, 5, 6, 2, 4, 7).map { Foedselsnummer(it.toString()) }
+
+        listOf(Language.Bokmal, Language.Nynorsk, Language.English).forEach {
+            val scope = ExpressionScope(Unit, Fixtures.felles, it)
+            assertEquals(
+                BinaryOperation.LocalizedCollectionFormat.apply(fnrs.map { it.value }, it),
+                fnrs.expr().map(valueSelector).format().eval(scope)
+            )
+        }
     }
 
 }

--- a/skribenten-backend/build.gradle.kts
+++ b/skribenten-backend/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
 
-    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.15")
+    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.19")
 
     // Logging
     implementation("ch.qos.logback:logback-classic:$logbackVersion")

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/BrevbakerService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/BrevbakerService.kt
@@ -46,7 +46,8 @@ class BrevbakerService(config: Config, authService: AzureADService) {
                         LocalDate.now(),
                         "1234",
                         NAVEnhet("nav.no", "NAV", Telefonnummer("22225555")),
-                        Bruker(Foedselsnummer("12345678910"), LocalDate.of(2000, Month.JANUARY, 1), "Test", null, "Testeson")
+                        Bruker(Foedselsnummer("12345678910"), LocalDate.of(2000, Month.JANUARY, 1), "Test", null, "Testeson"),
+                        "Verge vergesen",
                     ),
                     language = LanguageCode.BOKMAL,
                 )


### PR DESCRIPTION
Legger til støtte for å kunne transformere elementene i en liste:
```
// Gitt -  datoer: Expression<List<LocalDate>>
val datoStrenger: Expression<List<String>> = datoer.map(BinaryOperation.LocalizedDateFormat)
```

Legger til støtte for å liste opp alle elementene i en liste med komma og "og"/"and"
```
// Gitt - navn: Expression<List<String>> 
val alleNavn: Expression<String> = navn.format()
```

Dette kan brukes sammen slik:
```
val alleDatoer = datoer.map(BinaryOperation.LocalizedDateFormat).format()
text(
   Bokmal to "Vi er åpne på følgende datoer: ".expr() + alleDatoer,
   English to "We are open on these dates: ".expr() + alleDatoer,
)
```