### PR TITLE
PL-5105: bugfix

### DIFF
--- a/pensjon-brevbaker-api-model/build.gradle.kts
+++ b/pensjon-brevbaker-api-model/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "no.nav.pensjon.brev"
-version = "3.5.22"
+version = "3.5.23"
 
 java {
     withSourcesJar()

--- a/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/vedlegg/OpplysningerBruktIBeregning.kt
+++ b/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/vedlegg/OpplysningerBruktIBeregning.kt
@@ -10,7 +10,7 @@ data class OpplysningerBruktIBeregningUTDto(
     val beregnetUTPerManedGjeldende: BeregnetUTPerManedGjeldende,
     val grunnbeloep: Kroner,
     val fraOgMedDatoErNesteAar: Boolean,
-    val inntektEtterUfoereGjeldende_beloepIEU: Kroner,
+    val inntektEtterUfoereGjeldende_beloepIEU: Kroner?,
     val inntektFoerUfoereGjeldende: InntektFoerUfoereGjeldende,
     val inntektsAvkortingGjeldende: InntektsAvkortingGjeldende,
     val minsteytelseGjeldende_sats: Double?,

--- a/pensjon-brevbaker/build.gradle.kts
+++ b/pensjon-brevbaker/build.gradle.kts
@@ -83,7 +83,7 @@ dependencies {
     implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
     implementation("io.ktor:ktor-client-encoding:$ktorVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
-    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.22")
+    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.23")
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.8.0")
 
     implementation(project(":template-model-generator"))

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAuto.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAuto.kt
@@ -289,13 +289,13 @@ object OpphoerBarnetilleggAuto : VedtaksbrevTemplate<OpphoerBarnetilleggAutoDto>
             includePhrase(Ufoeretrygd.SkattForDegSomBorIUtlandet(brukerBorInorge))
         }
         includeAttachment(vedleggMaanedligUfoeretrygdFoerSkatt, maanedligUfoeretrygdFoerSkatt)
-        includeAttachment(vedleggDineRettigheterOgPlikterUfoere, orienteringOmRettigheterUfoere)
         includeAttachment(
             createVedleggOpplysningerBruktIBeregningUT(
                 skalViseMinsteytelse = false,
                 skalViseBarnetillegg = true,
             ), opplysningerBruktIBeregningUT
         )
+        includeAttachment(vedleggDineRettigheterOgPlikterUfoere, orienteringOmRettigheterUfoere)
     }
 }
 

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/opplysningerbruktiberegningufoere/TabellUfoereOpplysninger.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/opplysningerbruktiberegningufoere/TabellUfoereOpplysninger.kt
@@ -62,7 +62,7 @@ data class TabellUfoereOpplysninger(
     val inntektsAvkortingGjeldende: Expression<OpplysningerBruktIBeregningUTDto.InntektsAvkortingGjeldende>,
     val inntektsgrenseErUnderTak: Expression<Boolean>,
     val beregnetUTPerManedGjeldende: Expression<OpplysningerBruktIBeregningUTDto.BeregnetUTPerManedGjeldende>,
-    val inntektEtterUfoereGjeldende_beloepIEU: Expression<Kroner>,
+    val inntektEtterUfoereGjeldendeBeloep: Expression<Kroner?>,
     val ungUfoerGjeldende_erUnder20Aar: Expression<Boolean?>,
     val trygdetidsdetaljerGjeldende: Expression<OpplysningerBruktIBeregningUTDto.TrygdetidsdetaljerGjeldende>,
     val barnetilleggGjeldende: Expression<OpplysningerBruktIBeregningUTDto.BarnetilleggGjeldende?>,
@@ -145,17 +145,19 @@ data class TabellUfoereOpplysninger(
                         }
                     }
                 }
-                showIf(inntektEtterUfoereGjeldende_beloepIEU.greaterThan(0)) {
-                    row {
-                        cell {
-                            text(
-                                Language.Bokmal to "Inntekt etter uførhet",
-                                Language.Nynorsk to "Inntekt etter uførleik",
-                                Language.English to "Income after disability"
-                            )
-                        }
-                        cell {
-                            includePhrase(Felles.KronerText(inntektEtterUfoereGjeldende_beloepIEU))
+                ifNotNull(inntektEtterUfoereGjeldendeBeloep) { beloep ->
+                    showIf(beloep.greaterThan(0)) {
+                        row {
+                            cell {
+                                text(
+                                    Language.Bokmal to "Inntekt etter uførhet",
+                                    Language.Nynorsk to "Inntekt etter uførleik",
+                                    Language.English to "Income after disability"
+                                )
+                            }
+                            cell {
+                                includePhrase(Felles.KronerText(beloep))
+                            }
                         }
                     }
                 }
@@ -367,7 +369,7 @@ data class TabellUfoereOpplysninger(
                         }
                     }
                 }
-                showIf(beregningsmetode.isOneOf(Beregningsmetode.FOLKETRYGD)){
+                showIf(beregningsmetode.isOneOf(Beregningsmetode.FOLKETRYGD)) {
                     row {
                         cell {
                             text(
@@ -436,7 +438,7 @@ data class TabellUfoereOpplysninger(
                     }
                 }
                 ifNotNull(trygdetidsdetaljerGjeldende.faktiskTTNorge) {
-                    showIf(beregningsmetode.isOneOf(Beregningsmetode.FOLKETRYGD)) {
+                    showIf(beregningsmetode.isNotAnyOf(Beregningsmetode.FOLKETRYGD)) {
                         row {
                             cell {
                                 text(
@@ -751,5 +753,6 @@ data class TabellUfoereOpplysninger(
                     }
                 }
             }
-        }    }
+        }
+    }
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerBruktIBeregningUT.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerBruktIBeregningUT.kt
@@ -61,7 +61,7 @@ fun createVedleggOpplysningerBruktIBeregningUT(skalViseMinsteytelse: Boolean, sk
                 inntektsAvkortingGjeldende = inntektsAvkortingGjeldende,
                 inntektsgrenseErUnderTak = inntektsgrenseErUnderTak,
                 beregnetUTPerManedGjeldende = beregnetUTPerManedGjeldende,
-                inntektEtterUfoereGjeldende_beloepIEU = inntektEtterUfoereGjeldende_beloepIEU,
+                inntektEtterUfoereGjeldendeBeloep = inntektEtterUfoereGjeldende_beloepIEU,
                 ungUfoerGjeldende_erUnder20Aar = ungUfoerGjeldende_erUnder20Aar,
                 trygdetidsdetaljerGjeldende = trygdetidsdetaljerGjeldende,
                 barnetilleggGjeldende = barnetilleggGjeldende,

--- a/skribenten-backend/build.gradle.kts
+++ b/skribenten-backend/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
 
-    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.22")
+    implementation("no.nav.pensjon.brev:pensjon-brevbaker-api-model:3.5.23")
 
     // Logging
     implementation("ch.qos.logback:logback-classic:$logbackVersion")


### PR DESCRIPTION
Bytter om rekkefølge på vedlegg, korrekt visning av faktisk trygdetid norge, påkrever ikke inntekt etter uføre(saker konvertert fra uførepensjon har ikke det) og refactoring.