### PR TITLE
Bugfix lag tomme env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker compose up -d --build
    * python
    * vault
    * gcloud cli
-   * kjørende docker/colima (docker compose v2, ikke "docker-compose")
+   * kjørende docker/colima
    * naisdevice med standard dev-miljø tilganger og tjenestebuss-q2 gruppe-tilgang
 2. Hent alle secrets:
    ```bash

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker compose up -d --build
    * python
    * vault
    * gcloud cli
-   * kjørende docker/colima
+   * kjørende docker/colima (docker compose v2, ikke "docker-compose")
    * naisdevice med standard dev-miljø tilganger og tjenestebuss-q2 gruppe-tilgang
 2. Hent alle secrets:
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 #Used for local testing purposes
+version: '3.8'
 services:
   pdf-bygger:
     build: ./pdf-bygger
@@ -33,8 +34,7 @@ services:
       - "8082:8080"
       - "5017:5007"
     env_file:
-      - path: ./skribenten-backend/secrets/azuread.env
-        optional: true
+      - ./skribenten-backend/secrets/azuread.env
     environment:
       - BREVBAKER_SCOPE=api://dev-gcp.pensjonsbrev.pensjon-brevbaker/.default
       - BREVBAKER_URL=http://pensjon-brevbaker:8080
@@ -81,8 +81,7 @@ services:
       - "8086:8080"
       - "5018:5008"
     env_file:
-      - path: tjenestebuss-integrasjon/secrets/docker.env
-        optional: true
+      - tjenestebuss-integrasjon/secrets/docker.env
     environment:
       - TJENESTEBUSS_URL=https://tjenestebuss-q2.adeo.no/
       - STS_URL=https://security-token-service.dev.adeo.no
@@ -100,8 +99,7 @@ services:
       - "8083:8083"
     restart: on-failure
     env_file:
-      - path: skribenten-web/bff/.env
-        optional: true
+      - skribenten-web/bff/.env
     environment:
       - WONDERWALL_AUTO_LOGIN=true
       - WONDERWALL_OPENID_PROVIDER=azure
@@ -118,8 +116,7 @@ services:
     secrets:
       - npmrc
     env_file:
-      - path: skribenten-web/bff/.env
-        optional: true
+      - skribenten-web/bff/.env
     ports:
       - "8084:8084"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 #Used for local testing purposes
-version: '3.8'
 services:
   pdf-bygger:
     build: ./pdf-bygger
@@ -34,7 +33,8 @@ services:
       - "8082:8080"
       - "5017:5007"
     env_file:
-      - ./skribenten-backend/secrets/azuread.env
+      - path: ./skribenten-backend/secrets/azuread.env
+        optional: true
     environment:
       - BREVBAKER_SCOPE=api://dev-gcp.pensjonsbrev.pensjon-brevbaker/.default
       - BREVBAKER_URL=http://pensjon-brevbaker:8080
@@ -81,7 +81,8 @@ services:
       - "8086:8080"
       - "5018:5008"
     env_file:
-      - tjenestebuss-integrasjon/secrets/docker.env
+      - path: tjenestebuss-integrasjon/secrets/docker.env
+        optional: true
     environment:
       - TJENESTEBUSS_URL=https://tjenestebuss-q2.adeo.no/
       - STS_URL=https://security-token-service.dev.adeo.no
@@ -99,7 +100,8 @@ services:
       - "8083:8083"
     restart: on-failure
     env_file:
-      - skribenten-web/bff/.env
+      - path: skribenten-web/bff/.env
+        optional: true
     environment:
       - WONDERWALL_AUTO_LOGIN=true
       - WONDERWALL_OPENID_PROVIDER=azure
@@ -116,7 +118,8 @@ services:
     secrets:
       - npmrc
     env_file:
-      - skribenten-web/bff/.env
+      - path: skribenten-web/bff/.env
+        optional: true
     ports:
       - "8084:8084"
     environment:


### PR DESCRIPTION
Legger til tomme env files slik at docker-compose ikke feiler når du prøver å kjøre brevbaker/pdf-bygger. Dette skjer fordi docker påkrever alle env-files selv om skribenten-profilen ikke er valgt.