### PR TITLE
use traditional load/data/error instead of suspense and error boundaries

### DIFF
--- a/skribenten-web/frontend/src/components/ApiError.tsx
+++ b/skribenten-web/frontend/src/components/ApiError.tsx
@@ -12,7 +12,6 @@ export function ApiError({ error, text }: { error: unknown; text: string }) {
           margin-top: var(--a-spacing-4);
           width: fit-content;
           align-self: center;
-          min-width: 600px;
         `}
         variant="error"
       >


### PR DESCRIPTION
Å bruke Errorboundary og Await komponenten ser fine and dandy ut i dokumentasjonen, men i praksis visste det seg at feilen som blir kastet mister kontekst at det er en axiosError, som gjorde det mer kronglete å vise feilmelding på en logisk måte. Reverter derfor det eksperimentet