### PR TITLE
Loggar til både ELK og til loki i Grafana

### DIFF
--- a/pdf-bygger/.nais/nais.yaml
+++ b/pdf-bygger/.nais/nais.yaml
@@ -34,6 +34,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: "100m"

--- a/pensjon-brevbaker/.nais/nais.yaml
+++ b/pensjon-brevbaker/.nais/nais.yaml
@@ -36,6 +36,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: "400m"


### PR DESCRIPTION
Kan med det få opp relevante loggsnuttar saman med sporinga i Grafana.

Standard-verdien er elastic, så må definere den eksplisitt også no når vi overstyrer til å også sende til loki