### PR TITLE
Fiksar brevoppskrift-web-deploy

### DIFF
--- a/brevoppskrift-web/bff/src/config.ts
+++ b/brevoppskrift-web/bff/src/config.ts
@@ -1,5 +1,3 @@
-import { requireEnvironment } from "@navikt/backend-for-frontend-utils";
-
 const app = {
   nodeEnv: requireEnvironment("NODE_ENV"),
   host: requireEnvironment("EXPRESS_HOST"),
@@ -14,3 +12,11 @@ export default {
   app,
   brevbakerApiProxy,
 };
+
+function requireEnvironment(environmentName: string) {
+  const environmentContent = process.env[environmentName];
+  if (!environmentContent) {
+    throw new Error("Missing environment variable with name: " + environmentName);
+  }
+  return environmentContent;
+}


### PR DESCRIPTION
Omgår behovet for å deklarere opp Azure for appen

Får denne feilmeldinga etter deploy: "Error: Missing environment variable with name: AZURE_APP_CLIENT_ID
    at requireEnvironment (file:///app/node_modules/@navikt/backend-for-frontend-utils/dist/config.js:7:15)"

Ser at config-klassa i biblioteket blir brukt for å tilgjengeleggjera requireEnvironment-hjelpemetoden, og i tillegg krev Azure-konfig. Vi treng ikkje å bruke denne, så kopierer heller berre over requireEnvironment-metoden direkte og omgår problematikken

Da eg gjorde endringa frå NAV til Nav endra eg nokre filer her, og da feila bygget sånn: https://github.com/navikt/pensjonsbrev/actions/runs/11559168526/job/32174561846 , og den eine podden har gått i crashloop sia da. Trur dette skal halde.