### PR TITLE
Fjerner vedlegg fra tom mal informasjonsbrev

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/andre/TomMalInformasjonsbrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/andre/TomMalInformasjonsbrev.kt
@@ -14,7 +14,6 @@ import no.nav.pensjon.etterlatte.EtterlatteTemplate
 import no.nav.pensjon.etterlatte.maler.ManueltBrevMedTittelDTO
 import no.nav.pensjon.etterlatte.maler.ManueltBrevMedTittelDTOSelectors.innhold
 import no.nav.pensjon.etterlatte.maler.ManueltBrevMedTittelDTOSelectors.tittel
-import no.nav.pensjon.etterlatte.maler.fraser.common.OMSFelles
 import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
 
 @TemplateModelHelpers
@@ -46,9 +45,6 @@ object TomMalInformasjonsbrev : EtterlatteTemplate<ManueltBrevMedTittelDTO> {
 
         outline {
             konverterElementerTilBrevbakerformat(innhold)
-
-            includePhrase(OMSFelles.DuHarRettTilInnsyn)
-            includePhrase(OMSFelles.HarDuSpoersmaal)
         }
     }
 }


### PR DESCRIPTION
De skal ikke alltid være med og da får saksbehandler klippe de inn

(+ varianter med saktype og utland er pain 😬 )