### PR TITLE
Ikkje lag PDF av kvar etterlatte-mal for kvar einaste PR

### DIFF
--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/TemplateResourceTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/TemplateResourceTest.kt
@@ -21,7 +21,7 @@ private val objectMapper = jacksonObjectMapper()
 
 class TemplateResourceTest {
 
-    @Tag(TestTags.INTEGRATION_TEST)
+    @Tag(TestTags.MANUAL_TEST)
     @ParameterizedTest(name = "{index} => template={0}, etterlatteBrevKode={1}, fixtures={2}, spraak={3}")
     @MethodSource("alleMalene")
     fun <T : Any> testPdf(


### PR DESCRIPTION
Det å lage PDF av alle etterlatte-malane treng vi ikkje eigentleg å gjera automatisk for kvar PR, det held med å lage HTML for alle.

Sparer oss _mykje_ tid under integrasjonstestkøyring.