### PR TITLE
Setter max pool size til 4 for å unngå å bruke opp alle connections

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/Database.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/Database.kt
@@ -26,6 +26,7 @@ fun initDatabase(config: Config) {
             jdbcUrl = createJdbcUrl(dbConfig)
             username = dbConfig.getString("username")
             password = dbConfig.getString("password")
+            maximumPoolSize = 4
             validate()
         }),
     )


### PR DESCRIPTION
Setter max pool size til 4 for å unngå å bruke opp alle connections ved deployment hvor det er 4 aktive pods. Det kan gå inntil 6 connections til diverse nais admin greier. Da vil vi bruke 21/25 connections under deployment, og det er greit å ha noen reserve i tilfelle noen er koblet til databasen. 8 Connections spredd på to instanser bør være nokk til å serve saksbehandlere. Ellers må vi se på å velge en større postgres instans.