### PR TITLE
Fjern paragraf 18 klage anke

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/avslag/BarnepensjonAvslag.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/avslag/BarnepensjonAvslag.kt
@@ -19,8 +19,7 @@ import no.nav.pensjon.etterlatte.maler.barnepensjon.avslag.BarnepensjonAvslagDTO
 import no.nav.pensjon.etterlatte.maler.barnepensjon.avslag.BarnepensjonAvslagDTOSelectors.innhold
 import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.BarnepensjonFellesFraser
 import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
-import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnkeUtland
-import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnkeNasjonal
+import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnke
 
 data class BarnepensjonAvslagDTO(
     override val innhold: List<Element>,
@@ -59,9 +58,9 @@ object BarnepensjonAvslag : EtterlatteTemplate<BarnepensjonAvslagDTO>, Hovedmal 
         }
 
         // Nasjonal
-        includeAttachment(klageOgAnkeNasjonal, innhold, bosattUtland.not())
+        includeAttachment(klageOgAnke(bosattUtland = false), innhold, bosattUtland.not())
 
         // Bosatt utland
-        includeAttachment(klageOgAnkeUtland, innhold, bosattUtland)
+        includeAttachment(klageOgAnke(bosattUtland = true), innhold, bosattUtland)
     }
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/opphoer/BarnepensjonOpphoer.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/opphoer/BarnepensjonOpphoer.kt
@@ -29,8 +29,7 @@ import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.BarnepensjonFellesFra
 import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.BarnepensjonRevurderingFraser
 import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
 import no.nav.pensjon.etterlatte.maler.vedlegg.barnepensjon.forhaandsvarselFeilutbetalingBarnepensjonOpphoer
-import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnkeNasjonal
-import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnkeUtland
+import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnke
 import java.time.LocalDate
 
 data class BarnepensjonOpphoerDTO(
@@ -81,10 +80,10 @@ object BarnepensjonOpphoer : EtterlatteTemplate<BarnepensjonOpphoerDTO>, Hovedma
         }
 
         // Nasjonal
-        includeAttachment(klageOgAnkeNasjonal, innhold, bosattUtland.not())
+        includeAttachment(klageOgAnke(bosattUtland = false), innhold, bosattUtland.not())
 
         // Bosatt utland
-        includeAttachment(klageOgAnkeUtland, innhold, bosattUtland)
+        includeAttachment(klageOgAnke(bosattUtland = true), innhold, bosattUtland)
 
         includeAttachment(forhaandsvarselFeilutbetalingBarnepensjonOpphoer, this.argument, feilutbetaling.equalTo(FeilutbetalingType.FEILUTBETALING_MED_VARSEL))
     }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/klage/AvvistKlageFerdigstilling.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/klage/AvvistKlageFerdigstilling.kt
@@ -20,7 +20,7 @@ import no.nav.pensjon.etterlatte.maler.klage.AvvistKlageFerdigDTOSelectors.data
 import no.nav.pensjon.etterlatte.maler.klage.AvvistKlageFerdigDTOSelectors.innhold
 import no.nav.pensjon.etterlatte.maler.klage.AvvistKlageInnholdDTOSelectors.sakType
 import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
-import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnkeUtland
+import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnke
 
 
 data class AvvistKlageFerdigDTO(
@@ -65,6 +65,6 @@ object AvvistKlageFerdigstilling : EtterlatteTemplate<AvvistKlageFerdigDTO>, Hov
             }
         }
         // Vet ikke hva utlandstilknytning er. Går for bosatt utland for nå
-        includeAttachment(klageOgAnkeUtland, innhold)
+        includeAttachment(klageOgAnke(bosattUtland = true), innhold)
     }
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/avslag/OmstillingsstoenadAvslag.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/avslag/OmstillingsstoenadAvslag.kt
@@ -19,8 +19,7 @@ import no.nav.pensjon.etterlatte.maler.fraser.omstillingsstoenad.Omstillingsstoe
 import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.avslag.OmstillingstoenadAvslagDTOSelectors.bosattUtland
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.avslag.OmstillingstoenadAvslagDTOSelectors.innhold
-import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnkeNasjonal
-import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnkeUtland
+import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnke
 
 
 data class OmstillingstoenadAvslagDTO(
@@ -62,9 +61,9 @@ object OmstillingsstoenadAvslag : EtterlatteTemplate<OmstillingstoenadAvslagDTO>
         }
 
         // Nasjonal
-        includeAttachment(klageOgAnkeNasjonal, innhold, bosattUtland.not())
+        includeAttachment(klageOgAnke(bosattUtland = false), innhold, bosattUtland.not())
 
         // Bosatt utland
-        includeAttachment(klageOgAnkeUtland, innhold, bosattUtland)
+        includeAttachment(klageOgAnke(bosattUtland = true), innhold, bosattUtland)
     }
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/opphoer/OmstillingsstoenadOpphoer.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/opphoer/OmstillingsstoenadOpphoer.kt
@@ -20,7 +20,6 @@ import no.nav.pensjon.etterlatte.maler.BrevDTO
 import no.nav.pensjon.etterlatte.maler.Element
 import no.nav.pensjon.etterlatte.maler.FeilutbetalingType
 import no.nav.pensjon.etterlatte.maler.Hovedmal
-import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.BarnepensjonRevurderingFraser
 import no.nav.pensjon.etterlatte.maler.fraser.omstillingsstoenad.OmstillingsstoenadFellesFraser
 import no.nav.pensjon.etterlatte.maler.fraser.omstillingsstoenad.OmstillingsstoenadRevurderingFraser
 import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
@@ -28,9 +27,7 @@ import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.opphoer.Omstillingssto
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.opphoer.OmstillingsstoenadOpphoerDTOSelectors.feilutbetaling
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.opphoer.OmstillingsstoenadOpphoerDTOSelectors.innhold
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.opphoer.OmstillingsstoenadOpphoerDTOSelectors.virkningsdato
-import no.nav.pensjon.etterlatte.maler.vedlegg.barnepensjon.forhaandsvarselFeilutbetalingBarnepensjonOpphoer
-import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnkeNasjonal
-import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnkeUtland
+import no.nav.pensjon.etterlatte.maler.vedlegg.klageOgAnke
 import no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad.forhaandsvarselFeilutbetalingOmstillingsstoenadOpphoer
 import java.time.LocalDate
 
@@ -83,10 +80,10 @@ object OmstillingsstoenadOpphoer : EtterlatteTemplate<OmstillingsstoenadOpphoerD
         }
 
         // Nasjonal
-        includeAttachment(klageOgAnkeNasjonal, innhold, bosattUtland.not())
+        includeAttachment(klageOgAnke(bosattUtland = false), innhold, bosattUtland.not())
 
         // Bosatt utland
-        includeAttachment(klageOgAnkeUtland, innhold, bosattUtland)
+        includeAttachment(klageOgAnke(bosattUtland = true), innhold, bosattUtland)
 
         includeAttachment(forhaandsvarselFeilutbetalingOmstillingsstoenadOpphoer, this.argument, feilutbetaling.equalTo(FeilutbetalingType.FEILUTBETALING_MED_VARSEL))
     }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFerdig.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFerdig.kt
@@ -69,6 +69,7 @@ data class TilbakekrevingBeloeper(
 	val nettoTilbakekreving: Kroner,
 	val fradragSkatt: Kroner,
 	val renteTillegg: Kroner,
+	val sumNettoRenter: Kroner
 )
 
 @TemplateModelHelpers

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
@@ -111,8 +111,8 @@ object TilbakekrevingFraser {
 	): OutlinePhrase<LangBokmalNynorskEnglish>() {
 		override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
 			val feilutbetaling = tilbakekreving.summer.feilutbetaling
-			val nettoTilbakekreving = tilbakekreving.summer.nettoTilbakekreving
 			val renteTillegg = tilbakekreving.summer.renteTillegg
+			val sumTilbakekreving = renteTillegg.plus(tilbakekreving.summer.nettoTilbakekreving)
 			val fraOgMed = tilbakekreving.fraOgMed
 			val tilOgMed = tilbakekreving.tilOgMed
 
@@ -139,17 +139,23 @@ object TilbakekrevingFraser {
 					English to "Vi har kommet frem til at du skal betale tilbake ".expr() +
 							ifElse(tilbakekreving.helTilbakekreving, "hele", "deler av") + " beløpet.",
 				)
-				showIf(tilbakekreving.summer.renteTillegg.greaterThan(0)) {
+				showIf(renteTillegg.greaterThan(0)) {
 					textExpr(
 						Bokmal to " Du må også betale ".expr() + renteTillegg.format() +
-								" kroner i renter. Til sammen skal du betale " + nettoTilbakekreving.format() +
+								" kroner i renter. Til sammen skal du betale " + sumTilbakekreving.format() +
 								" kroner etter at skatten er trukket fra.",
 						Nynorsk to " Du må også betale ".expr() + renteTillegg.format() +
-								" kroner i renter. Til sammen skal du betale " + nettoTilbakekreving.format() +
+								" kroner i renter. Til sammen skal du betale " + sumTilbakekreving.format() +
 								" kroner etter at skatten er trukket fra.",
 						English to " Du må også betale ".expr() + renteTillegg.format() +
-								" kroner i renter. Til sammen skal du betale " + nettoTilbakekreving.format() +
+								" kroner i renter. Til sammen skal du betale " + sumTilbakekreving.format() +
 								" kroner etter at skatten er trukket fra.",
+					)
+				}.orShow {
+					textExpr(
+						Bokmal to " Det blir ".expr() + sumTilbakekreving.format() + " kroner.",
+						Nynorsk to "".expr(),
+						English to "".expr(),
 					)
 				}
 			}
@@ -164,8 +170,8 @@ object TilbakekrevingFraser {
 	): OutlinePhrase<LangBokmalNynorskEnglish>() {
 		override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
 			val feilutbetaling = tilbakekreving.summer.feilutbetaling
-			val nettoTilbakekreving = tilbakekreving.summer.nettoTilbakekreving
 			val renteTillegg = tilbakekreving.summer.renteTillegg
+			val sumTilbakekreving = renteTillegg.plus(tilbakekreving.summer.nettoTilbakekreving)
 			val fraOgMed = tilbakekreving.fraOgMed
 			val tilOgMed = tilbakekreving.tilOgMed
 
@@ -186,17 +192,17 @@ object TilbakekrevingFraser {
 					Nynorsk to "".expr(),
 					English to "".expr()
 				)
-				showIf(tilbakekreving.summer.renteTillegg.greaterThan(0)) {
+				showIf(renteTillegg.greaterThan(0)) {
 					textExpr(
 						Bokmal to " Boet må også betale ".expr() + renteTillegg.format() +
-								" kroner i renter. Til sammen skal boet betale " + nettoTilbakekreving.format() +
+								" kroner i renter. Til sammen skal boet betale " + sumTilbakekreving.format() +
 								" kroner etter at skatten er trukket fra.",
 						Nynorsk to "".expr(),
 						English to "".expr()
 					)
 				}.orShow {
 					textExpr(
-						Bokmal to " Det blir ".expr() + nettoTilbakekreving.format() + " kroner.",
+						Bokmal to " Det blir ".expr() + sumTilbakekreving.format() + " kroner.",
 						Nynorsk to "".expr(),
 						English to "".expr()
 					)

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
@@ -1,6 +1,5 @@
 package no.nav.pensjon.etterlatte.maler.tilbakekreving
 
-
 import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Text.FontType
@@ -25,6 +24,7 @@ import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingBeloeperSele
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingBeloeperSelectors.fradragSkatt
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingBeloeperSelectors.nettoTilbakekreving
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingBeloeperSelectors.renteTillegg
+import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingBeloeperSelectors.sumNettoRenter
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingDTOSelectors.fraOgMed
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingDTOSelectors.helTilbakekreving
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingDTOSelectors.summer
@@ -65,9 +65,9 @@ object TilbakekrevingFraser {
 				}
 				ifNotNull(datoTilsvarBruker) { datoTilsvarBruker ->
 					textExpr(
-						Bokmal to ", og dine kommentarer til dette som vi mottok den".expr() + datoTilsvarBruker.format(),
-						Nynorsk to ", og dine kommentarer til dette som vi mottok den".expr() + datoTilsvarBruker.format(),
-						English to ", og dine kommentarer til dette som vi mottok den".expr() + datoTilsvarBruker.format(),
+						Bokmal to ", og dine kommentarer til dette som vi mottok den ".expr() + datoTilsvarBruker.format(),
+						Nynorsk to ", og dine kommentarer til dette som vi mottok den ".expr() + datoTilsvarBruker.format(),
+						English to ", og dine kommentarer til dette som vi mottok den ".expr() + datoTilsvarBruker.format(),
 					)
 				}
 				text(
@@ -113,7 +113,7 @@ object TilbakekrevingFraser {
 		override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
 			val feilutbetaling = tilbakekreving.summer.feilutbetaling
 			val renteTillegg = tilbakekreving.summer.renteTillegg
-			val sumTilbakekreving = renteTillegg.plus(tilbakekreving.summer.nettoTilbakekreving)
+			val sumTilbakekreving = tilbakekreving.summer.sumNettoRenter
 			val fraOgMed = tilbakekreving.fraOgMed
 			val tilOgMed = tilbakekreving.tilOgMed
 
@@ -360,14 +360,14 @@ object TilbakekrevingVedleggFraser {
 			paragraph {
 				table(
 					header = {
-						column(1) {
+						column {
 							text(
 								Bokmal to "Beløp som skal kreves tilbake i hele feilutbetalingsperioden",
 								Nynorsk to "",
 								English to "",
 							)
 						}
-						column(2) {}
+						column {}
 					}
 				) {
 					row {
@@ -428,7 +428,7 @@ object TilbakekrevingVedleggFraser {
 							)
 						}
 						cell {
-							includePhrase(Felles.KronerText(summer.renteTillegg, FontType.BOLD))
+							includePhrase(Felles.KronerText(summer.sumNettoRenter, FontType.BOLD))
 						}
 					}
 				}

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.etterlatte.maler.tilbakekreving
 
 import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.model.format
+import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Text.FontType
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.Language.Bokmal
 import no.nav.pensjon.brev.template.Language.English
@@ -362,8 +363,8 @@ object TilbakekrevingVedleggFraser {
 						column(1) {
 							text(
 								Bokmal to "Beløp som skal kreves tilbake i hele feilutbetalingsperioden",
-								Nynorsk to "Beløp som skal kreves tilbake i hele feilutbetalingsperioden",
-								English to "Beløp som skal kreves tilbake i hele feilutbetalingsperioden",
+								Nynorsk to "",
+								English to "",
 							)
 						}
 						column(2) {}
@@ -373,8 +374,8 @@ object TilbakekrevingVedleggFraser {
 						cell {
 							text(
 								Bokmal to "Brutto tilbakekreving",
-								Nynorsk to "Brutto tilbakekreving",
-								English to "Brutto tilbakekreving",
+								Nynorsk to "",
+								English to ""
 							)
 						}
 						cell {
@@ -385,8 +386,8 @@ object TilbakekrevingVedleggFraser {
 						cell {
 							text(
 								Bokmal to "- fradrag skatt",
-								Nynorsk to "- fradrag skatt",
-								English to "- fradrag skatt"
+								Nynorsk to "",
+								English to ""
 							)
 						}
 						cell {
@@ -396,9 +397,9 @@ object TilbakekrevingVedleggFraser {
 					row {
 						cell {
 							text(
-								Bokmal to "Netto tilbakekreving",
-								Nynorsk to "Netto tilbakekreving",
-								English to "Netto tilbakekreving",
+								Bokmal to "= Netto tilbakekreving",
+								Nynorsk to "",
+								English to "",
 							)
 						}
 						cell {
@@ -409,12 +410,25 @@ object TilbakekrevingVedleggFraser {
 						cell {
 							text(
 								Bokmal to "+ Rentetillegg",
-								Nynorsk to "+ Rentetillegg",
-								English to "+ Rentetillegg"
+								Nynorsk to "",
+								English to " "
 							)
 						}
 						cell {
 							includePhrase(Felles.KronerText(summer.renteTillegg))
+						}
+					}
+					row {
+						cell {
+							text(
+								Bokmal to "= Sum tilbakekreving",
+								Nynorsk to "",
+								English to "",
+								FontType.BOLD
+							)
+						}
+						cell {
+							includePhrase(Felles.KronerText(summer.renteTillegg, FontType.BOLD))
 						}
 					}
 				}

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/KlageOgAnke.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/KlageOgAnke.kt
@@ -16,39 +16,7 @@ import no.nav.pensjon.etterlatte.maler.fraser.common.Constants
 import no.nav.pensjon.etterlatte.maler.fraser.common.kontakttelefonPensjon
 import no.nav.pensjon.etterlatte.maler.fraser.common.postadresse
 
-@TemplateModelHelpers
-val klageOgAnkeUtland = createAttachment(
-    title = newText(
-        Bokmal to "Informasjon om klage og anke",
-        Nynorsk to "Informasjon om klage og anke",
-        English to "Information on Complaints and Appeals"
-    ),
-    includeSakspart = false,
-) {
-    veiledning()
-    hjelpFraAndre()
-    klagePaaVedtaket()
-    hvordanSendeKlage(true.expr())
-    hvaMaaKlagenInneholde(true.expr())
-    duKanFaaDekketUtgifter()
-}
 
-@TemplateModelHelpers
-val klageOgAnkeNasjonal = createAttachment(
-    title = newText(
-        Bokmal to "Informasjon om klage og anke",
-        Nynorsk to "Informasjon om klage og anke",
-        English to "Information on Complaints and Appeals"
-    ),
-    includeSakspart = false,
-) {
-    veiledning()
-    hjelpFraAndre()
-    klagePaaVedtaket()
-    hvordanSendeKlage(false.expr())
-    hvaMaaKlagenInneholde(false.expr())
-    duKanFaaDekketUtgifter()
-}
 
 fun klageOgAnke(
 	bosattUtland: Boolean,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/KlageOgAnke.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/KlageOgAnke.kt
@@ -63,9 +63,6 @@ fun klageOgAnke(
 		includeSakspart = false,
 	) {
 		veiledning()
-		if (tilbakekreving) {
-			innsynISaken()
-		}
 		hjelpFraAndre()
 		klagePaaVedtaket()
 		hvordanSendeKlage(bosattUtland.expr())
@@ -295,25 +292,6 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, A
                     "If you have any questions or are unsure about anything, we will do our best to help you."
         )
     }
-}
-
-private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, Any>.innsynISaken() {
-	title2 {
-		text(
-			Bokmal to "Innsyn i saken din - forvaltningsloven § 18",
-			Nynorsk to "",
-			English to ""
-		)
-	}
-	paragraph {
-		text(
-			Bokmal to "Med få unntak har du rett til å se dokumentene i saken din. Du kan logge deg inn på " + Constants.DIN_PENSJON_URL +
-					" for å se all kommunikasjon som har vært mellom deg og NAV i saken din. Du kan også ringe oss på telefon " +
-					Constants.KONTAKTTELEFON_PENSJON + ". ",
-			Nynorsk to "",
-			English to Constants.KONTATTELEFON_PENSJON_MED_LANDKODE
-		)
-	}
 }
 
 private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, Any>.tilbakekreving() {

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/Tilbakekreving.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/Tilbakekreving.kt
@@ -5,7 +5,9 @@ import no.nav.pensjon.etterlatte.maler.fraser.common.SakType
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingBeloeper
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingBrevDTO
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingDTO
+import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingPeriode
 import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingRedigerbartBrevDTO
+import no.nav.pensjon.etterlatte.maler.tilbakekreving.TilbakekrevingResultat
 import java.time.LocalDate
 
 fun createTilbakekrevingRedigerbartBrevDTO() =  TilbakekrevingRedigerbartBrevDTO(
@@ -27,7 +29,30 @@ fun createTilbakekrevingFerdigDTO() =
 			tilOgMed = LocalDate.now(),
 			skalTilbakekreve = true,
 			helTilbakekreving = true,
-			perioder = emptyList(),
+			perioder = listOf(
+				TilbakekrevingPeriode(
+					maaned = LocalDate.of(2024, 1, 1),
+					beloeper = TilbakekrevingBeloeper(
+						feilutbetaling = Kroner(50),
+						bruttoTilbakekreving = Kroner(50),
+						nettoTilbakekreving = Kroner(35),
+						fradragSkatt = Kroner(10),
+						renteTillegg = Kroner(5),
+					),
+					resultat = TilbakekrevingResultat.FULL_TILBAKEKREV,
+				),
+				TilbakekrevingPeriode(
+					maaned = LocalDate.of(2024, 2, 1),
+					beloeper = TilbakekrevingBeloeper(
+						feilutbetaling = Kroner(50),
+						bruttoTilbakekreving = Kroner(50),
+						nettoTilbakekreving = Kroner(35),
+						fradragSkatt = Kroner(10),
+						renteTillegg = Kroner(5),
+					),
+					resultat = TilbakekrevingResultat.FULL_TILBAKEKREV,
+				)
+			),
 			summer = TilbakekrevingBeloeper(
 				feilutbetaling = Kroner(100),
 				bruttoTilbakekreving = Kroner(100),

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/Tilbakekreving.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/Tilbakekreving.kt
@@ -38,6 +38,8 @@ fun createTilbakekrevingFerdigDTO() =
 						nettoTilbakekreving = Kroner(35),
 						fradragSkatt = Kroner(10),
 						renteTillegg = Kroner(5),
+						sumNettoRenter = Kroner(40)
+
 					),
 					resultat = TilbakekrevingResultat.FULL_TILBAKEKREV,
 				),
@@ -49,6 +51,7 @@ fun createTilbakekrevingFerdigDTO() =
 						nettoTilbakekreving = Kroner(35),
 						fradragSkatt = Kroner(10),
 						renteTillegg = Kroner(5),
+						sumNettoRenter = Kroner(40)
 					),
 					resultat = TilbakekrevingResultat.FULL_TILBAKEKREV,
 				)
@@ -59,6 +62,7 @@ fun createTilbakekrevingFerdigDTO() =
 				nettoTilbakekreving = Kroner(70),
 				fradragSkatt = Kroner(20),
 				renteTillegg = Kroner(10),
+				sumNettoRenter = Kroner(80)
 			)
 		)
 	)


### PR DESCRIPTION
- Fjerner paragraf 18 fra klage og anke tilbakekreving
- Viser sum av netto og renter i brevtekst ikke bare netto
- Legger til sum tilbakekreving i vedlegg
- Bruker metode for klage og anke alle steder for å slippe dupliserte objekter