### PR TITLE
PL-5105: Rettinger etter test.

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAuto.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAuto.kt
@@ -117,7 +117,7 @@ object OpphoerBarnetilleggAuto : AutobrevTemplate<OpphoerBarnetilleggAutoDto> {
                 )
             )
 
-            includePhrase(Ufoeretrygd.UtbetalingsdatoUfoeretrygd)
+            includePhrase(Ufoeretrygd.UtbetalingsdatoUfoeretrygd(ufoeretrygd.utbetaltPerMaaned.greaterThan(0)))
             includePhrase(Ufoeretrygd.ViktigAALeseHeleBrevet)
             includePhrase(Vedtak.BegrunnelseOverskrift)
             includePhrase(

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Ufoeretrygd.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Ufoeretrygd.kt
@@ -168,14 +168,16 @@ object Ufoeretrygd {
     }
 
     // TBU2223
-    object UtbetalingsdatoUfoeretrygd : OutlinePhrase<LangBokmalNynorskEnglish>() {
+    data class UtbetalingsdatoUfoeretrygd(val faarUtbetaltUfoeretrygd: Expression<Boolean>) : OutlinePhrase<LangBokmalNynorskEnglish>() {
         override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
-            paragraph {
-                text(
-                    Bokmal to "Uføretrygden blir fortsatt utbetalt senest den 20. hver måned.",
-                    Nynorsk to "Uføretrygda blir framleis utbetalt seinast den 20. i kvar månad.",
-                    English to "Your disability benefit will still be paid no later than the 20th of every month."
-                )
+            showIf(faarUtbetaltUfoeretrygd) {
+                paragraph {
+                    text(
+                        Bokmal to "Uføretrygden blir fortsatt utbetalt senest den 20. hver måned.",
+                        Nynorsk to "Uføretrygda blir framleis utbetalt seinast den 20. i kvar månad.",
+                        English to "Your disability benefit will still be paid no later than the 20th of every month."
+                    )
+                }
             }
         }
     }
@@ -306,11 +308,10 @@ object Ufoeretrygd {
     }
 
     // TBU3730, SkattBorIUtlandPesys_001
-    data class SkattForDegSomBorIUtlandet(
-        val brukerBorInorge: Expression<Boolean>
-    ) : OutlinePhrase<LangBokmalNynorskEnglish>() {
+    data class SkattForDegSomBorIUtlandet(val brukerBorInorge: Expression<Boolean>) :
+        OutlinePhrase<LangBokmalNynorskEnglish>() {
         override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
-            showIf(brukerBorInorge) {
+            showIf(not(brukerBorInorge)) {
                 title1 {
                     text(
                         Bokmal to "Skatt for deg som bor i utlandet",

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/opplysningerbruktiberegningufoere/TabellUfoereOpplysninger.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/opplysningerbruktiberegningufoere/TabellUfoereOpplysninger.kt
@@ -66,6 +66,7 @@ data class TabellUfoereOpplysninger(
     val ungUfoerGjeldende_erUnder20Aar: Expression<Boolean?>,
     val trygdetidsdetaljerGjeldende: Expression<OpplysningerBruktIBeregningUTDto.TrygdetidsdetaljerGjeldende>,
     val barnetilleggGjeldende: Expression<OpplysningerBruktIBeregningUTDto.BarnetilleggGjeldende?>,
+    val harMinsteytelse: Expression<Boolean>,
 
     ) : OutlinePhrase<LangBokmalNynorskEnglish>() {
     override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
@@ -259,22 +260,24 @@ data class TabellUfoereOpplysninger(
                         }
                     }
                 }
-                // Mandatory
-                row {
-                    cell {
-                        text(
-                            Language.Bokmal to "Sivilstatus lagt til grunn i beregningen",
-                            Language.Nynorsk to "Sivilstatus lagt til grunn i utrekninga",
-                            Language.English to "Marital status applied to calculation"
-                        )
-                    }
-                    cell {
-                        val brukersSivilstand = beregnetUTPerManedGjeldende.brukersSivilstand.tableFormat()
-                        textExpr(
-                            Language.Bokmal to brukersSivilstand,
-                            Language.Nynorsk to brukersSivilstand,
-                            Language.English to brukersSivilstand
-                        )
+
+                showIf(harMinsteytelse) {
+                    row {
+                        cell {
+                            text(
+                                Language.Bokmal to "Sivilstatus lagt til grunn i beregningen",
+                                Language.Nynorsk to "Sivilstatus lagt til grunn i utrekninga",
+                                Language.English to "Marital status applied to calculation"
+                            )
+                        }
+                        cell {
+                            val brukersSivilstand = beregnetUTPerManedGjeldende.brukersSivilstand.tableFormat()
+                            textExpr(
+                                Language.Bokmal to brukersSivilstand,
+                                Language.Nynorsk to brukersSivilstand,
+                                Language.English to brukersSivilstand
+                            )
+                        }
                     }
                 }
                 showIf(ungUfoerGjeldende_erUnder20Aar.ifNull(false)) {

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerBruktIBeregningUT.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerBruktIBeregningUT.kt
@@ -65,6 +65,7 @@ fun createVedleggOpplysningerBruktIBeregningUT(skalViseMinsteytelse: Boolean, sk
                 ungUfoerGjeldende_erUnder20Aar = ungUfoerGjeldende_erUnder20Aar,
                 trygdetidsdetaljerGjeldende = trygdetidsdetaljerGjeldende,
                 barnetilleggGjeldende = barnetilleggGjeldende,
+                harMinsteytelse = minsteytelseGjeldende_sats.notNull(),
             )
         )
         if(skalViseMinsteytelse) {


### PR DESCRIPTION
* retter feil i "skatt for deg som bor i utlandet" visnings-logikk
* viser kun sivilstand når det er relevant i tabellen (bruker har minsteytelse)
* kun vis tekst om utbetaling av uføretrygd om du får utbetalt uføretrygd.