### PR TITLE
allowAllUsers in dev for brevbaker for now

### DIFF
--- a/pensjon-brevbaker/.nais/dev.yaml
+++ b/pensjon-brevbaker/.nais/dev.yaml
@@ -1,3 +1,4 @@
+allowAllUsers: true
 app-name: "pensjon-brevbaker"
 pdf-bygger-app: "pensjon-pdf-bygger"
 ingresses:

--- a/pensjon-brevbaker/.nais/nais.yaml
+++ b/pensjon-brevbaker/.nais/nais.yaml
@@ -40,6 +40,7 @@ spec:
   azure:
     application:
       enabled: true
+      allowAllUsers: {{allowAllUsers}}
       claims:
         extra:
           - azp_name

--- a/pensjon-brevbaker/.nais/prod.yaml
+++ b/pensjon-brevbaker/.nais/prod.yaml
@@ -1,3 +1,4 @@
+allowAllUsers: false
 app-name: "pensjon-brevbaker"
 pdf-bygger-app: "pensjon-pdf-bygger"
 ingresses:


### PR DESCRIPTION
Inntil vi har oppsett på AD-gruppe hadde det vært nice å tillate allUsers for brevbaker i dev. Så jeg slipper dispatche den på ny hver gang noe deployes 🙏 