### PR TITLE
Bruk GitHub mirror så man slipper å logge inn for å hente ned pakker

### DIFF
--- a/brevbaker-api-model-common/build.gradle.kts
+++ b/brevbaker-api-model-common/build.gradle.kts
@@ -27,11 +27,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/navikt/pensjonsbrev")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
-                password = project.findProperty("gpr.token") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
+            url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
         }
     }
     publications {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,15 +13,7 @@ allprojects {
         mavenLocal()
         mavenCentral()
         maven {
-            // Create a token at https://github.com/settings/tokens/new with package.read
-            // Then create a gradle.properties file in $HOME/.gradle with the following:
-            // gpr.user=<your github username>
-            // gpr.token=<the token>
-            url = uri("https://maven.pkg.github.com/navikt/pensjonsbrev")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
-                password = project.findProperty("gpr.token") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
+            url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
             content {
                 includeGroup("no.nav.pensjon.brev") // api-model
                 includeGroup("no.nav.pensjon.brevbaker") // api-model-common

--- a/pensjon-brevbaker-api-model/build.gradle.kts
+++ b/pensjon-brevbaker-api-model/build.gradle.kts
@@ -31,11 +31,7 @@ publishing {
 
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/navikt/pensjonsbrev")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
-                password = project.findProperty("gpr.token") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
+            url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
         }
     }
     publications {

--- a/tjenestebuss-integrasjon/build.gradle.kts
+++ b/tjenestebuss-integrasjon/build.gradle.kts
@@ -87,15 +87,7 @@ dependencies {
 
 repositories {
 	maven {
-		// Create a token at https://github.com/settings/tokens/new with package.read
-		// Then create a gradle.properties file in $HOME/.gradle with the following:
-		// gpr.user=<your github username>
-		// gpr.token=<the token>
-		url = uri("https://maven.pkg.github.com/navikt/pesys-esb-wsclient")
-		credentials {
-			username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
-			password = project.findProperty("gpr.token") as String? ?: System.getenv("GITHUB_TOKEN")
-		}
+		url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
 		metadataSources {
 			artifact() //Look directly for artifact
 		}
@@ -104,11 +96,7 @@ repositories {
 		}
 	}
 	maven {
-		url = uri("https://maven.pkg.github.com/navikt/tjenestespesifikasjoner")
-		credentials {
-			username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
-			password = project.findProperty("gpr.token") as String? ?: System.getenv("GITHUB_TOKEN")
-		}
+		url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
 	}
 }
 


### PR DESCRIPTION
Ved å bytte Maven repository for pakker fra GitHub så slipper man å logge inn i GitHub. Dette repoet er et speil av GitHub, laget og vedlikeholdt av Nav, som tilgjengeliggjør pakker fra repoer som er public