### PR TITLE
Aukar timeout på initielt oppsett av dataconfig før hikari feilar.

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/DatabaseSchema.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/DatabaseSchema.kt
@@ -154,6 +154,7 @@ fun initDatabase(jdbcUrl: String, username: String, password: String) {
             this.jdbcUrl = jdbcUrl
             this.username = username
             this.password = password
+            this.initializationFailTimeout = 6000
             maximumPoolSize = 2
             validate()
         }),


### PR DESCRIPTION
Lokalt hos meg feilar skribenten-testane som bruker testcontainers på at datasourcen bruker lengre tid på å starte enn det standardverdien her tillet. Aukar derfor timeout-verdien. Seks sekund er ikkje veldig mykje, men nok til at testane køyrer stabilt. Det var også det vi brukte i tilsvarande samanheng i etterlatte utan at det gjorde noko.