### PR TITLE
Under 100% er feil grad å mappe mot, siden den betyr i stedet != 100%

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/aktivitetsplikt/Aktivitetsplikt.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/aktivitetsplikt/Aktivitetsplikt.kt
@@ -1,4 +1,4 @@
 package no.nav.pensjon.etterlatte.maler.omstillingsstoenad.aktivitetsplikt
 
-enum class Aktivitetsgrad { IKKE_I_AKTIVITET, UNDER_50_PROSENT, OVER_50_PROSENT, UNDER_100_PROSENT, AKKURAT_100_PROSENT }
+enum class Aktivitetsgrad { IKKE_I_AKTIVITET, UNDER_50_PROSENT, OVER_50_PROSENT, AKKURAT_100_PROSENT }
 enum class NasjonalEllerUtland { NASJONAL, UTLAND }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/aktivitetsplikt/OmstillingsstoenadAktivitetspliktInformasjon10mndInnhold.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/omstillingsstoenad/aktivitetsplikt/OmstillingsstoenadAktivitetspliktInformasjon10mndInnhold.kt
@@ -8,6 +8,7 @@ import no.nav.pensjon.brev.template.dsl.expression.and
 import no.nav.pensjon.brev.template.dsl.expression.equalTo
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.expression.not
+import no.nav.pensjon.brev.template.dsl.expression.notEqualTo
 import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
 import no.nav.pensjon.brev.template.dsl.languages
 import no.nav.pensjon.brev.template.dsl.text
@@ -78,7 +79,7 @@ object OmstillingsstoenadAktivitetspliktInformasjon10mndInnhold :
                 }
             }
 
-            showIf(redusertEtterInntekt) {
+            showIf(redusertEtterInntekt.and(utbetaling)) {
                 paragraph {
                     text(
                         Bokmal to "Omstillingsstønaden din er redusert etter en forventet arbeidsinntekt på <FORVENTET INNTEKT TOTALT, AVRUNDET> kroner i år. LEGG TIL ETTER KRONER HVIS INNVILGET FRA FEBRUAR-AUGUST: fra <måned> og ut året.",
@@ -86,7 +87,7 @@ object OmstillingsstoenadAktivitetspliktInformasjon10mndInnhold :
                         English to "Your adjustment allowance is reduced based on your income from employment of NOK <FORVENTET INNTEKT TOTALT, AVRUNDET> this year. LEGG TIL ETTER BELØP HVIS INNVILGET FRA FEBRUAR-AUGUST: from <måned> until the end of this year.",
                     )
                 }
-            } orShow {
+            }.orShowIf(utbetaling) {
                 paragraph {
                     text(
                         Bokmal to "Omstillingsstønaden din er i dag ikke redusert etter arbeidsinntekt eller annen inntekt som er likestilt med arbeidsinntekt.",
@@ -132,7 +133,7 @@ object OmstillingsstoenadAktivitetspliktInformasjon10mndInnhold :
                 }
             }
 
-            showIf(aktivitetsgrad.equalTo(Aktivitetsgrad.UNDER_100_PROSENT) and utbetaling) {
+            showIf(aktivitetsgrad.notEqualTo(Aktivitetsgrad.AKKURAT_100_PROSENT) and utbetaling) {
                 paragraph {
                     text(
                         Bokmal to "For å motta omstillingsstønad videre bør du øke aktiviteten din. Se “Hvordan oppfylle aktivitetsplikten?”.  Hvis du ikke foretar deg noen av de andre aktivitetene som er nevnt, bør du melde deg som reell arbeidssøker hos NAV. Dette innebærer at du sender meldekort, er aktiv med å søke jobber, samt deltar på de kurs som NAV tilbyr.",

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoendaAktivitetspliktInformasjon10mnd.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoendaAktivitetspliktInformasjon10mnd.kt
@@ -6,7 +6,7 @@ import no.nav.pensjon.etterlatte.maler.omstillingsstoenad.aktivitetsplikt.Omstil
 
 fun createOmstillingsstoenadAktivitetspliktInformasjon10mndInnholdDTO() =
     OmstillingsstoenadAktivitetspliktInformasjon10mndInnholdDTO(
-        aktivitetsgrad = Aktivitetsgrad.AKKURAT_100_PROSENT,
+        aktivitetsgrad = Aktivitetsgrad.OVER_50_PROSENT,
         utbetaling = true,
         redusertEtterInntekt = true,
         nasjonalEllerUtland = NasjonalEllerUtland.NASJONAL


### PR DESCRIPTION
Fjerner også duplikat henvendelse i brevtekst