### PR TITLE
Foreldreløs forhåndsvarsel + migreringsbrev

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/BarnepensjonOmregnetNyttRegelverkDTO.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/BarnepensjonOmregnetNyttRegelverkDTO.kt
@@ -1,9 +1,9 @@
 package no.nav.pensjon.etterlatte.maler.barnepensjon.migrering
 
 import no.nav.pensjon.brevbaker.api.model.Kroner
-import no.nav.pensjon.etterlatte.maler.IntBroek
 import no.nav.pensjon.etterlatte.maler.BrevDTO
 import no.nav.pensjon.etterlatte.maler.Element
+import no.nav.pensjon.etterlatte.maler.IntBroek
 
 data class BarnepensjonOmregnetNyttRegelverkDTO(
     val utbetaltFoerReform: Kroner,
@@ -12,7 +12,8 @@ data class BarnepensjonOmregnetNyttRegelverkDTO(
     val anvendtTrygdetid: Int,
     val prorataBroek: IntBroek?,
     val erBosattUtlandet: Boolean,
-    val erYrkesskade: Boolean
+    val erYrkesskade: Boolean,
+    val erForeldreloes: Boolean
 )
 
 data class BarnepensjonOmregnetNyttRegelverkFerdigDTO(

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverk.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverk.kt
@@ -18,6 +18,7 @@ import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.EtterlatteTemplate
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkDTOSelectors.anvendtTrygdetid
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkDTOSelectors.erBosattUtlandet
+import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkDTOSelectors.erForeldreloes
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkDTOSelectors.erYrkesskade
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkDTOSelectors.grunnbeloep
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkDTOSelectors.prorataBroek
@@ -86,12 +87,22 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
 
             paragraph {
                 list {
-                    item {
-                        text(
-                            Language.Bokmal to "Barnepensjonen din øker.",
-                            Language.Nynorsk to "Barnepensjonen din aukar.",
-                            Language.English to "Your children's pension will increase."
-                        )
+                    showIf(erForeldreloes) {
+                        item {
+                            text(
+                                Language.Bokmal to "Barnepensjonen din øker.",
+                                Language.Nynorsk to "Barnepensjonen din aukar.",
+                                Language.English to "Your children's pension will increase."
+                            )
+                        }
+                    } orShow {
+                        item {
+                            text(
+                                Language.Bokmal to "Barnepensjonen din øker dersom nye regler gir best beregning.",
+                                Language.Nynorsk to "",
+                                Language.English to ""
+                            )
+                        }
                     }
                     item {
                         showIf(erYrkesskade) {
@@ -108,12 +119,14 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
                             )
                         }
                     }
-                    item {
-                        text(
-                            Language.Bokmal to "Barnepensjonen blir ikke justert som følge av søsken.",
-                            Language.Nynorsk to "Det er ikkje lenger søskenjustering i barnepensjonen.",
-                            Language.English to "Children’s pensions are no longer subject to the sibling adjustment."
-                        )
+                    showIf(erForeldreloes.not()) {
+                        item {
+                            text(
+                                Language.Bokmal to "Barnepensjonen blir ikke justert som følge av søsken.",
+                                Language.Nynorsk to "Det er ikkje lenger søskenjustering i barnepensjonen.",
+                                Language.English to "Children’s pensions are no longer subject to the sibling adjustment."
+                            )
+                        }
                     }
                 }
             }
@@ -125,16 +138,59 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
                     Language.English to "This is how we calculated your pension"
                 )
             }
-            paragraph {
-                textExpr(
-                    Language.Bokmal to "Barnepensjonen din blir lik en ganger folketrygdens grunnbeløp per år. Grunnbeløpet i januar 2024 er ".expr() +
-                            grunnbeloep.format() + " kroner. Dette deles på 12 måneder. ",
-                    Language.Nynorsk to "Barnepensjonen din blir lik éin gong grunnbeløpet i folketrygda per år. Grunnbeløpet i januar 2024 er ".expr() +
-                            grunnbeloep.format() + " kroner. Dette blir fordelt på 12 månader.",
-                    Language.English to "Your children's pension will equal one times the National Insurance basic amount (G) per year. ".expr() +
-                            "The basic amount in January 2024 is " + grunnbeloep.format() + " kroner. " +
-                            "This is divided by 12 months."
-                )
+            showIf(erForeldreloes) {
+                paragraph {
+                    textExpr(
+                        Language.Bokmal to "Når begge foreldrene dine er døde, blir den årlige pensjonen etter nytt regelverk lik 2,25 ganger grunnbeløpet. Grunnbeløpet i januar 2024 er ".expr() +
+                                grunnbeloep.format() + " kroner. Dette deles på 12 måneder. I noen tilfeller vil beregning av barnepensjon etter " +
+                                "dagens regelverk gi høyere utbetaling av pensjon 2,25 ganger grunnbeløpet. Du får det som gir høyest beløp.",
+                        Language.Nynorsk to "".expr(),
+                        Language.English to "".expr()
+                    )
+                }
+
+                paragraph {
+                    text(
+                        Language.Bokmal to "<Gammelt regelverk - beste beregning>",
+                        Language.Nynorsk to "<Gammelt regelverk - beste beregning>",
+                        Language.English to "<Gammelt regelverk - beste beregning>"
+                    )
+                }
+                paragraph {
+                    text(
+                        Language.Bokmal to "Vi har kontrollert barnepensjonen din. Du får høyere pensjon med gammelt regelverk. Pensjonen din er derfor ikke endret fra 1. januar 2024.",
+                        Language.Nynorsk to "",
+                        Language.English to ""
+                    )
+                }
+
+                paragraph {
+                    text(
+                        Language.Bokmal to "<Nytt regelverk - beste beregning>",
+                        Language.Nynorsk to "<Nytt regelverk - beste beregning>",
+                        Language.English to "<Nytt regelverk - beste beregning>"
+                    )
+                }
+                paragraph {
+                    text(
+                        Language.Bokmal to "Vi har kontrollert barnepensjonen din. Du får høyere pensjon med nytt regelverk. Pensjonen din er derfor økt fra 1. januar 2024.",
+                        Language.Nynorsk to "",
+                        Language.English to ""
+                    )
+                }
+
+            } orShow {
+                paragraph {
+                    textExpr(
+                        Language.Bokmal to "Barnepensjonen din blir lik en ganger folketrygdens grunnbeløp per år. Grunnbeløpet i januar 2024 er ".expr() +
+                                grunnbeloep.format() + " kroner. Dette deles på 12 måneder. ",
+                        Language.Nynorsk to "Barnepensjonen din blir lik éin gong grunnbeløpet i folketrygda per år. Grunnbeløpet i januar 2024 er ".expr() +
+                                grunnbeloep.format() + " kroner. Dette blir fordelt på 12 månader.",
+                        Language.English to "Your children's pension will equal one times the National Insurance basic amount (G) per year. ".expr() +
+                                "The basic amount in January 2024 is " + grunnbeloep.format() + " kroner. " +
+                                "This is divided by 12 months."
+                    )
+                }
             }
 
             showIf(prorataBroek.notNull()) {

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverk.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverk.kt
@@ -90,17 +90,17 @@ object EnkeltVedtakOmregningNyttRegelverk : EtterlatteTemplate<BarnepensjonOmreg
                     showIf(erForeldreloes) {
                         item {
                             text(
-                                Language.Bokmal to "Barnepensjonen din øker.",
-                                Language.Nynorsk to "Barnepensjonen din aukar.",
-                                Language.English to "Your children's pension will increase."
+                                Language.Bokmal to "Barnepensjonen din øker dersom nye regler gir best beregning.",
+                                Language.Nynorsk to "",
+                                Language.English to ""
                             )
                         }
                     } orShow {
                         item {
                             text(
-                                Language.Bokmal to "Barnepensjonen din øker dersom nye regler gir best beregning.",
-                                Language.Nynorsk to "",
-                                Language.English to ""
+                                Language.Bokmal to "Barnepensjonen din øker.",
+                                Language.Nynorsk to "Barnepensjonen din aukar.",
+                                Language.English to "Your children's pension will increase."
                             )
                         }
                     }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/ForhaandsvarselOmregningBP.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/ForhaandsvarselOmregningBP.kt
@@ -70,13 +70,13 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
                         Language.English to "The new monthly amount will appear in the attachment, Draft decision – adjustment of children's pension."
                     )
                 }
-            }
-            paragraph {
-                text(
-                    Language.Bokmal to "Du trenger ikke å gi beskjed til NAV om du ønsker høyere barnepensjon. Det nye beløpet får du fra januar 2024.",
-                    Language.Nynorsk to "Du treng ikkje å gi beskjed til NAV om at du ønskjer høgare barnepensjon. Du får det nye beløpet frå og med januar 2024.",
-                    Language.English to "You do not need to notify NAV if you want a higher children's pension. The new amount will be available starting in January 2024."
-                )
+                paragraph {
+                    text(
+                        Language.Bokmal to "Du trenger ikke å gi beskjed til NAV om du ønsker høyere barnepensjon. Det nye beløpet får du fra januar 2024.",
+                        Language.Nynorsk to "Du treng ikkje å gi beskjed til NAV om at du ønskjer høgare barnepensjon. Du får det nye beløpet frå og med januar 2024.",
+                        Language.English to "You do not need to notify NAV if you want a higher children's pension. The new amount will be available starting in January 2024."
+                    )
+                }
             }
 
             title2 {

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/ForhaandsvarselOmregningBP.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/ForhaandsvarselOmregningBP.kt
@@ -10,6 +10,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.EtterlatteTemplate
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkDTOSelectors.erBosattUtlandet
+import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkDTOSelectors.erForeldreloes
 import no.nav.pensjon.etterlatte.maler.fraser.common.Constants
 import no.nav.pensjon.etterlatte.maler.fraser.common.kontakttelefonPensjon
 
@@ -29,12 +30,21 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
 
         )
     ) {
+
         title {
-            text(
-                Language.Bokmal to "Forhåndsvarsel om økt barnepensjon",
-                Language.Nynorsk to "Førehandsvarsel om auka barnepensjon",
-                Language.English to "Advance notice of increase in children's pension",
-            )
+            showIf(erForeldreloes) {
+                text(
+                    Language.Bokmal to "Forhåndsvarsel om mulig endring av barnepensjon",
+                    Language.Nynorsk to "Førehandsvarsel om mulig endring av barnepensjon",
+                    Language.English to "Advance notice of possible change in children's pension",
+                )
+            } orShow {
+                text(
+                    Language.Bokmal to "Forhåndsvarsel om økt barnepensjon",
+                    Language.Nynorsk to "Førehandsvarsel om auka barnepensjon",
+                    Language.English to "Advance notice of increase in children's pension",
+                )
+            }
         }
         outline {
             paragraph {
@@ -44,12 +54,22 @@ object ForhaandsvarselOmregningBP : EtterlatteTemplate<BarnepensjonOmregnetNyttR
                     Language.English to "This is an advance notice that NAV will be considering adjustments to the children's pensions because the Storting has adopted new rules for this type of pension. The new rules will apply from 1 January 2024."
                 )
             }
-            paragraph {
-                text(
-                    Language.Bokmal to "Du kan se nytt månedsbeløp i vedlegget “Utkast til vedtak – endring av barnepensjon”.",
-                    Language.Nynorsk to "Du kan sjå det nye månadsbeløpet i vedlegget «Utkast til vedtak – endring av barnepensjon».",
-                    Language.English to "The new monthly amount will appear in the attachment, Draft decision – adjustment of children's pension."
-                )
+            showIf(erForeldreloes) {
+                paragraph {
+                    text(
+                        Language.Bokmal to "Beregningen av barnepensjon til foreldreløse barn er annerledes fra 1. januar 2024. Det vil vurderes om pensjonen din vil bli høyere med nytt regelverk enn det du har i dag. Du vil få det som gir høyest utbetaling hver måned. Du trenger ikke å gi beskjed til NAV om hvilken beregning du ønsker.",
+                        Language.Nynorsk to "",
+                        Language.English to ""
+                    )
+                }
+            } orShow {
+                paragraph {
+                    text(
+                        Language.Bokmal to "Du kan se nytt månedsbeløp i vedlegget “Utkast til vedtak – endring av barnepensjon”.",
+                        Language.Nynorsk to "Du kan sjå det nye månadsbeløpet i vedlegget «Utkast til vedtak – endring av barnepensjon».",
+                        Language.English to "The new monthly amount will appear in the attachment, Draft decision – adjustment of children's pension."
+                    )
+                }
             }
             paragraph {
                 text(

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
@@ -7,7 +7,6 @@ import no.nav.pensjon.brev.template.Language
 import no.nav.pensjon.brev.template.LocalizedFormatter
 import no.nav.pensjon.brev.template.OutlinePhrase
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
-import no.nav.pensjon.brev.template.dsl.expression.format
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.dsl.textExpr
 import no.nav.pensjon.etterlatte.maler.Periode

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmregnetBPNyttRegelverkDto.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmregnetBPNyttRegelverkDto.kt
@@ -16,7 +16,8 @@ fun createBarnepensjonOmregnetNyttRegelverkDTO() =
         grunnbeloep = Kroner(400000),
         prorataBroek = IntBroek(43, 156),
         erBosattUtlandet = true,
-        erYrkesskade = false
+        erYrkesskade = false,
+        erForeldreloes = false
     )
 
 fun createBarnepensjonOmregnetNyttRegelverkFerdigDTO() =
@@ -59,7 +60,7 @@ fun createBarnepensjonOmregnetNyttRegelverkFerdigDTO() =
                         )
                     )
                 )
-            ),
+            )
         ),
         data = BarnepensjonOmregnetNyttRegelverkDTO(
             utbetaltFoerReform = Kroner(1337),
@@ -68,6 +69,7 @@ fun createBarnepensjonOmregnetNyttRegelverkFerdigDTO() =
             grunnbeloep = Kroner(400000),
             prorataBroek = IntBroek(43, 156),
             erBosattUtlandet = true,
-            erYrkesskade = false
+            erYrkesskade = false,
+            erForeldreloes = false
         )
     )


### PR DESCRIPTION
Hvis foreldreløs inneholder vedtaksbrevet tekster som skal slettes i endelig vedtak. Forhåndsvarselet trenger ikke å redigeres av saksbehandler