### PR TITLE
EY-2530 Legger inn includePhrase rundt beregningstabellen, noe som manglet

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/Barnepensjon.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/Barnepensjon.kt
@@ -2,14 +2,8 @@ package no.nav.pensjon.etterlatte.maler.fraser.barnepensjon
 
 import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.model.format
-import no.nav.pensjon.brev.template.Expression
-import no.nav.pensjon.brev.template.LangBokmal
-import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
-import no.nav.pensjon.brev.template.Language.Bokmal
-import no.nav.pensjon.brev.template.Language.English
-import no.nav.pensjon.brev.template.Language.Nynorsk
-import no.nav.pensjon.brev.template.OutlinePhrase
-import no.nav.pensjon.brev.template.TextOnlyPhrase
+import no.nav.pensjon.brev.template.*
+import no.nav.pensjon.brev.template.Language.*
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
 import no.nav.pensjon.brev.template.dsl.TextOnlyScope
 import no.nav.pensjon.brev.template.dsl.expression.expr
@@ -100,7 +94,7 @@ object Barnepensjon {
                     )
                 }
             }
-            BeregnetPensjonTabell(beregningsperioder)
+            includePhrase(BeregnetPensjonTabell(beregningsperioder))
         }
     }
 


### PR DESCRIPTION
Dette gjorde at tabellen ikke ble med i brevene. Feilen ser ut til å ha blitt innført 27. juli i samme fil som i commiten her.