### PR TITLE
EY-3748: Viser ikke utbetalingsinformasjon når utbetalingen er 0

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelse.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelse.kt
@@ -23,6 +23,7 @@ import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnv
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.brukerUnder18Aar
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.erGjenoppretting
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.etterbetaling
+import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.harUtbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.innhold
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.kunNyttRegelverk
 import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.BarnepensjonFellesFraser
@@ -44,7 +45,8 @@ data class BarnepensjonInnvilgelseDTO(
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
     val kunNyttRegelverk: Boolean,
-    val erGjenoppretting: Boolean
+    val erGjenoppretting: Boolean,
+    val harUtbetaling: Boolean,
 ) : BrevDTO
 
 @TemplateModelHelpers
@@ -81,7 +83,9 @@ object BarnepensjonInnvilgelse : EtterlatteTemplate<BarnepensjonInnvilgelseDTO>,
         outline {
             konverterElementerTilBrevbakerformat(innhold)
 
-            includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling.notNull()))
+            showIf(harUtbetaling) {
+                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling.notNull()))
+            }
             includePhrase(BarnepensjonFellesFraser.MeldFraOmEndringer)
             includePhrase(BarnepensjonFellesFraser.DuHarRettTilAaKlage)
             includePhrase(BarnepensjonFellesFraser.HarDuSpoersmaal(brukerUnder18Aar, bosattUtland))

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelseForeldreloes.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelseForeldreloes.kt
@@ -6,10 +6,8 @@ import no.nav.pensjon.brev.template.Language.English
 import no.nav.pensjon.brev.template.Language.Nynorsk
 import no.nav.pensjon.brev.template.dsl.createTemplate
 import no.nav.pensjon.brev.template.dsl.expression.and
-import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.expression.not
 import no.nav.pensjon.brev.template.dsl.expression.notNull
-import no.nav.pensjon.brev.template.dsl.expression.plus
 import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
 import no.nav.pensjon.brev.template.dsl.languages
 import no.nav.pensjon.brev.template.dsl.text
@@ -25,13 +23,12 @@ import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.BrevDTO
 import no.nav.pensjon.etterlatte.maler.Element
 import no.nav.pensjon.etterlatte.maler.Hovedmal
-import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.bareEnPeriode
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.beregning
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.bosattUtland
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.brukerUnder18Aar
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.etterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.flerePerioder
-import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.ingenUtbetaling
+import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.harUtbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.innhold
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.kunNyttRegelverk
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.vedtattIPesys
@@ -53,9 +50,8 @@ data class BarnepensjonForeldreloesDTO(
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
     val kunNyttRegelverk: Boolean,
-    val bareEnPeriode: Boolean,
     val flerePerioder: Boolean,
-    val ingenUtbetaling: Boolean,
+    val harUtbetaling: Boolean,
     val vedtattIPesys: Boolean
 ) : BrevDTO
 
@@ -98,16 +94,17 @@ object BarnepensjonInnvilgelseForeldreloes : EtterlatteTemplate<BarnepensjonFore
                     virkningstidspunkt = beregning.virkningsdato,
                     sistePeriodeBeloep = beregning.sisteBeregningsperiode.utbetaltBeloep,
                     sistePeriodeFom = beregning.sisteBeregningsperiode.datoFOM,
-                    bareEnPeriode = bareEnPeriode,
                     flerePerioder = flerePerioder,
-                    ingenUtbetaling = ingenUtbetaling,
+                    harUtbetaling = harUtbetaling,
                     vedtattIPesys = vedtattIPesys
                 )
             )
 
             konverterElementerTilBrevbakerformat(innhold)
 
-            includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling.notNull()))
+            showIf(harUtbetaling) {
+                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling.notNull()))
+            }
             includePhrase(BarnepensjonFellesFraser.HvorLengeKanDuFaaBarnepensjon)
             includePhrase(BarnepensjonFellesFraser.MeldFraOmEndringer)
             includePhrase(BarnepensjonFellesFraser.DuHarRettTilAaKlage)

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonForeldreloesFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonForeldreloesFraser.kt
@@ -9,6 +9,7 @@ import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.expression.format
 import no.nav.pensjon.brev.template.dsl.expression.ifElse
+import no.nav.pensjon.brev.template.dsl.expression.not
 import no.nav.pensjon.brev.template.dsl.expression.plus
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.dsl.textExpr
@@ -21,9 +22,8 @@ object BarnepensjonForeldreloesFraser {
         val virkningstidspunkt: Expression<LocalDate>,
         val sistePeriodeFom: Expression<LocalDate>,
         val sistePeriodeBeloep: Expression<Kroner>,
-        val bareEnPeriode: Expression<Boolean>,
         val flerePerioder: Expression<Boolean>,
-        val ingenUtbetaling: Expression<Boolean>,
+        val harUtbetaling: Expression<Boolean>,
         val vedtattIPesys: Expression<Boolean>,
     ) : OutlinePhrase<LangBokmalNynorskEnglish>() {
         override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
@@ -73,7 +73,7 @@ object BarnepensjonForeldreloesFraser {
                     )
                 }
             }
-            showIf(ingenUtbetaling) {
+            showIf(harUtbetaling.not()) {
                 paragraph {
                     text(
                         Language.Bokmal to "Du får ikke utbetalt barnepensjon fordi den er redusert utfra det du" +

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/omstillingsstoenad/OmstillingsstoenadInnvilgelseFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/omstillingsstoenad/OmstillingsstoenadInnvilgelseFraser.kt
@@ -33,6 +33,7 @@ object OmstillingsstoenadInnvilgelseFraser {
     data class Vedtak(
         val avdoed: Expression<Avdoed>,
         val omstillingsstoenadBeregning: Expression<OmstillingsstoenadBeregning>,
+        val harUtbetaling: Expression<Boolean>
     ) :
         OutlinePhrase<LangBokmalNynorskEnglish>() {
         override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
@@ -52,7 +53,7 @@ object OmstillingsstoenadInnvilgelseFraser {
                 )
             }
 
-            showIf(utbetaltBeloep.greaterThan(0)) {
+            showIf(harUtbetaling) {
                 showIf(harFlerePerioder) {
                     val datoFomSisteBeregningsperiode = omstillingsstoenadBeregning.sisteBeregningsperiode.datoFOM
 

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/innvilgelse/OmstillingsstoenadInnvilgelse.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/innvilgelse/OmstillingsstoenadInnvilgelse.kt
@@ -23,6 +23,7 @@ import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.innvilgelse.OmstillingsstoenadInnvilgelseDTOSelectors.avdoed
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.innvilgelse.OmstillingsstoenadInnvilgelseDTOSelectors.beregning
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.innvilgelse.OmstillingsstoenadInnvilgelseDTOSelectors.etterbetaling
+import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.innvilgelse.OmstillingsstoenadInnvilgelseDTOSelectors.harUtbetaling
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.innvilgelse.OmstillingsstoenadInnvilgelseDTOSelectors.innhold
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.innvilgelse.OmstillingsstoenadInnvilgelseDTOSelectors.innvilgetMindreEnnFireMndEtterDoedsfall
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.innvilgelse.OmstillingsstoenadInnvilgelseDTOSelectors.lavEllerIngenInntekt
@@ -37,6 +38,7 @@ data class OmstillingsstoenadInnvilgelseDTO(
     val beregning: OmstillingsstoenadBeregning,
     val innvilgetMindreEnnFireMndEtterDoedsfall: Boolean,
     val lavEllerIngenInntekt: Boolean,
+    val harUtbetaling: Boolean,
     val etterbetaling: OmstillingsstoenadEtterbetaling?,
 ): BrevDTO
 
@@ -64,11 +66,13 @@ object OmstillingsstoenadInnvilgelse  : EtterlatteTemplate<OmstillingsstoenadInn
         }
 
         outline {
-            includePhrase(OmstillingsstoenadInnvilgelseFraser.Vedtak(avdoed, beregning))
+            includePhrase(OmstillingsstoenadInnvilgelseFraser.Vedtak(avdoed, beregning, harUtbetaling))
 
             konverterElementerTilBrevbakerformat(innhold)
 
-            includePhrase(OmstillingsstoenadInnvilgelseFraser.Utbetaling(etterbetaling))
+            showIf(harUtbetaling) {
+                includePhrase(OmstillingsstoenadInnvilgelseFraser.Utbetaling(etterbetaling))
+            }
             includePhrase(OmstillingsstoenadInnvilgelseFraser.HvaErOmstillingsstoenad)
             includePhrase(OmstillingsstoenadFellesFraser.HvorLengerKanDuFaaOmstillingsstoenad(beregning, lavEllerIngenInntekt))
             showIf(lavEllerIngenInntekt.not()) {

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
@@ -88,9 +88,8 @@ fun createBarnepensjonForeldreloesDTO() =
         bosattUtland = true,
         brukerUnder18Aar = true,
         kunNyttRegelverk = true,
-        bareEnPeriode = true,
         flerePerioder = true,
-        ingenUtbetaling = true,
+        harUtbetaling = true,
         vedtattIPesys = true
     )
 

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
@@ -88,7 +88,8 @@ fun createBarnepensjonInnvilgelseDTO() =
         bosattUtland = true,
         brukerUnder18Aar = true,
         kunNyttRegelverk = false,
-        erGjenoppretting = false
+        erGjenoppretting = false,
+        harUtbetaling = true
     )
 
 fun createBarnepensjonInnvilgelseRedigerbartUtfallDTO() = BarnepensjonInnvilgelseRedigerbartUtfallDTO(

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadInnvilgelse.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadInnvilgelse.kt
@@ -104,6 +104,7 @@ fun createOmstillingsstoenadInnvilgelseDTO() =
         ),
         innvilgetMindreEnnFireMndEtterDoedsfall = true,
         lavEllerIngenInntekt = true,
+        harUtbetaling = true,
     )
 
 fun createOmstillingsstoenadInnvilgelseRedigerbartUtfallDTO() =


### PR DESCRIPTION
- Viser ikke utbetalingsinformasjon i innvilgelsesbrev når ytelsen er 0
- Fjerner ubrukt felt for foreldreløs-mal og døper om feltet `ingenUtbetaling` til `harUtbetaling` for å være mer konsistent med resten av malene.