### PR TITLE
fikser kall for å hente nav enhet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - AD_GROUP_Fortrolig_Adresse=ea930b6b-9397-44d9-b9e6-f4cf527a632a
       - AD_GROUP_Strengt_Fortrolig_Adresse=5ef775f2-61f8-4283-bf3d-8d03f428aa14
       - AD_GROUP_EndreStrengtFortroligUtland=fc792042-93d8-4d5e-a501-55c45c03c576
-      - NORG2_URL=https://norg2.intern.dev.nav.no/norg2
+      - NORG2_URL=https://norg2.intern.dev.nav.no/norg2/
 
   skribenten-backend-db:
     profiles:

--- a/skribenten-backend/.nais/dev.yaml
+++ b/skribenten-backend/.nais/dev.yaml
@@ -105,4 +105,4 @@ env:
     value: "api://dev-fss.pensjon-q2.pensjon-samhandler-proxy-q2/.default"
 
   - name: NORG2_URL
-    value: "https://norg2.intern.dev.nav.no/norg2"
+    value: "https://norg2.intern.dev.nav.no/norg2/"

--- a/skribenten-backend/.nais/prod.yaml
+++ b/skribenten-backend/.nais/prod.yaml
@@ -102,4 +102,4 @@ env:
     value: "api://prod-fss.pensjondeployer.pensjon-samhandler-proxy/.default"
 
   - name: NORG2_URL
-    value: "https://norg2.intern.nav.no/norg2"
+    value: "https://norg2.intern.nav.no/norg2/"

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/model/Api.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/model/Api.kt
@@ -7,7 +7,8 @@ import no.nav.pensjon.brev.api.model.maler.Brevkode
 import no.nav.pensjon.brev.skribenten.db.EditLetterHash
 import no.nav.pensjon.brev.skribenten.letter.Edit
 import no.nav.pensjon.brev.skribenten.services.LetterMetadata
-import no.nav.pensjon.brev.skribenten.services.NAVEnhet
+import no.nav.pensjon.brev.skribenten.services.NAVAnsattEnhet
+import no.nav.pensjon.brev.skribenten.services.NavEnhet
 import no.nav.pensjon.brev.skribenten.services.SpraakKode
 import java.time.Duration
 import java.time.Instant
@@ -48,7 +49,7 @@ object Api {
         val status: BrevStatus,
         val distribusjonstype: Distribusjonstype,
         val mottaker: OverstyrtMottaker?,
-        val avsenderEnhet: NAVEnhet?,
+        val avsenderEnhet: NavEnhet?,
         val spraak: SpraakKode,
     )
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/NavansattService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/NavansattService.kt
@@ -31,8 +31,8 @@ class NavansattService(config: Config, authService: AzureADService) : ServiceSta
         }
     }
 
-    suspend fun hentNavAnsattEnhetListe(call: ApplicationCall, ansattId: String): ServiceResult<List<NAVEnhet>> {
-        return client.get(call, "navansatt/$ansattId/enheter").toServiceResult<List<NAVEnhet>>()
+    suspend fun hentNavAnsattEnhetListe(call: ApplicationCall, ansattId: String): ServiceResult<List<NAVAnsattEnhet>> {
+        return client.get(call, "navansatt/$ansattId/enheter").toServiceResult<List<NAVAnsattEnhet>>()
     }
 
     suspend fun harTilgangTilEnhet(call: ApplicationCall, ansattId: String, enhetsId: String): ServiceResult<Boolean> =
@@ -55,7 +55,7 @@ class NavansattService(config: Config, authService: AzureADService) : ServiceSta
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class NAVEnhet(
+data class NAVAnsattEnhet(
     val id: String,
     val navn: String,
 )
@@ -67,3 +67,5 @@ data class Navansatt(
     val fornavn: String,
     val etternavn: String,
 )
+
+

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/ApiServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/ApiServiceTest.kt
@@ -100,8 +100,8 @@ class ApiServiceTest {
     @Test
     fun `henter navn paa avsenderEnhet`(): Unit = runBlocking {
         val brev = createBrev(avsenderEnhetId = "1234")
-        coEvery { norg2Service.getEnhet(any(), eq("1234")) } returns NAVEnhet("1234", "En kul enhet")
-        assertThat(dto2ApiService.toApi(mockCall, brev).avsenderEnhet).isEqualTo(NAVEnhet("1234", "En kul enhet"))
+        coEvery { norg2Service.getEnhet(any(), eq("1234")) } returns NavEnhet("1234", "En kul enhet")
+        assertThat(dto2ApiService.toApi(mockCall, brev).avsenderEnhet).isEqualTo(NavEnhet("1234", "En kul enhet"))
     }
 
     @Test

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/LegacyBrevServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/LegacyBrevServiceTest.kt
@@ -34,7 +34,7 @@ class LegacyBrevServiceTest {
         every { callId } returns "utrolig kul callId"
         every { principal() } returns principal
     }
-    private val principalSinNAVEnhet = NAVEnhet("1111", "NAV Ozzzlo")
+    private val principalSinNAVEnhet = NAVAnsattEnhet("1111", "NAV Ozzzlo")
 
 
     private val exstreamBrevMetadata = BrevdataDto(

--- a/skribenten-web/frontend/src/types/brev.ts
+++ b/skribenten-web/frontend/src/types/brev.ts
@@ -118,6 +118,6 @@ export interface UtenlandskAdresse {
 }
 
 export interface NAVEnhet {
-  id: string;
+  enhetNr: string;
   navn: string;
 }


### PR DESCRIPTION
`/norg2` ble fjernet når man valgte å legge på `/api/...`. Faktisk så ble den fjernet selv om man bare hadde `/lol` eller `lol`. Men ved å legge på en / på slutten av `/norg2/`, og å fjerne den fra `/api`, funker det fint. 

Jeg tror det er kanskje en spesiell regel dersom url pathen vi bruker slutter på `/api`, det er fordi vi har et endepunkt i PenService `/pen/actuator/health/readiness` og den funker helt fint 🤷 