### PR TITLE
Vi gjer framtidig endring lettare viss LetterResponse for etterlatte …

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/EtterlatteRouting.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/EtterlatteRouting.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.etterlatte
 
+import io.ktor.http.ContentType
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -13,7 +14,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 private val letterResource = LetterResource()
 
-data class LetterResponse(val base64pdf: String, val letterMetadata: LetterMetadata)
+data class LetterResponse(val base64pdf: String, val file: String, val contentType: String, val letterMetadata: LetterMetadata)
 
 fun Route.etterlatteRouting(latexCompilerService: LaTeXCompilerService) {
 
@@ -25,7 +26,12 @@ fun Route.etterlatteRouting(latexCompilerService: LaTeXCompilerService) {
             .let { LatexDocumentRenderer.render(it.letterMarkup, it.attachments, letter) }
             .let { latexCompilerService.producePDF(it) }
 
-        call.respond(LetterResponse(pdfBase64.base64PDF, letter.template.letterMetadata))
+        call.respond(LetterResponse(
+            base64pdf = pdfBase64.base64PDF,
+            file = pdfBase64.base64PDF,
+            contentType = ContentType.Application.Pdf.toString(),
+            letterMetadata = letter.template.letterMetadata
+        ))
 
         // Om dere vil ha det
         Metrics.prometheusRegistry.counter(


### PR DESCRIPTION
…har samme feltnamn som LetterResponse for dei andre.

Innfører i første omgang file som ekstra parameter. Når Gjenny har bytta over til å lesa frå denne heller enn frå base64pdf, kjem det ny PR med å fjerne denne. Unngår på denne måten nedetid.