### PR TITLE
EY-2926 Trygdetidstabellen skal vises kun hvis vi har perioder

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -55,7 +55,7 @@ data class Trygdetidsperiode(
 
 data class Periode(
     val aar: Int,
-    val maaaneder: Int,
+    val maaneder: Int,
     val dager: Int,
 )
 

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -50,7 +50,13 @@ data class Trygdetidsperiode(
     val datoFOM: LocalDate,
     val datoTOM: LocalDate?,
     val land: String,
-    val opptjeningsperiode: Period?,
+    val opptjeningsperiode: Periode?,
+)
+
+data class Periode(
+    val aar: Int,
+    val maaaneder: Int,
+    val dager: Int,
 )
 
 data class Utbetalingsinfo(

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.etterlatte.maler
 
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.LocalDate
+import java.time.Period
 
 data class EtterbetalingDTO(
     val fraDato: LocalDate,
@@ -49,7 +50,7 @@ data class Trygdetidsperiode(
     val datoFOM: LocalDate,
     val datoTOM: LocalDate?,
     val land: String,
-    val opptjeningsperiode: String,
+    val opptjeningsperiode: Period?,
 )
 
 data class Utbetalingsinfo(

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
@@ -1,8 +1,10 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg
 
 import no.nav.pensjon.brev.template.Expression
+import no.nav.pensjon.brev.template.ExpressionScope
 import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
 import no.nav.pensjon.brev.template.Language
+import no.nav.pensjon.brev.template.LocalizedFormatter
 import no.nav.pensjon.brev.template.OutlinePhrase
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
 import no.nav.pensjon.brev.template.dsl.expression.expr
@@ -14,6 +16,7 @@ import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.datoTOM
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.land
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.opptjeningsperiode
 import no.nav.pensjon.etterlatte.maler.fraser.common.PeriodeITabell
+import java.time.Period
 
 data class Trygdetidstabell(
     val trygdetidsperioder: Expression<List<Trygdetidsperiode>>
@@ -51,20 +54,58 @@ data class Trygdetidstabell(
                         cell {
                             textExpr(
                                 Language.Bokmal to it.land,
-                                Language.Nynorsk to "".expr(),
-                                Language.English to "".expr(),
+                                Language.Nynorsk to it.land,
+                                Language.English to it.land,
                             )
                         }
                         cell {
-                            textExpr(
-                                Language.Bokmal to it.opptjeningsperiode,
-                                Language.Nynorsk to "".expr(),
-                                Language.English to "".expr(),
-                            )
+                            ifNotNull(it.opptjeningsperiode) {
+                                textExpr(
+                                    Language.Bokmal to it.format(),
+                                    Language.Nynorsk to "".expr(),
+                                    Language.English to "".expr()
+                                )
+                            }
                         }
                     }
                 }
             }
         }
+    }
+}
+
+fun Expression<Period>.format() = Expression.BinaryInvoke(
+    first = this,
+    second = Expression.FromScope(ExpressionScope<Any, *>::language),
+    operation = PeriodFormatter,
+)
+
+object PeriodFormatter : LocalizedFormatter<Period>() {
+    override fun apply(first: Period, second: Language): String {
+        val actualValues = listOfNotNull(
+            first.years.takeIf { it > 0 }?.let {
+                when (second) {
+                    Language.Bokmal -> "$it år"
+                    Language.English -> "$it"
+                    Language.Nynorsk -> "$it"
+                }
+            },
+            first.months.takeIf { it > 0 }?.let {
+                when (second) {
+                    Language.Bokmal -> "$it måneder"
+                    Language.English -> ""
+                    Language.Nynorsk -> ""
+                }
+            },
+            first.days.takeIf { it > 0 }?.let {
+                when (second) {
+                    Language.Bokmal -> "$it dager"
+                    Language.English -> ""
+                    Language.Nynorsk -> ""
+                }
+            }
+        )
+
+        return actualValues.joinToString(separator = ", ") { it }
     }
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
@@ -17,7 +17,6 @@ import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.datoTOM
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.land
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.opptjeningsperiode
 import no.nav.pensjon.etterlatte.maler.fraser.common.PeriodeITabell
-import java.time.Period
 
 data class Trygdetidstabell(
     val trygdetidsperioder: Expression<List<Trygdetidsperiode>>
@@ -91,7 +90,7 @@ object PeriodeFormatter : LocalizedFormatter<Periode>() {
                     Language.Nynorsk -> "$it"
                 }
             },
-            first.maaaneder.takeIf { it > 0 }?.let {
+            first.maaneder.takeIf { it > 0 }?.let {
                 when (second) {
                     Language.Bokmal -> "$it måneder"
                     Language.English -> ""

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
@@ -10,6 +10,7 @@ import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.dsl.textExpr
+import no.nav.pensjon.etterlatte.maler.Periode
 import no.nav.pensjon.etterlatte.maler.Trygdetidsperiode
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.datoFOM
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.datoTOM
@@ -74,30 +75,30 @@ data class Trygdetidstabell(
     }
 }
 
-fun Expression<Period>.format() = Expression.BinaryInvoke(
+fun Expression<Periode>.format() = Expression.BinaryInvoke(
     first = this,
     second = Expression.FromScope(ExpressionScope<Any, *>::language),
-    operation = PeriodFormatter,
+    operation = PeriodeFormatter,
 )
 
-object PeriodFormatter : LocalizedFormatter<Period>() {
-    override fun apply(first: Period, second: Language): String {
+object PeriodeFormatter : LocalizedFormatter<Periode>() {
+    override fun apply(first: Periode, second: Language): String {
         val actualValues = listOfNotNull(
-            first.years.takeIf { it > 0 }?.let {
+            first.aar.takeIf { it > 0 }?.let {
                 when (second) {
                     Language.Bokmal -> "$it år"
                     Language.English -> "$it"
                     Language.Nynorsk -> "$it"
                 }
             },
-            first.months.takeIf { it > 0 }?.let {
+            first.maaaneder.takeIf { it > 0 }?.let {
                 when (second) {
                     Language.Bokmal -> "$it måneder"
                     Language.English -> ""
                     Language.Nynorsk -> ""
                 }
             },
-            first.days.takeIf { it > 0 }?.let {
+            first.dager.takeIf { it > 0 }?.let {
                 when (second) {
                     Language.Bokmal -> "$it dager"
                     Language.English -> ""

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/BeregningAvBarnepensjon.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/BeregningAvBarnepensjon.kt
@@ -11,6 +11,7 @@ import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.expression.format
 import no.nav.pensjon.brev.template.dsl.expression.greaterThan
+import no.nav.pensjon.brev.template.dsl.expression.isNotEmpty
 import no.nav.pensjon.brev.template.dsl.expression.plus
 import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
 import no.nav.pensjon.brev.template.dsl.newText
@@ -25,7 +26,6 @@ import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BeregningsinfoBPSelectors
 import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BeregningsinfoBPSelectors.beregningsperioder
 import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BeregningsinfoBPSelectors.grunnbeloep
 import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BeregningsinfoBPSelectors.innhold
-import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BeregningsinfoBPSelectors.maanederTrygdetid
 import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BeregningsinfoBPSelectors.trygdetidsperioder
 import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
 import no.nav.pensjon.etterlatte.maler.vedlegg.Trygdetidstabell
@@ -44,7 +44,7 @@ val beregningAvBarnepensjon = createAttachment(
         grunnbeloep = grunnbeloep,
         antallBarn = antallBarn
     )
-    trygdetid(aarTrygdetid, maanederTrygdetid, trygdetidsperioder)
+    trygdetid(aarTrygdetid, trygdetidsperioder)
 }
 
 private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, BeregningsinfoBP>.slikHarViBeregnetPensjonenDin(
@@ -109,7 +109,6 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
 
 private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, BeregningsinfoBP>.trygdetid(
     aarTrygdetid: Expression<Int>,
-    maanederTrygdetid: Expression<Int>,
     trygdetidsperioder: Expression<List<Trygdetidsperiode>>
 ) {
 
@@ -126,19 +125,22 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                     "Trygdetiden tilsvarer det antall år avdøde har vært medlem i folketrygden etter fylte 16 år. " +
                     "Når avdøde var under 67 år ved dødsfallet blir det beregnet framtidig trygdetid. " +
                     "Det er vanligvis fram til og med det året avdøde ville ha fylt 66 år. " +
-                    "Avdødes samledes trygdetid er " + aarTrygdetid.format() + " år og " +
-                    maanederTrygdetid.format() + " måneder.",
+                    "Avdødes samledes trygdetid er " + aarTrygdetid.format() + " år",
             Nynorsk to "".expr(),
             English to "".expr(),
         )
     }
     konverterElementerTilBrevbakerformat(innhold)
-    includePhrase(Trygdetidstabell(trygdetidsperioder))
-    paragraph {
-        text(
-            Bokmal to "Tabellen viser når avdøde har vært medlem av folketrygden og når avdøde har bodd og/eller arbeidet i land som Norge har trygdeavtale med.",
-            Nynorsk to "",
-            English to "",
-        )
+
+    showIf(trygdetidsperioder.isNotEmpty()) {
+        includePhrase(Trygdetidstabell(trygdetidsperioder))
+        paragraph {
+            text(
+                Bokmal to "Tabellen viser når avdøde har vært medlem av folketrygden og når avdøde har bodd og/eller arbeidet i land som Norge har trygdeavtale med.",
+                Nynorsk to "",
+                English to "",
+            )
+        }
     }
+
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseNyDTO.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseNyDTO.kt
@@ -9,6 +9,7 @@ import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BarnepensjonInnvilgelseNy
 import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BeregningsinfoBP
 import java.time.LocalDate
 import java.time.Month
+import java.time.Period
 
 fun createBarnepensjonInnvilgelseNyDTO() =
     BarnepensjonInnvilgelseNyDTO(
@@ -60,7 +61,7 @@ fun createBarnepensjonInnvilgelseNyDTO() =
                     datoFOM = LocalDate.of(2020, Month.JANUARY, 1),
                     datoTOM = LocalDate.of(2023, Month.JULY, 31),
                     land = "Albania",
-                    opptjeningsperiode = "3y 0m",
+                    opptjeningsperiode = Period.of(3, 0, 0),
                 )
             )
         )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseNyDTO.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelseNyDTO.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.etterlatte.fixtures
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import no.nav.pensjon.etterlatte.maler.Beregningsperiode
 import no.nav.pensjon.etterlatte.maler.EtterbetalingDTO
+import no.nav.pensjon.etterlatte.maler.Periode
 import no.nav.pensjon.etterlatte.maler.Trygdetidsperiode
 import no.nav.pensjon.etterlatte.maler.Utbetalingsinfo
 import no.nav.pensjon.etterlatte.maler.barnepensjon.ny.BarnepensjonInnvilgelseNyDTO
@@ -61,7 +62,7 @@ fun createBarnepensjonInnvilgelseNyDTO() =
                     datoFOM = LocalDate.of(2020, Month.JANUARY, 1),
                     datoTOM = LocalDate.of(2023, Month.JULY, 31),
                     land = "Albania",
-                    opptjeningsperiode = Period.of(3, 0, 0),
+                    opptjeningsperiode = Periode(3, 0, 0),
                 )
             )
         )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSInnvilgelseFoerstegangsvedtak.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSInnvilgelseFoerstegangsvedtak.kt
@@ -94,7 +94,7 @@ fun createOMSInnvilgelseFoerstegangsvedtakDTO() =
                     datoFOM = LocalDate.now(),
                     datoTOM = LocalDate.now(),
                     land = "Norge",
-                    opptjeningsperiode = Period.of(3, 0, 0)
+                    opptjeningsperiode = Periode(3, 0, 0)
                 )
             )
         ),

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSInnvilgelseFoerstegangsvedtak.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSInnvilgelseFoerstegangsvedtak.kt
@@ -2,9 +2,9 @@ package no.nav.pensjon.etterlatte.fixtures
 
 import no.nav.pensjon.brevbaker.api.model.*
 import no.nav.pensjon.etterlatte.maler.*
-import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.OMSInnvilgelseDTO
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.foerstegangsvedtak.OMSInnvilgelseFoerstegangsvedtakDTO
 import java.time.LocalDate
+import java.time.Period
 
 fun createOMSInnvilgelseFoerstegangsvedtakDTO() =
     OMSInnvilgelseFoerstegangsvedtakDTO(
@@ -94,7 +94,7 @@ fun createOMSInnvilgelseFoerstegangsvedtakDTO() =
                     datoFOM = LocalDate.now(),
                     datoTOM = LocalDate.now(),
                     land = "Norge",
-                    opptjeningsperiode = "3 år?"
+                    opptjeningsperiode = Period.of(3, 0, 0)
                 )
             )
         ),

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSRevurdering.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OMSRevurdering.kt
@@ -67,7 +67,7 @@ fun createOMSRevurderingEndringDTO() =
                     datoFOM = LocalDate.now(),
                     datoTOM = LocalDate.now(),
                     land = "Norge",
-                    opptjeningsperiode = "3 år?"
+                    opptjeningsperiode = null
                 )
             )
         ),


### PR DESCRIPTION
Rydder også opp i periode: Vi kan ikke sende en allerede mappet tekst på norsk for å angi et intervall med år, måneder og dager