### PR TITLE
Distribuert sporing også for skribenten

### DIFF
--- a/skribenten-backend/.nais/nais.yaml
+++ b/skribenten-backend/.nais/nais.yaml
@@ -29,6 +29,14 @@ spec:
     enabled: true
     path: "/metrics"
     port: "8080"
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: "200m"

--- a/skribenten-web/bff/.nais/nais.yaml
+++ b/skribenten-web/bff/.nais/nais.yaml
@@ -22,6 +22,14 @@ spec:
   readiness:
     path: /internal/health/readiness
     initialDelay: 5
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: nodejs
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   azure:
     application:
       enabled: true


### PR DESCRIPTION
Ser det funkar fint for brevbaker, pdf-bygger og brevmetadata, så tar det i bruk også i skribenten