### PR TITLE
EY-2646: Forenkle DTO for etterbetaling

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -8,14 +8,6 @@ data class EtterbetalingDTO(
     val tilDato: LocalDate
 )
 
-data class Etterbetalingsperiode(
-    val datoFOM: LocalDate,
-    val datoTOM: LocalDate?,
-    val grunnbeloep: Kroner,
-    val stoenadFoerReduksjon: Kroner,
-    var utbetaltBeloep: Kroner
-)
-
 data class Avkortingsinfo(
     val grunnbeloep: Kroner,
     val inntekt: Kroner,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -5,8 +5,7 @@ import java.time.LocalDate
 
 data class EtterbetalingDTO(
     val fraDato: LocalDate,
-    val tilDato: LocalDate,
-    val beregningsperioder: List<Etterbetalingsperiode> = emptyList()
+    val tilDato: LocalDate
 )
 
 data class Etterbetalingsperiode(

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 data class EtterbetalingDTO(
     val fraDato: LocalDate,
     val tilDato: LocalDate,
-    val beregningsperioder: List<Etterbetalingsperiode>
+    val beregningsperioder: List<Etterbetalingsperiode> = emptyList()
 )
 
 data class Etterbetalingsperiode(

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/ny/BarnepensjonInnvilgelseEnkel.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/ny/BarnepensjonInnvilgelseEnkel.kt
@@ -16,7 +16,7 @@ import no.nav.pensjon.etterlatte.maler.Utbetalingsinfo
 import no.nav.pensjon.etterlatte.maler.UtbetalingsinfoSelectors.beloep
 import no.nav.pensjon.etterlatte.maler.UtbetalingsinfoSelectors.virkningsdato
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.ny.BarnepensjonInnvilgelseEnkelDTOSelectors.avdoed
-import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.ny.BarnepensjonInnvilgelseEnkelDTOSelectors.erEtterbetalingMerEnnTreMaaneder
+import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.ny.BarnepensjonInnvilgelseEnkelDTOSelectors.erEtterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.ny.BarnepensjonInnvilgelseEnkelDTOSelectors.utbetalingsinfo
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.ny.BarnepensjonInnvilgelseEnkelDTOSelectors.vedtaksdato
 import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.innvilgelse.BarnepensjonInnvilgelseEnkelFraser
@@ -27,7 +27,7 @@ data class BarnepensjonInnvilgelseEnkelDTO(
     val utbetalingsinfo: Utbetalingsinfo,
     val avdoed: Avdoed,
     val vedtaksdato: LocalDate,
-    val erEtterbetalingMerEnnTreMaaneder: Boolean,
+    val erEtterbetaling: Boolean,
     val erInstitusjonsopphold: Boolean,
 )
 
@@ -63,7 +63,7 @@ object BarnepensjonInnvilgelseEnkel : EtterlatteTemplate<BarnepensjonInnvilgelse
                     avdoed.doedsdato,
                     utbetalingsinfo.beloep,
                     vedtaksdato,
-                    erEtterbetalingMerEnnTreMaaneder
+                    erEtterbetaling
                 ),
             )
         }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/innvilgelse/BarnepensjonInnvilgelseEnkelFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/innvilgelse/BarnepensjonInnvilgelseEnkelFraser.kt
@@ -24,7 +24,7 @@ object BarnepensjonInnvilgelseEnkelFraser {
         val doedsdato: Expression<LocalDate>,
         val beloep: Expression<Kroner>,
         val vedtaksdato: Expression<LocalDate>,
-        val erEtterbetalingMerEnnTreMaaneder: Expression<Boolean>,
+        val erEtterbetaling: Expression<Boolean>,
     ) :
         OutlinePhrase<LangBokmalNynorskEnglish>() {
         override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
@@ -50,7 +50,7 @@ object BarnepensjonInnvilgelseEnkelFraser {
                     English to "",
                 )
             }
-            showIf(erEtterbetalingMerEnnTreMaaneder) {
+            showIf(erEtterbetaling) {
                 includePhrase(Etterbetaling)
             }.orShow {
                 paragraph {

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/EtterbetalingAvBarnepensjon.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/EtterbetalingAvBarnepensjon.kt
@@ -1,6 +1,5 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg.barnepensjon
 
-import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.template.Language.Bokmal
 import no.nav.pensjon.brev.template.Language.English
 import no.nav.pensjon.brev.template.Language.Nynorsk
@@ -12,14 +11,8 @@ import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
 import no.nav.pensjon.brev.template.dsl.newText
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.dsl.textExpr
-import no.nav.pensjon.etterlatte.maler.EtterbetalingDTOSelectors.beregningsperioder
 import no.nav.pensjon.etterlatte.maler.EtterbetalingDTOSelectors.fraDato
 import no.nav.pensjon.etterlatte.maler.EtterbetalingDTOSelectors.tilDato
-import no.nav.pensjon.etterlatte.maler.EtterbetalingsperiodeSelectors.datoFOM
-import no.nav.pensjon.etterlatte.maler.EtterbetalingsperiodeSelectors.datoTOM
-import no.nav.pensjon.etterlatte.maler.EtterbetalingsperiodeSelectors.grunnbeloep
-import no.nav.pensjon.etterlatte.maler.EtterbetalingsperiodeSelectors.utbetaltBeloep
-import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.Barnepensjon
 import no.nav.pensjon.etterlatte.maler.fraser.common.Constants
 
 @TemplateModelHelpers
@@ -69,28 +62,5 @@ val etterbetalingAvBarnepensjon = createAttachment(
             Nynorsk to "",
             English to "",
         )
-    }
-    paragraph {
-        table(
-            header = {
-                column(2) {
-                    text(Bokmal to "Periode", Nynorsk to "", English to "")
-                }
-                column(1) {
-                    text(Bokmal to "Grunnbeløp (G)", Nynorsk to "", English to "")
-                }
-                column(2) {
-                    text(Bokmal to "Utbetaling per måned før skatt", Nynorsk to "", English to "")
-                }
-            },
-        ) {
-            forEach(beregningsperioder) {
-                row {
-                    cell { includePhrase(Barnepensjon.PeriodeITabell(it.datoFOM, it.datoTOM)) }
-                    cell { includePhrase(Felles.KronerText(it.grunnbeloep)) }
-                    cell { includePhrase(Felles.KronerText(it.utbetaltBeloep)) }
-                }
-            }
-        }
     }
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/Etterbetaling.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/Etterbetaling.kt
@@ -1,20 +1,23 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad
 
-import no.nav.pensjon.brev.maler.fraser.common.Felles
-import no.nav.pensjon.brev.template.*
-import no.nav.pensjon.brev.template.Language.*
-import no.nav.pensjon.brev.template.dsl.*
-import no.nav.pensjon.brev.template.dsl.expression.*
+import no.nav.pensjon.brev.template.Expression
+import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
+import no.nav.pensjon.brev.template.Language.Bokmal
+import no.nav.pensjon.brev.template.Language.English
+import no.nav.pensjon.brev.template.Language.Nynorsk
+import no.nav.pensjon.brev.template.TextOnlyPhrase
+import no.nav.pensjon.brev.template.createAttachment
+import no.nav.pensjon.brev.template.dsl.TextOnlyScope
+import no.nav.pensjon.brev.template.dsl.expression.expr
+import no.nav.pensjon.brev.template.dsl.expression.format
+import no.nav.pensjon.brev.template.dsl.expression.plus
 import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
+import no.nav.pensjon.brev.template.dsl.newText
+import no.nav.pensjon.brev.template.dsl.text
+import no.nav.pensjon.brev.template.dsl.textExpr
 import no.nav.pensjon.etterlatte.maler.EtterbetalingDTO
-import no.nav.pensjon.etterlatte.maler.EtterbetalingDTOSelectors.beregningsperioder
 import no.nav.pensjon.etterlatte.maler.EtterbetalingDTOSelectors.fraDato
 import no.nav.pensjon.etterlatte.maler.EtterbetalingDTOSelectors.tilDato
-import no.nav.pensjon.etterlatte.maler.EtterbetalingsperiodeSelectors.datoFOM
-import no.nav.pensjon.etterlatte.maler.EtterbetalingsperiodeSelectors.datoTOM
-import no.nav.pensjon.etterlatte.maler.EtterbetalingsperiodeSelectors.grunnbeloep
-import no.nav.pensjon.etterlatte.maler.EtterbetalingsperiodeSelectors.stoenadFoerReduksjon
-import no.nav.pensjon.etterlatte.maler.EtterbetalingsperiodeSelectors.utbetaltBeloep
 import no.nav.pensjon.etterlatte.maler.fraser.common.Constants
 import java.time.LocalDate
 
@@ -31,7 +34,7 @@ val etterbetaling = createAttachment<LangBokmalNynorskEnglish, EtterbetalingDTO>
 
     paragraph {
         textExpr(
-            Bokmal to "Du får etterbetalt stønad fra ".expr() + fraDato.format() + " til " + tilDato.format()  +
+            Bokmal to "Du får etterbetalt stønad fra ".expr() + fraDato.format() + " til " + tilDato.format() +
                     ". Vanligvis vil du få denne etterbetalingen i løpet av tre uker. ",
             Nynorsk to "".expr(),
             English to "".expr(),
@@ -69,46 +72,6 @@ val etterbetaling = createAttachment<LangBokmalNynorskEnglish, EtterbetalingDTO>
             Nynorsk to "",
             English to "",
         )
-    }
-
-    paragraph {
-        table(
-            header = {
-                column(2) {
-                    text(Bokmal to "Periode",
-                        Nynorsk to "",
-                        English to "",
-                    )
-                }
-                column(1) {
-                    text(Bokmal to "Grunnbeløp (G)",
-                        Nynorsk to "",
-                        English to "",
-                    )
-                }
-                column(2) {
-                    text(Bokmal to "Stønad før reduksjon",
-                    Nynorsk to "",
-                    English to "",
-                    )
-                }
-                column(2) {
-                    text(Bokmal to "Brutto utbetaling per måned",
-                        Nynorsk to "",
-                        English to "",
-                    )
-                }
-            }
-        ) {
-            forEach(beregningsperioder) {
-                row {
-                    cell { includePhrase(PeriodeITabell(it.datoFOM, it.datoTOM)) }
-                    cell { includePhrase(Felles.KronerText(it.grunnbeloep)) }
-                    cell { includePhrase(Felles.KronerText(it.stoenadFoerReduksjon)) }
-                    cell { includePhrase(Felles.KronerText(it.utbetaltBeloep)) }
-                }
-            }
-        }
     }
 }
 

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonEndringHovedmalDTO.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonEndringHovedmalDTO.kt
@@ -11,7 +11,6 @@ import java.time.Month
 fun createEndringHovedmalDTO() = EndringHovedmalDTO(
     erEndret = true,
     etterbetaling = EtterbetalingDTO(
-        beregningsperioder = listOf(),
         fraDato = LocalDate.of(2020, Month.JANUARY, 1),
         tilDato = LocalDate.of(2023, Month.DECEMBER, 31),
     ),

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseEnkelDTO.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseEnkelDTO.kt
@@ -35,6 +35,6 @@ fun createBarnepensjonInnvilgelseEnkelDTO() = BarnepensjonInnvilgelseEnkelDTO(
         doedsdato = LocalDate.now().minusMonths(1),
     ),
     vedtaksdato = LocalDate.now(),
-    erEtterbetalingMerEnnTreMaaneder = true,
+    erEtterbetaling = true,
     erInstitusjonsopphold = true,
 )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseNyDTO.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseNyDTO.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.etterlatte.fixtures
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import no.nav.pensjon.etterlatte.maler.Beregningsperiode
 import no.nav.pensjon.etterlatte.maler.EtterbetalingDTO
-import no.nav.pensjon.etterlatte.maler.Etterbetalingsperiode
 import no.nav.pensjon.etterlatte.maler.Utbetalingsinfo
 import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BarnepensjonInnvilgelseNyDTO
 import java.time.LocalDate

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseNyDTO.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseNyDTO.kt
@@ -37,22 +37,6 @@ fun createBarnepensjonInnvilgelseNyDTO() =
         innhold = listOf(),
         etterbetalingDTO = EtterbetalingDTO(
             fraDato = LocalDate.of(2020, Month.JANUARY, 1),
-            tilDato = LocalDate.of(2023, Month.JULY, 31),
-            beregningsperioder = listOf(
-                Etterbetalingsperiode(
-                    datoFOM = LocalDate.of(2020, Month.JANUARY, 1),
-                    datoTOM = LocalDate.of(2023, Month.JANUARY, 1),
-                    grunnbeloep = Kroner(118000),
-                    stoenadFoerReduksjon = Kroner(9000),
-                    utbetaltBeloep = Kroner(3080)
-                ),
-                Etterbetalingsperiode(
-                    datoFOM = LocalDate.of(2023, Month.JANUARY, 2),
-                    datoTOM = null,
-                    grunnbeloep = Kroner(150000),
-                    stoenadFoerReduksjon = Kroner(11000),
-                    utbetaltBeloep = Kroner(2000)
-                )
-            )
+            tilDato = LocalDate.of(2023, Month.JULY, 31)
         )
     )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSInnvilgelseDTO.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSInnvilgelseDTO.kt
@@ -58,22 +58,6 @@ fun createOMSInnvilgelseDTO() =
         ),
         etterbetalingsinfo = EtterbetalingDTO(
             fraDato = LocalDate.now(),
-            tilDato = LocalDate.now(),
-            beregningsperioder = listOf(
-                Etterbetalingsperiode(
-                    datoFOM = LocalDate.now(),
-                    datoTOM = LocalDate.now(),
-                    grunnbeloep = Kroner(118000),
-                    stoenadFoerReduksjon = Kroner(9000),
-                    utbetaltBeloep = Kroner(3080)
-                ),
-                Etterbetalingsperiode(
-                    datoFOM = LocalDate.now(),
-                    datoTOM = null,
-                    grunnbeloep = Kroner(118000),
-                    stoenadFoerReduksjon = Kroner(11000),
-                    utbetaltBeloep = Kroner(2000)
-                )
-            )
+            tilDato = LocalDate.now()
         )
     )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSInnvilgelseFoerstegangsvedtak.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSInnvilgelseFoerstegangsvedtak.kt
@@ -59,23 +59,7 @@ fun createOMSInnvilgelseFoerstegangsvedtakDTO() =
         ),
         etterbetalinginfo = EtterbetalingDTO(
             fraDato = LocalDate.now(),
-            tilDato = LocalDate.now(),
-            beregningsperioder = listOf(
-                Etterbetalingsperiode(
-                    datoFOM = LocalDate.now(),
-                    datoTOM = LocalDate.now(),
-                    grunnbeloep = Kroner(118000),
-                    stoenadFoerReduksjon = Kroner(9000),
-                    utbetaltBeloep = Kroner(3080)
-                ),
-                Etterbetalingsperiode(
-                    datoFOM = LocalDate.now(),
-                    datoTOM = null,
-                    grunnbeloep = Kroner(118000),
-                    stoenadFoerReduksjon = Kroner(11000),
-                    utbetaltBeloep = Kroner(2000)
-                )
-            )
+            tilDato = LocalDate.now()
         ),
         beregningsinfo = Beregningsinfo(
             grunnbeloep = Kroner(118000),

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSRevurdering.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSRevurdering.kt
@@ -32,23 +32,7 @@ fun createOMSRevurderingEndringDTO() =
         ),
         etterbetalinginfo = EtterbetalingDTO(
             fraDato = LocalDate.now(),
-            tilDato = LocalDate.now(),
-            beregningsperioder = listOf(
-                Etterbetalingsperiode(
-                    datoFOM = LocalDate.now(),
-                    datoTOM = LocalDate.now(),
-                    grunnbeloep = Kroner(118000),
-                    stoenadFoerReduksjon = Kroner(9000),
-                    utbetaltBeloep = Kroner(3080)
-                ),
-                Etterbetalingsperiode(
-                    datoFOM = LocalDate.now(),
-                    datoTOM = null,
-                    grunnbeloep = Kroner(118000),
-                    stoenadFoerReduksjon = Kroner(11000),
-                    utbetaltBeloep = Kroner(2000)
-                )
-            )
+            tilDato = LocalDate.now()
         ),
         beregningsinfo = Beregningsinfo(
             grunnbeloep = Kroner(118000),


### PR DESCRIPTION
Vi har avklart med fag (Merethe og Liv Inger) at tabellen for kva periodar som er etterbetaling skal ut, og tabellen i vedlegg 1 (Slik har vi beregnet pensjonen din) skal ha alle.

Skal vera likt for både BP og OMS.