### PR TITLE
Fjerner duplikat avsnitt og legger til manglende ord

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/DineRettigheterOgPlikter.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/DineRettigheterOgPlikter.kt
@@ -114,14 +114,7 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, A
                     English to "",
                 )
             }
-                    }
-        text(
-            Bokmal to "Du er ansvarlig for å holde deg orientert om bevegelser på kontoen for utbetaling av " +
-                    "omstillingsstønad og du må straks melde fra om du oppdager feil. Hvis du ikke melder fra om " +
-                    "endringer og får utbetalt for mye stønad, kan stønad som er utbetalt feil kreves tilbake.",
-            Nynorsk to "",
-            English to "",
-        )
+        }
     }
 }
 
@@ -166,17 +159,21 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, A
     title2 {
         text(
             Bokmal to "Veiledning fra NAV - forvaltningsloven § 11",
-            Nynorsk to "",
-            English to "",
+            Nynorsk to "Rettleiing frå NAV – forvaltingslova § 11",
+            English to "Guidance from NAV – Section 11 of the Public Administration Act",
         )
     }
     paragraph {
         text(
-            Bokmal to "Vi har plikt til å veilede deg om dine rettigheter og plikter i saken din, " +
-                    "både før, under og etter saksbehandlingen. Dersom du har spørsmål eller er usikker på noe, " +
-                    "vil vi gjøre vårt beste for å hjelpe deg.",
-            Nynorsk to "",
-            English to "",
+            Bokmal to "Vi har plikt til å veilede deg om dine rettigheter og plikter i saken din, både før, " +
+                    "under og etter saksbehandlingen. Dersom du har spørsmål eller er usikker på noe, vil vi gjøre " +
+                    "vårt beste for å hjelpe deg.",
+            Nynorsk to "Vi pliktar å rettleie deg om rettane og pliktene du har i saka, både før, " +
+                    "under og etter saksbehandlinga. Dersom du har spørsmål eller er usikker på noko, " +
+                    "vil vi gjere vårt beste for å hjelpe deg.",
+            English to "We have a duty to advise you of your rights and obligations in your case – before, " +
+                    "during and after the case has been processed. " +
+                    "If you have any questions or are unsure about anything, we will do our best to help you.",
         )
     }
 }
@@ -185,16 +182,19 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, A
     title2 {
         text(
             Bokmal to "Du har rett til innsyn i saken din - forvaltningsloven § 18 ",
-            Nynorsk to "",
-            English to "",
+            Nynorsk to "Du har rett til innsyn i saka di – forvaltingslova § 18",
+            English to "You have the right to access the documents in your case – Section 18 of the " +
+                    "Public Administration Act",
         )
     }
     paragraph {
         text(
             Bokmal to "Du har som hovedregel rett til å se dokumentene i saken din. Hvis du ønsker innsyn, " +
-                    "så du kontakte oss på telefon eller per post.",
-            Nynorsk to "",
-            English to "",
+                    "kan du kontakte oss på telefon eller per post.",
+            Nynorsk to "Du har som hovudregel rett til å sjå dokumenta i saka di. Kontakt oss på telefon " +
+                    "eller per post dersom du ønskjer innsyn.",
+            English to "As a general rule, you have the right to see the documents in your case. If " +
+                    "you want access, you can contact us by phone or mail.",
         )
     }
 }


### PR DESCRIPTION
- Fjerner avsnitt som er duplikat. Dette lå på bunn av punktlista i barnepensjon, men har fått egen overskrift for OMS.
- Fikser manglende ord i avsnitt om innsyn.
- Legger også til oversettelser der vi har det. Mangler fortsatt et par avsnitt for å ha nynorsk og engelsk på plass.