### PR TITLE
Wrapper adresselinjene i paragraph siden det ikke blir rendret riktig…

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/informasjon/OmstillingsstoenadInnhentingAvOpplysninger.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/informasjon/OmstillingsstoenadInnhentingAvOpplysninger.kt
@@ -11,7 +11,6 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.EtterlatteTemplate
 import no.nav.pensjon.etterlatte.maler.fraser.common.Constants
-import no.nav.pensjon.etterlatte.maler.fraser.common.postadresse
 import no.nav.pensjon.etterlatte.maler.fraser.omstillingsstoenad.OmstillingsstoenadFellesFraser
 import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.informasjon.OmstillingsstoenadInnhentingAvOpplysningerDTOSelectors.borIUtlandet
 
@@ -82,7 +81,36 @@ object OmstillingsstoenadInnhentingAvOpplysninger : EtterlatteTemplate<Omstillin
                         English to "If you are submitting anything through the mail, you must use the following address:",
                     )
                 }
-                postadresse(borIUtlandet)
+                paragraph {
+                    text(
+                        Bokmal to "NAV skanning",
+                        Nynorsk to "NAV skanning",
+                        English to "NAV skanning",
+                    )
+                }
+                paragraph {
+                    text(
+                        Bokmal to "Postboks 1400",
+                        Nynorsk to "Postboks 1400",
+                        English to "Postboks 1400",
+                    )
+                }
+                paragraph {
+                    text(
+                        Bokmal to "0109 Oslo",
+                        Nynorsk to "0109 Oslo",
+                        English to "0109 Oslo",
+                    )
+                }
+                showIf(borIUtlandet) {
+                    paragraph {
+                        text(
+                            Bokmal to "Norge/Norway",
+                            Nynorsk to "Norge/Norway",
+                            English to "Norge/Norway",
+                        )
+                    }
+                }
                 includePhrase(OmstillingsstoenadFellesFraser.HarDuSpoersmaal)
             }
         }


### PR DESCRIPTION
… i slate, og heller ikke generert riktig i PDF på vei tilbake.

Ikke like pent, men iallefall konsekvent.
<img width="766" alt="Screenshot 2024-08-08 at 13 44 31" src="https://github.com/user-attachments/assets/b6545602-9cea-4358-bb26-b26cb2aa61fb">


EY-1599