### PR TITLE
Legg inn nynorskomsetjinga av førehandsvarselet

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverk.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverk.kt
@@ -38,7 +38,7 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
         title {
             text(
                 Language.Bokmal to "Utkast til vedtak - endring av barnepensjon",
-                Language.Nynorsk to "",
+                Language.Nynorsk to "Utkast til vedtak – endring av barnepensjon",
                 Language.English to "Draft decision – adjustment of children's pension",
             )
         }
@@ -48,7 +48,9 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
                     Language.Bokmal to "Stortinget har vedtatt nye regler for barnepensjon. Du får høyere barnepensjon. Du har ".expr()
                             + utbetaltFoerReform.format() + " kroner per måned i pensjon til 31. desember 2023. Du får " + utbetaltEtterReform.format()
                             + " kroner før skatt per måned fra 1. januar 2024.",
-                    Language.Nynorsk to "".expr(),
+                    Language.Nynorsk to "Stortinget har vedteke nye reglar for barnepensjon. Du får høgare barnepensjon. Du har ".expr() +
+                             utbetaltFoerReform.format() + " kroner per månad i pensjon fram til 31. desember 2023. Du får " + utbetaltEtterReform.format() +
+                            " kroner før skatt per månad frå og med 1. januar 2024.",
                     Language.English to "The Norwegian Parliament has adopted new rules for children's pensions. ".expr() +
                             "Your children's pension will now increase. " +
                             "You will receive pension payments amounting to " + utbetaltFoerReform.format() + " kroner per month until 31 December 2023. " +
@@ -58,7 +60,7 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
             paragraph {
                 text(
                     Language.Bokmal to "Vedtaket er gjort etter lov 18. desember 2020 nr. 139 om endringer i folketrygdloven del II nr. 4, jf. Folketrygdloven § 18-4 og § 18-5.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Vedtaket er gjort etter lov 18. desember 2020 nr. 139 om endringar i folketrygdlova del II nr. 4, jf. folketrygdlova § 18-4 og § 18-5.",
                     Language.English to "The decision was made pursuant to Act #139 of 18 December 2020 concerning Amendments to the National Insurance Act, Part II #4; cf. sections 18-4 and 18-5 of the National Insurance Act."
                 )
             }
@@ -66,7 +68,7 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
             title2 {
                 text(
                     Language.Bokmal to "Hva betyr de nye reglene for deg?",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Kva betyr dei nye reglane for deg?",
                     Language.English to "What do the new rules mean to you?"
                 )
             }
@@ -76,14 +78,14 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
                     item {
                         text(
                             Language.Bokmal to "Barnepensjonen din øker.",
-                            Language.Nynorsk to "",
+                            Language.Nynorsk to "Barnepensjonen din aukar.",
                             Language.English to "Your children's pension will increase."
                         )
                     }
                     item {
                         text(
                             Language.Bokmal to "Du får barnepensjon til du blir 20 år.",
-                            Language.Nynorsk to "",
+                            Language.Nynorsk to "Du får barnepensjon til du fyller 20 år.",
                             Language.English to "You will receive a children's pension until you turn 20."
                         )
                     }
@@ -93,7 +95,7 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
             title2 {
                 text(
                     Language.Bokmal to "Slik har vi beregnet pensjonen din",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Slik har vi rekna ut pensjonen din",
                     Language.English to "This is how we calculated your pension"
                 )
             }
@@ -102,7 +104,9 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
                     Language.Bokmal to "Barnepensjonen din blir lik en ganger folketrygdens grunnbeløp per år. Grunnbeløpet i januar 2024 er ".expr() +
                             grunnbeloep.format() + " kroner. Dette deles på 12 måneder. Du vil derfor få " +
                             utbetaltEtterReform.format() + " kroner per måned før skatt fra 1. januar 2024.",
-                    Language.Nynorsk to "".expr(),
+                    Language.Nynorsk to "Barnepensjonen din blir lik éin gong grunnbeløpet i folketrygda per år. Grunnbeløpet i januar 2024 er ".expr() +
+                            grunnbeloep.format() + " kroner. Dette blir fordelt på 12 månader. Du får såleis " +
+                            utbetaltEtterReform.format() + " kroner per månad før skatt frå og med 1. januar 2024.",
                     Language.English to "Your children's pension will equal one times the National Insurance basic amount (G) per year. ".expr() +
                             "The basic amount in January 2024 is " + grunnbeloep.format() + " kroner. " +
                             "This is divided by 12 months. You will therefore receive NOK <kronebeløp> per month (pre-tax) starting 1 January 2024."
@@ -112,7 +116,7 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
             paragraph {
                 textExpr(
                     Language.Bokmal to "For å få full pensjon må avdødes trygdetid være beregnet til minst 40 år. Trygdetiden tilsvarer det antall år avdøde har vært medlem i folketrygden etter fylte 16 år. Når avdøde var under 67 år ved dødsfallet blir det beregnet framtidig trygdetid. Det er vanligvis fram til og med det året avdøde ville ha fylt 66 år. Barnepensjonen din er beregnet med ".expr() + anvendtTrygdetid.format() + " år trygdetid.",
-                    Language.Nynorsk to "".expr(),
+                    Language.Nynorsk to "For å få full pensjon må den utrekna trygdetida til avdøde vere minst 40 år. Trygdetida svarer til talet på år avdøde var medlem i folketrygda etter fylte 16 år. Dersom personen døydde før fylte 67 år, blir det rekna ut framtidig trygdetid. Det er vanlegvis fram til og med det året avdøde ville ha fylt 66 år. Barnepensjonen din er rekna ut med ".expr() +anvendtTrygdetid.format() + " år trygdetid.".expr(),
                     Language.English to "To be entitled to a full pension, the deceased must have accumulated at least 40 years of national insurance coverage. The period of national insurance coverage equals the number of years the deceased has been a member of the Norwegian National Insurance Scheme after reaching the age of 16. If the deceased was less than 67 years old at the time of death, a calculation is made for what would have remained of the future period of national insurance coverage. This is usually calculated up to the year in which the deceased would have turned 66. Your children's pension is calculated based on a period of national insurance coverage of ".expr() + anvendtTrygdetid.format() + " years."
                 )
             }
@@ -120,14 +124,14 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
             title2 {
                 text(
                     Language.Bokmal to "Skattetrekk på barnepensjon",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Skattetrekk på barnepensjon",
                     Language.English to "Tax deductions on children's pensions"
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Barnepensjon er skattepliktig, men vi trekker ikke skatt uten at du gir beskjed om det. Du kan lese mer om skatt på barnepensjon på ${Constants.SKATTETREKK_PENGESTOETTE_URL}. Her finner du også informasjon om frivillig skattetrekk og hvordan du får registrert dette.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Barnepensjon er skattepliktig, men vi trekkjer ikkje skatt utan at du gir beskjed om det. Du kan lese meir om skatt på barnepensjon på ${Constants.SKATTETREKK_PENGESTOETTE_URL}. Her finn du også informasjon om frivillig skattetrekk og korleis du får registrert dette.",
                     Language.English to "Children's pensions are taxable, but we do not deduct tax without being notified. You can read more about the taxation of children's pensions online: ${Constants.SKATTETREKK_PENGESTOETTE_URL}. Here you will also find information about voluntary tax withholding and how to register this."
                 )
             }
@@ -135,14 +139,14 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
             title2 {
                 text(
                     Language.Bokmal to "Du har rett til å klage",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Du har rett til å klage",
                     Language.English to "You have the right to appeal"
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Hvis du mener vedtaket er feil, kan du klage innen seks uker fra 1. januar 2024. Klagen skal være skriftlig. Du finner skjema og informasjon på ${Constants.KLAGE_URL}.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Dersom du meiner at vedtaket er feil, kan du klage innan seks veker frå 1. januar 2024. Klaga må vere skriftleg. Du finn skjema og informasjon på ${Constants.KLAGE_URL}.",
                     Language.English to "If you believe the decision is incorrect, you can appeal within six weeks after 1 January 2024. The appeal must be in writing. You can find the form and information online: ${Constants.Engelsk.KLAGE_URL}."
                 )
             }
@@ -150,14 +154,14 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
             title2 {
                 text(
                     Language.Bokmal to "Du må melde fra om endringer",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Du må melde frå om endringar",
                     Language.English to "You must report any changes"
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Du har plikt til å melde fra til oss om endringer som har betydning for utbetalingen av barnepensjon, eller retten til å få barnepensjon. I vedlegget «Dine rettigheter og plikter» ser du hvilke endringer du må si fra om.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Du pliktar å melde frå til oss om endringar som har innverknad på utbetalinga av eller retten på barnepensjon. I vedlegget «Dine rettar og plikter» ser du kva endringar du må seie frå om.",
                     Language.English to "You are obligated to notify us of any changes that affect the payment of a children's pension, or the right to receive a children's pension. You will see which changes you must report in the attachment, Your Rights and Obligations."
                 )
             }
@@ -165,14 +169,14 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
             title2 {
                 text(
                     Language.Bokmal to "Har du spørsmål?",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Har du spørsmål?",
                     Language.English to "Any questions?"
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Du finner mer informasjon på ${Constants.BARNEPENSJON_URL}. Hvis du ikke finner svar på spørsmålet ditt, kan du ringe oss på telefon ${Constants.KONTAKTTELEFON_PENSJON} hverdager 9-15. Om du oppgir fødselsnummer til barnet, kan vi lettere gi deg rask og god hjelp.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Les meir på ${Constants.BARNEPENSJON_URL}. Dersom du ikkje finn svar på spørsmålet ditt der, kan du ringje oss på telefon ${Constants.KONTAKTTELEFON_PENSJON}, kvardagar 9–15. Det vil gjere det enklare for oss å gi deg rask og god hjelp om du oppgir fødselsnummeret til barnet.",
                     Language.English to "For more information, visit us online: ${Constants.Engelsk.BARNEPENSJON_URL}. If you cannot find the answer to your question, you can call us by phone (${Constants.KONTAKTTELEFON_PENSJON}) weekdays 9-15. If you provide your child's national identity number, we can more easily provide you with quick and good help."
                 )
             }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/ForhaandsvarselOmregningBP.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/ForhaandsvarselOmregningBP.kt
@@ -30,7 +30,7 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
         title {
             text(
                 Language.Bokmal to "Forhåndsvarsel om økt barnepensjon",
-                Language.Nynorsk to "",
+                Language.Nynorsk to "Førehandsvarsel om auka barnepensjon",
                 Language.English to "Advance notice of increase in children's pension",
             )
         }
@@ -38,21 +38,21 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
             paragraph {
                 text(
                     Language.Bokmal to "Dette er et forhåndsvarsel om at NAV vil fatte nytt vedtak om barnepensjon fordi Stortinget har vedtatt nye regler for barnepensjon. De nye reglene gjelder fra 1. januar 2024.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Dette er eit førehandsvarsel om at NAV vil fatte eit nytt vedtak om barnepensjon fordi Stortinget har vedteke nye reglar for barnepensjon. Dei nye reglane gjeld frå og med 1. januar 2024.",
                     Language.English to "This is an advance notice that NAV will be considering adjustments to the children's pensions because the Storting has adopted new rules for this type of pension. The new rules will apply from 1 January 2024."
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Du kan se nytt månedsbeløp i vedlegget “Utkast til vedtak- endring av barnepensjon”.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Du kan sjå det nye månadsbeløpet i vedlegget «Utkast til vedtak – endring av barnepensjon».",
                     Language.English to "The new monthly amount will appear in the attachment, Draft decision – adjustment of children's pension."
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Du trenger ikke å gi beskjed til NAV om du ønsker høyere barnepensjon. Det nye beløpet får du fra januar 2024.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Du treng ikkje å gi beskjed til NAV om at du ønskjer høgare barnepensjon. Du får det nye beløpet frå og med januar 2024.",
                     Language.English to "You do not need to notify NAV if you want a higher children's pension. The new amount will be available starting in January 2024."
                 )
             }
@@ -60,28 +60,28 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
             title2 {
                 text(
                     Language.Bokmal to "Hva betyr dette forhåndsvarselet?",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Kva betyr dette førehandsvarselet?",
                     Language.English to "What does this advance notice mean?"
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Vi forhåndsvarsler deg slik at du kan sjekke om beregningen av pensjonen din er korrekt. Dette er en foreløpig beregning som NAV har gjort på bakgrunn av opplysningene vi allerede har om barnepensjonen din.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Vi varslar deg på førehand slik at du kan sjekke at utrekninga av barnepensjonen din stemmer. Dette er ei førebels utrekning som NAV har gjort på bakgrunn av opplysningane som allereie er lagra om barnepensjonen din.",
                     Language.English to "We are notifying all children's pension recipients in advance so you can check whether the calculation of your pension is correct. This is a preliminary calculation that NAV has made based on the information we already have about your children's pension."
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Beregningen av barnepensjonen din trer i kraft som et vedtak fra fire uker fra du mottar dette forhåndsvarselet. I løpet av denne perioden kan du gi oss nye opplysninger slik at vi kan rette opp eventuelle feil i beregningen.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Utrekninga av barnepensjonen din trer i kraft som vedtak fire veker frå du får dette førehandsvarselet. I løpet av denne perioden kan du gi oss nye opplysningar slik at vi kan rette opp eventuelle feil i utrekninga.",
                     Language.English to "The calculation of your children's pension will take effect four weeks after you receive this advance notice. During this period, feel free to provide us with any new information so we can correct any errors in our calculation."
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Du kan se hvordan vi har beregnet ny barnepensjon i vedlegget “Utkast til vedtak – endring av barnepensjon”.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Du kan sjå i vedlegget «Utkast til vedtak – endring av barnepensjon» korleis vi har rekna ut den nye barnepensjonen.",
                     Language.English to "You can see how we have calculated the new children's pension in the attachment, Draft decision – adjustment of children's pension."
                 )
             }
@@ -89,14 +89,14 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
             title2 {
                 text(
                     Language.Bokmal to "Frister for å sende inn nye opplysninger og klage",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Fristar for å sende inn nye opplysningar og klage",
                     Language.English to "Deadlines for submitting new information and appeals"
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Hvis opplysningene ikke stemmer, må du gi beskjed til NAV innen fire uker fra du får dette forhåndsvarselet. Hvis opplysningene gjør at NAV må beregne barnepensjonen din på nytt, får du et nytt vedtak.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Dersom opplysningane ikkje stemmer, må du gi beskjed til NAV innan fire veker frå du får dette førehandsvarselet. Du vil få eit nytt vedtak dersom opplysningane gjer det nødvendig for NAV å rekne ut barnepensjonen din på nytt.",
                     Language.English to "If the information is incorrect, you must notify NAV within four weeks of receiving this advance notice. If the information means that NAV has to recalculate your children's pension, you will receive a new decision."
                 )
             }
@@ -104,7 +104,7 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
             paragraph {
                 text(
                     Language.Bokmal to "Hvis du ikke har nye opplysninger eller innsigelser til “Utkast til vedtak – endring av barnepensjon” som er vedlagt, vil vedlegget anses som et vedtak fra 1. januar 2024. Du vil altså ikke få et nytt vedtak fordi utkastet da er omgjort til “Vedtak - endring av barnepensjon”.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Dersom du ikkje har nye opplysningar eller innvendingar mot «Utkast til vedtak – endring av barnepensjon» som er lagt ved, vil vedlegget bli rekna som vedtak frå og med 1. januar 2024. Du vil med andre ikkje få eit nytt vedtak, fordi utkastet då har blitt gjort om til «Vedtak – endring av barnepensjon».",
                     Language.English to "If you have no new information or objections to the information provided in the Draft Decision, the decision will be deemed valid as of 1 January 2024. In other words, you will not receive a new decision because the draft decision will be converted to a formal decision and then entitled Decision – adjustment of children's pension."
                 )
             }
@@ -112,7 +112,7 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
             paragraph {
                 text(
                     Language.Bokmal to "Etter at vedtaket har tredd i kraft (altså 1. januar 2024) har du seks ukers klagefrist på vedtaket. Du finner informasjon om hvordan du klager i “Utkast til vedtak – endring av barnepensjon”.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Etter at vedtaket har tredd i kraft (altså 1. januar 2024), har du seks vekers klagefrist. Sjå «Utkast til vedtak – endring av barnepensjon» for meir informasjon om korleis du går fram for å klage.",
                     Language.English to "After the decision has entered into force (i.e. 1 January 2024), you have six weeks to appeal the decision. You can find information on how to appeal in the attachment, Draft decision – adjustment of children's pension."
                 )
             }
@@ -120,7 +120,7 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
             title2 {
                 text(
                     Language.Bokmal to "Døde din forelder av yrkesskade eller yrkessykdom?",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Døydde forelderen din av yrkesskade eller yrkessjukdom?",
                     Language.English to "Did your parent die of an occupational injury or illness?"
                 )
             }
@@ -128,7 +128,7 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
             paragraph {
                 text(
                     Language.Bokmal to "Hvis forelderen din døde av yrkesskade eller yrkessykdom, kan det ha betydning for barnepensjonen din. Da må du ta kontakt med NAV slik at vi er sikre på at vi har beregnet barnepensjonen din riktig.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Dersom forelderen din døydde av yrkesskade eller yrkessjukdom, kan det ha betydning for barnepensjonen din. Kontakt i dette tilfellet NAV, slik at vi er sikre på at vi har rekna ut barnepensjonen din rett.",
                     Language.English to "If your parent died of an occupational injury or illness, this may affect your children's pension. You must then contact NAV so we can be sure that we calculate your children's pension correctly."
                 )
             }
@@ -136,14 +136,14 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
             title2 {
                 text(
                     Language.Bokmal to "Har du spørsmål?",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Har du spørsmål?",
                     Language.English to "Any questions?"
                 )
             }
             paragraph {
                 text(
                     Language.Bokmal to "Du finner mer informasjon på ${Constants.BARNEPENSJON_URL}. Hvis du ikke finner svar på spørsmålet ditt, kan du ringe oss på telefon ${Constants.KONTAKTTELEFON_PENSJON} hverdager 9-15.",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Les meir på ${Constants.BARNEPENSJON_URL}. Dersom du ikkje finn svar på spørsmålet ditt der, kan du ringje oss på telefon ${Constants.KONTAKTTELEFON_PENSJON}, kvardagar 9–15. ",
                     Language.English to "For more information, visit us online: ${Constants.Engelsk.BARNEPENSJON_URL}. If you cannot find the answer to your question, you can call us by phone (${Constants.KONTAKTTELEFON_PENSJON}) weekdays 9-15."
                 )
             }
@@ -152,7 +152,7 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
             title2 {
                 text(
                     Language.Bokmal to "Vedlegg",
-                    Language.Nynorsk to "",
+                    Language.Nynorsk to "Vedlegg",
                     Language.English to "Attachment"
                 )
             }
@@ -161,8 +161,8 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
                     item {
                         text(
                             Language.Bokmal to "Utkast til vedtak - endring av barnepensjon",
-                            Language.Nynorsk to "",
-                            Language.English to ""
+                            Language.Nynorsk to "Utkast til vedtak – endring av barnepensjon",
+                            Language.English to "Draft decision – adjustment of children's pension"
                         )
                     }
                 }


### PR DESCRIPTION
Direkte lagt inn frå malen: https://confluence.adeo.no/display/TE/Brevmaler+-+Nytt+regelverk+%28NBP%29+Barnepensjon

Sjølve omsetjinga kjem frå kommunikasjonsavdelinga, PR-en her går på at det er lagt inn på rett plass