### PR TITLE
spec.accessPolicy.outbound.external[0].host in body should match '^([…

### DIFF
--- a/tjenestebuss-integrasjon/.nais/dev-q2.yaml
+++ b/tjenestebuss-integrasjon/.nais/dev-q2.yaml
@@ -19,6 +19,6 @@ inboundRules:
     cluster: dev-gcp
 
 externalHosts:
-  - host: https://tjenestebuss-q2.adeo.no
-  - host: https://security-token-service.dev.adeo.no
-  - host: https://dokprod-q2.dev.intern.nav.no/dokprod
+  - host: tjenestebuss-q2.adeo.no
+  - host: security-token-service.dev.adeo.no
+  - host: dokprod-q2.dev.intern.nav.no


### PR DESCRIPTION
…a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]

dette er en dns greie hvor man limer inn hosts eller subdomener, http og ekstra paths er ikke en del av konseptet