### PR TITLE
Punktlister konverteres nå riktig når dem er på et format som kan endres på i Gjenny

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/ElementTilBrevbakerkonvertering.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/ElementTilBrevbakerkonvertering.kt
@@ -46,10 +46,11 @@ fun <D : BrevDTO> OutlineOnlyScope<LangBokmalNynorskEnglish, D>.konverterElement
         }.orShowIf(element.type.equalTo(ElementType.PARAGRAPH)) {
             paragraph {
                 forEach(element.children) { inner ->
+                    // TODO vi har muligens lagret ned brev med dette formatet allerede så må støtte det videre
                     showIf(inner.type.equalTo(ElementType.BULLETED_LIST)) {
                         list {
                             ifNotNull(inner.children) { i ->
-                                lagPunktliste(i)
+                                lagPunktlisteGammeltFormat(i)
                             }
                         }
                     }.orShow {
@@ -73,7 +74,7 @@ fun <D : BrevDTO> OutlineOnlyScope<LangBokmalNynorskEnglish, D>.konverterElement
     }
 }
 
-private fun <D : BrevDTO> ListScope<LangBokmalNynorskEnglish, D>.lagPunktliste(
+private fun <D : BrevDTO> ListScope<LangBokmalNynorskEnglish, D>.lagPunktlisteGammeltFormat(
     items: Expression<List<InnerElement>>
 ) {
     forEach(items) { listItem ->
@@ -84,6 +85,26 @@ private fun <D : BrevDTO> ListScope<LangBokmalNynorskEnglish, D>.lagPunktliste(
                     Nynorsk to text,
                     English to text,
                 )
+            }
+        }
+    }
+}
+
+private fun <D : BrevDTO> ListScope<LangBokmalNynorskEnglish, D>.lagPunktliste(
+    items: Expression<List<InnerElement>>
+) {
+    forEach(items) { listItem ->
+        item {
+            ifNotNull(listItem.children) { children ->
+                forEach(children) { paragraph ->
+                    ifNotNull(paragraph.text) { text ->
+                        textExpr(
+                            Bokmal to text,
+                            Nynorsk to text,
+                            English to text,
+                        )
+                    }
+                }
             }
         }
     }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadInnvilgelse.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadInnvilgelse.kt
@@ -14,7 +14,7 @@ fun createOmstillingsstoenadInnvilgelseDTO() =
                 type = ElementType.HEADING_TWO,
                 children = listOf(
                     InnerElement(
-                        text = "Innhold fra utfall"
+                        text = "Begrunnelse for vedtaket"
                     )
                 )
             ),
@@ -22,10 +22,63 @@ fun createOmstillingsstoenadInnvilgelseDTO() =
                 type = ElementType.PARAGRAPH,
                 children = listOf(
                     InnerElement(
-                        text = "Her kommer det valgfri tekst om innvilget vedtak"
+                        text = "Omstillingsstønad gis på bakgrunn av at"
+                    )
+                )
+            ),
+            Element(
+                type = ElementType.BULLETED_LIST,
+                children = listOf(
+                    InnerElement(
+                        type = ElementType.LIST_ITEM,
+                        children = listOf(
+                            InnerElement(
+                                type = ElementType.PARAGRAPH,
+                                text = "du som gjenlevende ektefelle på dødsfallstidspunktet hadde vært gift " +
+                                        "med avdøde i minst fem år, har eller har hatt barn med avdøde, eller har " +
+                                        "omsorgen for barn under 18 år med minst halvparten av full tid"
+                            )
+                        ),
+                    ),
+                    InnerElement(
+                        type = ElementType.LIST_ITEM,
+                        children = listOf(
+                            InnerElement(
+                                type = ElementType.PARAGRAPH,
+                                text = "du er medlem i folketrygden"
+                            )
+                        ),
+                    ),
+                    InnerElement(
+                        type = ElementType.LIST_ITEM,
+                        children = listOf(
+                            InnerElement(
+                                type = ElementType.PARAGRAPH,
+                                text = "avdøde i de siste fem årene før dødsfallet var medlem i folketrygden, " +
+                                        "eller fikk pensjon eller uføretrygd fra folketrygden."
+                            )
+                        ),
+                    )
+                )
+            ),
+            Element(
+                type = ElementType.PARAGRAPH,
+                children = listOf(
+                    InnerElement(
+                        text = "Samboere med felles barn og samboere som tidligere har vært gift likestilles med ektefeller."
+                    )
+                )
+            ),
+            Element(
+                type = ElementType.PARAGRAPH,
+                children = listOf(
+                    InnerElement(
+                        text = "Vedtaket er gjort etter bestemmelsene om omstillingsstønad i folketrygdloven " +
+                                "§ 17-2, § 17-3, § 17-4, § 17-5, § 17-6, § 17-9, § 22-12 og § 22-13."
                     )
                 )
             )
+
         ),
         avdoed = Avdoed(
             navn = "Avdoed Avdoedesen",


### PR DESCRIPTION
Tidligere la vi lister på innsiden av paragrafer når vi konverterte til Slate, men det fungerer ikke ved redigering av lister. 