### PR TITLE
PL-5105: 

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAuto.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAuto.kt
@@ -193,17 +193,6 @@ object OpphoerBarnetilleggAuto : AutobrevTemplate<OpphoerBarnetilleggAutoDto> {
                     )
                 }
 
-                ifNotNull(barnetilleggSaerkullsbarn) { barnetilleggSaerkullsbarn ->
-                    includePhrase(
-                        Barnetillegg.InntektTilAvkortningSaerkullsbarn(
-                            beloepNettoSaerkullsbarn = barnetilleggSaerkullsbarn.beloepNetto,
-                            fribeloepSaerkullsbarn = barnetilleggSaerkullsbarn.fribeloep,
-                            inntektBruktIAvkortningSaerkullsbarn = barnetilleggSaerkullsbarn.inntektBruktIAvkortning,
-                            harJusteringsbeloepSaerkullsbarn = barnetilleggSaerkullsbarn.harJusteringsbeloep,
-                        )
-                    )
-                }
-
                 ifNotNull(
                     barnetilleggFellesbarn,
                     barnetilleggSaerkullsbarn
@@ -227,6 +216,15 @@ object OpphoerBarnetilleggAuto : AutobrevTemplate<OpphoerBarnetilleggAutoDto> {
                             harTilleggForFlereFellesbarn = barnetilleggFellesbarn.gjelderFlereBarn,
                             samletInntektBruktiAvkortningFellesbarn = barnetilleggFellesbarn.samletInntektBruktIAvkortning,
                             borMed = barnetilleggFellesbarn.brukerBorMed,
+                        )
+                    )
+                }.orIfNotNull(barnetilleggSaerkullsbarn) { barnetilleggSaerkullsbarn ->
+                    includePhrase(
+                        Barnetillegg.InntektTilAvkortningSaerkullsbarn(
+                            beloepNettoSaerkullsbarn = barnetilleggSaerkullsbarn.beloepNetto,
+                            fribeloepSaerkullsbarn = barnetilleggSaerkullsbarn.fribeloep,
+                            inntektBruktIAvkortningSaerkullsbarn = barnetilleggSaerkullsbarn.inntektBruktIAvkortning,
+                            harJusteringsbeloepSaerkullsbarn = barnetilleggSaerkullsbarn.harJusteringsbeloep,
                         )
                     )
                 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Barnetillegg.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Barnetillegg.kt
@@ -114,7 +114,8 @@ object Barnetillegg {
                             Nynorsk to " Denne grensa kallar vi for fribeløp.",
                             English to " We call this limit the exemption amount."
                         )
-                    }.orShowIf(harBarnetilleggSaerkullsbarn) {
+                    }
+                    showIf(harBarnetilleggSaerkullsbarn) {
                         textExpr(
                             Bokmal to " Inntekten til ".expr() + borMedSivilstand.bestemtForm() + " din har kun betydning for størrelsen på barnetillegget til barna som bor sammen med begge sine foreldre.",
                             Nynorsk to " Inntekta til ".expr() + borMedSivilstand.bestemtForm() + " din har berre betydning for storleiken på barnetillegget til barna som bur saman med begge foreldra sine.",


### PR DESCRIPTION
Ikke vis InntektTilAvkortningSaerkullsbarn i kombinasjon med BarnetilleggReduksjonSaerkullsbarnFellesbarn i opphør barnetillegg brev. Retting i rar ekskluderings-logikk som førte til at deler av setningen ikke ble vist. 