### PR TITLE
Bruker bold i stedet for title2 pga bug ved listevisning

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/informasjon/BarnepensjonInformasjonDoedsfallMellomAttenOgTjueVedReformtidspunkt.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/informasjon/BarnepensjonInformasjonDoedsfallMellomAttenOgTjueVedReformtidspunkt.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.etterlatte.maler.barnepensjon.informasjon
 
+import no.nav.pensjon.brev.template.Element
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.Language.Bokmal
 import no.nav.pensjon.brev.template.Language.English
@@ -72,11 +73,12 @@ object BarnepensjonInformasjonDoedsfallMellomAttenOgTjueVedReformtidspunkt : Ett
                     )
                 }
 
-                title2 {
+                paragraph {
                     text(
                         Bokmal to "Hva betyr de nye reglene?",
                         Nynorsk to "Kva betyr dei nye reglane?",
                         English to "What do these new rules entail?",
+                        Element.OutlineContent.ParagraphContent.Text.FontType.BOLD
                     )
                 }
                 paragraph {
@@ -97,11 +99,12 @@ object BarnepensjonInformasjonDoedsfallMellomAttenOgTjueVedReformtidspunkt : Ett
                         }
                     }
                 }
-                title2 {
+                paragraph {
                     text(
                         Bokmal to "Hvordan søker du?",
                         Nynorsk to "Korleis søkjer du?",
                         English to "How to apply",
+                        Element.OutlineContent.ParagraphContent.Text.FontType.BOLD
                     )
                 }
                 showIf(borIutland.not()) {
@@ -132,11 +135,12 @@ object BarnepensjonInformasjonDoedsfallMellomAttenOgTjueVedReformtidspunkt : Ett
                     }
                 }
 
-                title2 {
+                paragraph {
                     text(
                         Bokmal to "Rettigheter hvis avdøde har bodd eller arbeidet i utlandet",
                         Nynorsk to "Rettar dersom avdøde har budd eller jobba i utlandet",
                         English to "Rights if the deceased has lived or worked abroad",
+                        Element.OutlineContent.ParagraphContent.Text.FontType.BOLD
                     )
                 }
                 paragraph {
@@ -147,11 +151,12 @@ object BarnepensjonInformasjonDoedsfallMellomAttenOgTjueVedReformtidspunkt : Ett
                     )
                 }
 
-                title2 {
+                paragraph {
                     text(
                         Bokmal to "Andre pensjonsordninger",
                         Nynorsk to "Andre pensjonsordningar",
                         English to "Other pension schemes",
+                        Element.OutlineContent.ParagraphContent.Text.FontType.BOLD
                     )
                 }
                 paragraph {
@@ -162,7 +167,7 @@ object BarnepensjonInformasjonDoedsfallMellomAttenOgTjueVedReformtidspunkt : Ett
                     )
                 }
 
-                    includePhrase(BarnepensjonFellesFraser.HarDuSpoersmaal(Expression.Literal(false), borIutland))
+                    includePhrase(BarnepensjonFellesFraser.HarDuSpoersmaalDoedsfallMellomAttenOgTjue(Expression.Literal(false), borIutland))
             }
         }
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonFellesFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonFellesFraser.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.etterlatte.maler.fraser.barnepensjon
 
+import no.nav.pensjon.brev.template.Element
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
 import no.nav.pensjon.brev.template.Language.Bokmal
@@ -115,6 +116,52 @@ object BarnepensjonFellesFraser {
                     Bokmal to "Har du spørsmål?",
                     Nynorsk to "Har du spørsmål?",
                     English to "Any questions?",
+                )
+            }
+
+            showIf(brukerUnder18Aar) {
+                paragraph {
+                    text(
+                        Bokmal to "Du finner mer informasjon på ${Constants.BARNEPENSJON_URL}. Hvis du ikke finner svar på spørsmålet ditt, kan du ringe oss på telefon ",
+                        Nynorsk to "Du finn meir informasjon på ${Constants.BARNEPENSJON_URL}. Dersom du ikkje finn svar på spørsmålet ditt der, kan du ringje oss på telefon ",
+                        English to "For more information, visit us online: ${Constants.Engelsk.BARNEPENSJON_URL}. If you cannot find the answer to your question, you can call us by phone at "
+                    )
+                    kontakttelefonPensjon(bosattUtland)
+                    text(
+                        Bokmal to ", hverdager mellom klokken 09.00-15.00. Om du oppgir fødselsnummer til barnet, kan vi lettere gi deg rask og god hjelp.",
+                        Nynorsk to ", kvardagar mellom klokka 09.00–15.00. Det vil gjere det enklare for oss å gi deg rask og god hjelp om du oppgir fødselsnummeret til barnet.",
+                        English to ", Monday to Friday between 09:00 AM and 03:00 PM. If you provide your child's national identity number, we can more easily provide you with quick and good help."
+                    )
+                }
+            }.orShow {
+                paragraph {
+                    text(
+                        Bokmal to "Du finner mer informasjon på ${Constants.BARNEPENSJON_URL}. På ${Constants.KONTAKT_URL} kan du chatte eller skrive til oss. Du kan også kontakte oss på telefon ",
+                        Nynorsk to "Du finn meir informasjon på ${Constants.BARNEPENSJON_URL}. Du kan skrive til eller chatte med oss på ${Constants.KONTAKT_URL}. Alternativt kan du ringje oss på telefon ",
+                        English to "You can find answers to your questions online: ${Constants.Engelsk.BARNEPENSJON_URL}. Feel free to chat with us or write to us here: ${Constants.Engelsk.KONTAKT_URL}. You can also contact us by phone at "
+                    )
+                    kontakttelefonPensjon(bosattUtland)
+                    text(
+                        Bokmal to ", hverdager klokken 09.00-15.00. Om du oppgir fødselsnummeret ditt, kan vi lettere gi deg rask og god hjelp.",
+                        Nynorsk to ", kvardagar mellom klokka 09.00–15.00. Det vil gjere det enklare for oss å gi deg rask og god hjelp om du oppgir fødselsnummeret ditt.",
+                        English to ", Monday to Friday between 9:00 AM and 3:00 PM. If you provide your national identity number, we can more easily provide you with quick and good help."
+                    )
+                }
+            }
+        }
+    }
+
+    data class HarDuSpoersmaalDoedsfallMellomAttenOgTjue(
+        val brukerUnder18Aar: Expression<Boolean>,
+        val bosattUtland: Expression<Boolean>,
+    ) : OutlinePhrase<LangBokmalNynorskEnglish>() {
+        override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
+            paragraph {
+                text(
+                    Bokmal to "Har du spørsmål?",
+                    Nynorsk to "Har du spørsmål?",
+                    English to "Any questions?",
+                    Element.OutlineContent.ParagraphContent.Text.FontType.BOLD
                 )
             }
 


### PR DESCRIPTION
Ser litt rart ut ved listevisning, så prøver å erstatte `title2` med `bold`, som foreslått av brevbaker-teamet.

![Screenshot 2024-09-23 at 15 33 12](https://github.com/user-attachments/assets/8f2a5027-64a1-42cb-a468-b3b1022b5d08)
