### PR TITLE
Klargjør typer for revurdering av omstillingsstønad

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -91,19 +91,3 @@ data class Avdoed(
     val navn: String,
     val doedsdato: LocalDate,
 )
-
-@Deprecated("Denne utgår når vi får ryddet opp i omstillingsstønad revurdering")
-data class NyBeregningsperiode(
-    val inntekt: Kroner,
-    val trygdetid: Int,
-    val stoenadFoerReduksjon: Kroner,
-    var utbetaltBeloep: Kroner,
-)
-
-@Deprecated("Denne utgår når vi får ryddet opp i omstillingsstønad revurdering")
-data class Beregningsinfo(
-    override val innhold: List<Element>,
-    val grunnbeloep: Kroner,
-    val beregningsperioder: List<NyBeregningsperiode>,
-    val trygdetidsperioder: List<Trygdetidsperiode>,
-) : BrevDTO

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/revurdering/OmstillingsstoenadRevurdering.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/revurdering/OmstillingsstoenadRevurdering.kt
@@ -10,7 +10,6 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.EtterlatteTemplate
-import no.nav.pensjon.etterlatte.maler.Beregningsinfo
 import no.nav.pensjon.etterlatte.maler.BrevDTO
 import no.nav.pensjon.etterlatte.maler.Element
 import no.nav.pensjon.etterlatte.maler.Hovedmal
@@ -20,21 +19,19 @@ import no.nav.pensjon.etterlatte.maler.fraser.common.Vedtak
 import no.nav.pensjon.etterlatte.maler.fraser.omstillingsstoenad.OmstillingsstoenadFellesFraser
 import no.nav.pensjon.etterlatte.maler.fraser.omstillingsstoenad.OmstillingsstoenadInnvilgelseFraser
 import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
+import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.revurdering.OmstillingsstoenadRevurderingDTOSelectors.beregning
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.revurdering.OmstillingsstoenadRevurderingDTOSelectors.erEndret
-import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.revurdering.OmstillingsstoenadRevurderingDTOSelectors.etterbetalinginfo
+import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.revurdering.OmstillingsstoenadRevurderingDTOSelectors.etterbetaling
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.revurdering.OmstillingsstoenadRevurderingDTOSelectors.innhold
-import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.revurdering.OmstillingsstoenadRevurderingDTOSelectors.omstillingsstoenadBeregning
 import no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad.beregningAvOmstillingsstoenad
 import no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad.dineRettigheterOgPlikter
 import no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad.etterbetalingOmstillingsstoenad
 import no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad.informasjonOmOmstillingsstoenad
-import no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad.informasjonOmYrkesskade
 
 data class OmstillingsstoenadRevurderingDTO(
     override val innhold: List<Element>,
-    val omstillingsstoenadBeregning: OmstillingsstoenadBeregning,
-    val etterbetalinginfo: OmstillingsstoenadEtterbetaling? = null,
-    val beregningsinfo: Beregningsinfo,
+    val beregning: OmstillingsstoenadBeregning,
+    val etterbetaling: OmstillingsstoenadEtterbetaling?,
     val erEndret: Boolean
 ): BrevDTO
 
@@ -91,10 +88,10 @@ object OmstillingsstoenadRevurdering : EtterlatteTemplate<OmstillingsstoenadRevu
             includePhrase(OmstillingsstoenadFellesFraser.HarDuSpoersmaal)
         }
 
-        includeAttachment(beregningAvOmstillingsstoenad, omstillingsstoenadBeregning)
+        includeAttachment(beregningAvOmstillingsstoenad, beregning)
+        includeAttachmentIfNotNull(etterbetalingOmstillingsstoenad, etterbetaling)
         includeAttachment(informasjonOmOmstillingsstoenad, innhold)
         includeAttachment(dineRettigheterOgPlikter, innhold)
-        includeAttachment(informasjonOmYrkesskade, innhold)
-        includeAttachmentIfNotNull(etterbetalingOmstillingsstoenad, etterbetalinginfo)
+        // includeAttachment(informasjonOmYrkesskade, innhold) TODO denne skal vel ikke være med her uten noen conditions?
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadRevurdering.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadRevurdering.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 fun createOmstillingsstoenadRevurderingDTO() =
     OmstillingsstoenadRevurderingDTO(
-        omstillingsstoenadBeregning = OmstillingsstoenadBeregning(
+        beregning = OmstillingsstoenadBeregning(
             innhold = emptyList(),
             grunnbeloep = Kroner(118000),
             inntekt = Kroner(550000),
@@ -56,47 +56,9 @@ fun createOmstillingsstoenadRevurderingDTO() =
                 mindreEnnFireFemtedelerAvOpptjeningstiden = true,
             )
         ),
-        etterbetalinginfo = OmstillingsstoenadEtterbetaling(
+        etterbetaling = OmstillingsstoenadEtterbetaling(
             fraDato = LocalDate.now(),
             tilDato = LocalDate.now()
-        ),
-        beregningsinfo = Beregningsinfo(
-            grunnbeloep = Kroner(118000),
-            innhold = listOf(
-                Element(
-                    type = ElementType.HEADING_TWO,
-                    children = listOf(
-                        InnerElement(
-                            text = "<INSERT UTFALL HERE>"
-                        )
-                    )
-                ),
-                Element(
-                    type = ElementType.PARAGRAPH,
-                    children = listOf(
-                        InnerElement(
-                            text = "Her kommer det valgfri tekst om utfallene til beregning av stønaden"
-                        )
-                    )
-                )
-            ),
-            beregningsperioder = listOf(
-                NyBeregningsperiode(
-                    inntekt = Kroner(650000),
-                    trygdetid = 123,
-                    stoenadFoerReduksjon = Kroner(9000),
-                    utbetaltBeloep = Kroner(1234)
-                )
-            ),
-            trygdetidsperioder = listOf(
-                Trygdetidsperiode(
-                    datoFOM = LocalDate.now(),
-                    datoTOM = LocalDate.now(),
-                    land = "Norge",
-                    opptjeningsperiode = null,
-                    type = TrygdetidType.FAKTISK
-                )
-            )
         ),
         innhold = listOf(
             Element(


### PR DESCRIPTION
Fjerner noen deprecated'e typer fra brevet for revurdering av omstillingsstønad. Brevet er forøvrig ikke klart for bruk i produksjon ennå.