### PR TITLE
Endre engelsk tittel til caseworker for saksbehandler

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/render/LanguageSettings.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/render/LanguageSettings.kt
@@ -98,7 +98,7 @@ val pensjonLatexSettings = languageSettings {
         text(
             Bokmal to "Saksbehandler",
             Nynorsk to "Saksbehandlar",
-            English to "Assessor",
+            English to "Caseworker",
         )
     }
     setting(LanguageSetting.Closing.automatiskInformasjonsbrev) {


### PR DESCRIPTION
Ref denne [EY-3543](https://jira.adeo.no/browse/EY-3543), så har vi nå fått klarsignal at engelsk oversettelse for "saksbehandler" skal endres fra "Assesor" til "Caseworker"