### PR TITLE
Update permissions pensjon

### DIFF
--- a/pensjon-brevbaker/.nais/dev.yaml
+++ b/pensjon-brevbaker/.nais/dev.yaml
@@ -10,26 +10,35 @@ preAuthorized:
   - name: pensjon-pen-q0
     namespace: teampensjon
     cluster: dev-fss
-  - name: pensjon-pen-t0
-    namespace: teampensjon
+  - name: pensjon-pen-q0
+    namespace: pensjon-q0
     cluster: dev-fss
   - name: pensjon-pen-q1
     namespace: teampensjon
     cluster: dev-fss
+  - name: pensjon-pen-q1
+    namespace: pensjon-q1
+    cluster: dev-fss
   - name: pensjon-pen-q2
     namespace: teampensjon
+    cluster: dev-fss
+  - name: pensjon-pen-q2
+    namespace: pensjon-q2
     cluster: dev-fss
   - name: penbatch
     namespace: pensjon-batch
     cluster: dev-fss
-  - name: pensjon-pen-q4
-    namespace: teampensjon
-    cluster: dev-fss
   - name: pensjon-pen-q5
     namespace: teampensjon
     cluster: dev-fss
+  - name: pensjon-pen-q5
+    namespace: pensjon-q5
+    cluster: dev-fss
   - name: pensjon-psak-q2
     namespace: teampensjon
+    cluster: dev-fss
+  - name: pensjon-psak-q2
+    namespace: pensjon-q2
     cluster: dev-fss
   - name: locust
     namespace: pensjonsbrev


### PR DESCRIPTION
We are moving applications to new namespaces in order to lock down access to the test environments with production data.
Upcoming platform change makes it possible to lock down certain kubectl commands in given namespaces.

This PR is preparing namespace move for pen, psak, pselv and name change for pselv application (both pselv applications are going to gcp in the same namespace).

A cleanup PR will be made when the applications are moved.