### PR TITLE
Viser tekst for restansetrekk hvis restansebeløp er positiv og motsatt

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/BeregningAvOmstillingsstoenad.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/BeregningAvOmstillingsstoenad.kt
@@ -217,7 +217,7 @@ private fun OutlineOnlyScope<LangBokmalNynorskEnglish, OmstillingsstoenadBeregni
         }
 
         showIf(sisteBeregningsperiode.restanse.notEqualTo(0)) {
-            val erRestanseTrekk = sisteBeregningsperiode.restanse.lessThan(0)
+            val erRestanseTrekk = sisteBeregningsperiode.restanse.greaterThan(0)
             val restanse = sisteBeregningsperiode.restanse.absoluteValue()
             title2 {
                 textExpr(


### PR DESCRIPTION
Siden avkorting er et positivt tall og trekkes ifra følger restanse samme mønster. Derfor er restanse som positivt tall et trekk og restanse som et negativt tall et tillegg.