### PR TITLE
EY-3360: Støtte for ukjent avdød i brev

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -79,7 +79,7 @@ data class OmstillingsstoenadBeregningsperiode(
 )
 
 data class Trygdetid(
-    val navnAvdoed: String,
+    val navnAvdoed: String?,
     val trygdetidsperioder: List<Trygdetidsperiode>,
     val beregnetTrygdetidAar: Int,
     val prorataBroek: IntBroek?,
@@ -141,7 +141,7 @@ data class ForskjelligTrygdetid(
 }
 
 data class ForskjelligAvdoedPeriode(
-    val foersteAvdoed: Avdoed,
-    val senereAvdoed: Avdoed,
+    val foersteAvdoed: Avdoed?,
+    val senereAvdoed: Avdoed?,
     val senereVirkningsdato: LocalDate,
 )

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelseRedigerbartUfall.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelseRedigerbartUfall.kt
@@ -26,7 +26,7 @@ import java.time.LocalDate
 
 data class BarnepensjonInnvilgelseRedigerbartUtfallDTO(
     val virkningsdato: LocalDate,
-    val avdoed: Avdoed,
+    val avdoed: Avdoed?,
     val sisteBeregningsperiodeDatoFom: LocalDate,
     val sisteBeregningsperiodeBeloep: Kroner,
     val erEtterbetaling: Boolean,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonForeldreloesFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonForeldreloesFraser.kt
@@ -1,15 +1,9 @@
 package no.nav.pensjon.etterlatte.maler.fraser.barnepensjon
 
 import no.nav.pensjon.brev.model.format
-import no.nav.pensjon.brev.template.Expression
-import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
-import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.OutlinePhrase
+import no.nav.pensjon.brev.template.*
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
-import no.nav.pensjon.brev.template.dsl.expression.and
-import no.nav.pensjon.brev.template.dsl.expression.expr
-import no.nav.pensjon.brev.template.dsl.expression.format
-import no.nav.pensjon.brev.template.dsl.expression.plus
+import no.nav.pensjon.brev.template.dsl.expression.*
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.dsl.textExpr
 import no.nav.pensjon.brevbaker.api.model.Kroner
@@ -61,15 +55,28 @@ object BarnepensjonForeldreloesFraser {
                                 formatertVirkningsdato + " both your parents are registered as deceased."
                     )
                 }.orIfNotNull(forskjelligAvdoedPeriode) { forskjelligAvdoed ->
-                    val avdoedNavn = forskjelligAvdoed.foersteAvdoed.navn
-                    val formatertDoedsdato = forskjelligAvdoed.foersteAvdoed.doedsdato.format()
-                    val senereDoedsdato = forskjelligAvdoed.senereAvdoed.doedsdato.format()
-                    val senereVirkningsdato = forskjelligAvdoed.senereVirkningsdato.format()
-                    textExpr(
-                        Language.Bokmal to "Du er innvilget barnepensjon fra ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". Barnepensjon endres fra " + senereVirkningsdato + " fordi den andre forelderen din er registrert død " + senereDoedsdato + ". ",
-                        Language.Nynorsk to "Du er innvilga barnepensjon frå og med ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". Barnepensjonen din er endra frå " + senereVirkningsdato + " fordi begge foreldra dine er registrert som døde. ",
-                        Language.English to "You have been granted a children's pension ".expr() + formatertVirkningsdato + " because " + avdoedNavn + " is registered as deceased on "+ formatertDoedsdato + ". Your children's pension will change on " + senereVirkningsdato + " because both your parents are registered as deceased. ",
-                    )
+                    ifNotNull(forskjelligAvdoed.foersteAvdoed, forskjelligAvdoed.senereAvdoed) { foersteAvdoed, senereAvdoed ->
+                        val senereVirkningsdato = forskjelligAvdoed.senereVirkningsdato.format()
+                        val avdoedNavn = foersteAvdoed.navn
+                        val formatertDoedsdato = foersteAvdoed.doedsdato.format()
+                        val formatertSenereDoedsdato = senereAvdoed.doedsdato.format()
+
+                        textExpr(
+                            Language.Bokmal to "Du er innvilget barnepensjon fra ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". Barnepensjon endres fra " + senereVirkningsdato + " fordi den andre forelderen din er registrert død " + formatertSenereDoedsdato + ". ",
+                            Language.Nynorsk to "Du er innvilga barnepensjon frå og med ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". Barnepensjonen din er endra frå " + senereVirkningsdato + " fordi begge foreldra dine er registrert som døde. ",
+                            Language.English to "You have been granted a children's pension ".expr() + formatertVirkningsdato + " because " + avdoedNavn + " is registered as deceased on "+ formatertDoedsdato + ". Your children's pension will change on " + senereVirkningsdato + " because both your parents are registered as deceased. ",
+                        )
+                    }.orShow {
+                        textExpr(
+                            Language.Bokmal to "Du er innvilget barnepensjon fra ".expr() +
+                                    formatertVirkningsdato + " fordi begge foreldrene dine er registrert død.".expr(),
+                            Language.Nynorsk to "Du er innvilga barnepensjon frå ".expr() +
+                                    formatertVirkningsdato + " fordi begge foreldra dine er registrert som døde.".expr(),
+                            Language.English to "You have been granted a children's pension starting ".expr() +
+                                    formatertVirkningsdato + " because both your parents are registered as deceased.".expr()
+                        )
+                    }
+
                 }.orShow {
                     textExpr(
                         Language.Bokmal to "Du er innvilget barnepensjon fra ".expr() +

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonForeldreloesFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonForeldreloesFraser.kt
@@ -69,22 +69,22 @@ object BarnepensjonForeldreloesFraser {
                     }.orShow {
                         textExpr(
                             Language.Bokmal to "Du er innvilget barnepensjon fra ".expr() +
-                                    formatertVirkningsdato + " fordi begge foreldrene dine er registrert død.".expr(),
+                                    formatertVirkningsdato + " fordi begge foreldrene dine er registrert død.",
                             Language.Nynorsk to "Du er innvilga barnepensjon frå ".expr() +
-                                    formatertVirkningsdato + " fordi begge foreldra dine er registrert som døde.".expr(),
+                                    formatertVirkningsdato + " fordi begge foreldra dine er registrert som døde.",
                             Language.English to "You have been granted a children's pension starting ".expr() +
-                                    formatertVirkningsdato + " because both your parents are registered as deceased.".expr()
+                                    formatertVirkningsdato + " because both your parents are registered as deceased."
                         )
                     }
 
                 }.orShow {
                     textExpr(
                         Language.Bokmal to "Du er innvilget barnepensjon fra ".expr() +
-                                formatertVirkningsdato + " fordi begge foreldrene dine er registrert død.".expr(),
+                                formatertVirkningsdato + " fordi begge foreldrene dine er registrert død.",
                         Language.Nynorsk to "Du er innvilga barnepensjon frå ".expr() +
-                                formatertVirkningsdato + " fordi begge foreldra dine er registrert som døde.".expr(),
+                                formatertVirkningsdato + " fordi begge foreldra dine er registrert som døde.",
                         Language.English to "You have been granted a children's pension starting ".expr() +
-                                formatertVirkningsdato + " because both your parents are registered as deceased.".expr()
+                                formatertVirkningsdato + " because both your parents are registered as deceased."
                     )
                 }
 
@@ -100,9 +100,9 @@ object BarnepensjonForeldreloesFraser {
                         )
                     }.orShow {
                         textExpr(
-                            Language.Bokmal to " Du får ".expr() + formatertBeloep + " kroner hver måned før skatt.".expr(),
-                            Language.Nynorsk to " Du får ".expr() + formatertBeloep + " kroner per månad før skatt.".expr(),
-                            Language.English to " You will receive NOK ".expr() + formatertBeloep + " each month before tax.".expr(),
+                            Language.Bokmal to " Du får ".expr() + formatertBeloep + " kroner hver måned før skatt.",
+                            Language.Nynorsk to " Du får ".expr() + formatertBeloep + " kroner per månad før skatt.",
+                            Language.English to " You will receive NOK ".expr() + formatertBeloep + " each month before tax.",
                         )
                     }
                 }.orShow {

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonInnvilgelseFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonInnvilgelseFraser.kt
@@ -7,23 +7,22 @@ import no.nav.pensjon.brev.template.Language
 import no.nav.pensjon.brev.template.Language.*
 import no.nav.pensjon.brev.template.OutlinePhrase
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
-import no.nav.pensjon.brev.template.dsl.expression.and
-import no.nav.pensjon.brev.template.dsl.expression.expr
-import no.nav.pensjon.brev.template.dsl.expression.format
-import no.nav.pensjon.brev.template.dsl.expression.plus
+import no.nav.pensjon.brev.template.dsl.expression.*
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.dsl.textExpr
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import no.nav.pensjon.etterlatte.maler.Avdoed
 import no.nav.pensjon.etterlatte.maler.AvdoedSelectors.doedsdato
+import no.nav.pensjon.etterlatte.maler.AvdoedSelectors.doedsdato_safe
 import no.nav.pensjon.etterlatte.maler.AvdoedSelectors.navn
+import no.nav.pensjon.etterlatte.maler.AvdoedSelectors.navn_safe
 import no.nav.pensjon.etterlatte.maler.fraser.common.Vedtak
 import java.time.LocalDate
 
 object BarnepensjonInnvilgelseFraser {
 
     data class Foerstegangsbehandlingsvedtak(
-        val avdoed: Expression<Avdoed>,
+        val avdoed: Expression<Avdoed?>,
         val virkningsdato: Expression<LocalDate>,
         val sisteBeregningsperiodeDatoFom: Expression<LocalDate>,
         val sisteBeregningsperiodeBeloep: Expression<Kroner>,
@@ -42,23 +41,45 @@ object BarnepensjonInnvilgelseFraser {
 
             paragraph {
                 val formatertVirkningsdato = virkningsdato.format()
-                val formatertDoedsdato = avdoed.doedsdato.format()
                 val formatertNyesteUtbetalingsperiodeDatoFom = sisteBeregningsperiodeDatoFom.format()
                 val formatertBeloep = sisteBeregningsperiodeBeloep.format()
-                val avdoedNavn = avdoed.navn
 
                 showIf(erGjenoppretting) {
-                    textExpr(
-                        Language.Bokmal to "Vi viser til forhåndsvarsel om ny barnepensjon. Du er innvilget barnepensjon på nytt fra ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". ",
-                        Language.Nynorsk to "Vi viser til førehandsvarselet om ny barnepensjon. Du er innvilga ny barnepensjon frå og med ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". ",
-                        Language.English to "We refer to the advance notice about a new children’s pension scheme. You have been granted a children's pension again from ".expr() + formatertVirkningsdato + " because " + avdoedNavn + " is registered as deceased on "+ formatertDoedsdato + ". "
-                    )
+                    ifNotNull(avdoed) { avdoed ->
+                        val avdoedNavn = avdoed.navn
+                        val formatertDoedsdato = avdoed.doedsdato.format()
+
+                        textExpr(
+                            Language.Bokmal to "Vi viser til forhåndsvarsel om ny barnepensjon. Du er innvilget barnepensjon på nytt fra ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". ",
+                            Language.Nynorsk to "Vi viser til førehandsvarselet om ny barnepensjon. Du er innvilga ny barnepensjon frå og med ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". ",
+                            Language.English to "We refer to the advance notice about a new children’s pension scheme. You have been granted a children's pension again from ".expr() + formatertVirkningsdato + " because " + avdoedNavn + " is registered as deceased on "+ formatertDoedsdato + ". "
+                        )
+                    }.orShow {
+                        textExpr(
+                            Language.Bokmal to "Vi viser til forhåndsvarsel om ny barnepensjon. Du er innvilget barnepensjon på nytt fra ".expr() + formatertVirkningsdato + ". ",
+                            Language.Nynorsk to "Vi viser til førehandsvarselet om ny barnepensjon. Du er innvilga ny barnepensjon frå og med ".expr() + formatertVirkningsdato + ". ",
+                            Language.English to "We refer to the advance notice about a new children’s pension scheme. You have been granted a children's pension again from ".expr() + formatertVirkningsdato + ". "
+                        )
+                    }
+
                 }.orShow {
-                    textExpr(
-                        Language.Bokmal to "Du er innvilget barnepensjon fra ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". ",
-                        Language.Nynorsk to "Du er innvilga barnepensjon frå og med ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". ",
-                        Language.English to "You have been granted a children's pension ".expr() + formatertVirkningsdato + " because " + avdoedNavn + " is registered as deceased on "+ formatertDoedsdato + ". "
-                    )
+                    ifNotNull(avdoed) { avdoed ->
+                        val avdoedNavn = avdoed.navn
+                        val formatertDoedsdato = avdoed.doedsdato.format()
+
+                        textExpr(
+                            Language.Bokmal to "Du er innvilget barnepensjon fra ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". ",
+                            Language.Nynorsk to "Du er innvilga barnepensjon frå og med ".expr() + formatertVirkningsdato + " fordi " + avdoedNavn + " er registrert død " + formatertDoedsdato + ". ",
+                            Language.English to "You have been granted a children's pension ".expr() + formatertVirkningsdato + " because " + avdoedNavn + " is registered as deceased on "+ formatertDoedsdato + ". "
+                        )
+                    }.orShow {
+                        textExpr(
+                            Language.Bokmal to "Du er innvilget barnepensjon fra ".expr() + formatertVirkningsdato + ". ",
+                            Language.Nynorsk to "Du er innvilga barnepensjon frå og med ".expr() + formatertVirkningsdato + ". ",
+                            Language.English to "You have been granted a children's pension ".expr() + formatertVirkningsdato + ". "
+                        )
+                    }
+
                 }
 
                 showIf(harUtbetaling) {

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/BeregningAvBarnepensjon.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/BeregningAvBarnepensjon.kt
@@ -349,7 +349,7 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                                 ". The deceased's total contribution time amounts to " + aarTrygdetid.format() + " years.",
                     )
                 }.orShow {
-                    // TODO mangler tekster ved ukjent avdød
+                    // TODO støtter ikke to trygdetider med en ukjent og en kjent avdød. To ukjente skal ikke støttes i Gjenny
                 }
 
             }.orShow {
@@ -369,7 +369,17 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                                 "The deceased's total contribution time amounts to " + aarTrygdetid.format() + " years.",
                     )
                 }.orShow {
-                    // TODO mangler tekster ved ukjent avdød
+                    textExpr(
+                        Bokmal to "For å få full pensjon må minst en av foreldrene ha hatt minst 40 års trygdetid. ".expr() +
+                                "Trygdetid over 40 år blir ikke tatt med i beregningen. Avdødes samlede trygdetid er " +
+                                "beregnet til " + aarTrygdetid.format() + " år.",
+                        Nynorsk to "For at det skal kunne betalast ut full pensjon, må minst éin av foreldra ".expr() +
+                                "ha hatt minimum 40 års trygdetid. Trygdetid over 40 år blir ikkje teken med i utrekninga. " +
+                                "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år",
+                        English to "To achieve a full pension, at least one of the parents must have accumulated 40 years ".expr() +
+                                "of contribution time. Contribution time above 40 years of coverage is not included in the calculation. " +
+                                "The deceased's total contribution time amounts to " + aarTrygdetid.format() + " years.",
+                    )
                 }
             }
         }
@@ -435,7 +445,17 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                                 "of " + navnAvdoed + ". The deceased total contribution time amounts to " + aarTrygdetid.format() + " years.",
                     )
                 }.orShow {
-                    // TODO mangler tekster ved ukjent avdød
+                    textExpr(
+                        Bokmal to "For å få full pensjon må minst en av foreldrene ha hatt minst 40 års trygdetid. ".expr() +
+                                "Trygdetid over 40 år blir ikke tatt med i beregningen. Avdødes samlede trygdetid er beregnet " +
+                                "til " + aarTrygdetid.format() + " år.",
+                        Nynorsk to "For at det skal kunne betalast ut full pensjon, må minst éin av foreldra ha hatt ".expr() +
+                                "minimum 40 års trygdetid. Trygdetid over 40 år blir ikkje teken med i utrekninga. " +
+                                "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år.",
+                        English to "To achieve a full pension, at least one of the parents must have accumulated ".expr() +
+                                "40 years of contribution time. Contribution time above 40 years of coverage is not included " +
+                                "in the calculation. The deceased total contribution time amounts to " + aarTrygdetid.format() + " years.",
+                    )
                 }
 
             }
@@ -563,7 +583,20 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                         )
                     }
                 }.orShow {
-                    // TODO mangler tekster ved ukjent avdød
+                    paragraph {
+                        textExpr(
+                            Bokmal to "For å få full pensjon må avdødes trygdetid være beregnet til minst 40 år. ".expr() +
+                                    "Trygdetid over 40 år blir ikke tatt med i beregningen. Avdødes samlede trygdetid er beregnet " +
+                                    "til " + aarTrygdetid.format() + " år.",
+                            Nynorsk to "For at det skal kunne betalast ut full pensjon, må minst éin av foreldra ha hatt ".expr() +
+                                    "minimum 40 års trygdetid. Trygdetid over 40 år blir ikkje teken med i utrekninga. " +
+                                    "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år.",
+                            English to "To achieve a full pension, at least one of the parents must have accumulated ".expr() +
+                                    "40 years of contribution time. Contribution time above 40 years of coverage is not " +
+                                    "included in the calculation. The deceased total contribution time amounts to " +
+                                    aarTrygdetid.format() + " years. ",
+                        )
+                    }
                 }
             }
             paragraph {
@@ -610,7 +643,7 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                                     "beregningen av trygdetid.",
                             Nynorsk to "Frå ".expr() + andreVirk.format() + " er det den andre forelderen sin " +
                                     "trygdetid som er brukt i beregningen. Avdødes samlede trygdetid er beregnet til " +
-                                    aarTrygdetid.format() + " år ved nasjonal opptjening. Dettefordi den gir beste " +
+                                    aarTrygdetid.format() + " år ved nasjonal opptjening. Dette fordi den gir beste " +
                                     "utrekning av trygdetid.",
                             English to "From ".expr() + andreVirk.format() + " it is the other parent's total " +
                                     "contribution time that has been used in the calculation. The deceased's total " +

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/BeregningAvBarnepensjon.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/BeregningAvBarnepensjon.kt
@@ -1,32 +1,17 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg.barnepensjon
 
 import no.nav.pensjon.brev.model.format
-import no.nav.pensjon.brev.template.AttachmentTemplate
+import no.nav.pensjon.brev.template.*
 import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Text.FontType
-import no.nav.pensjon.brev.template.Expression
-import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
-import no.nav.pensjon.brev.template.Language.Bokmal
-import no.nav.pensjon.brev.template.Language.English
-import no.nav.pensjon.brev.template.Language.Nynorsk
-import no.nav.pensjon.brev.template.LanguageSupport
-import no.nav.pensjon.brev.template.createAttachment
+import no.nav.pensjon.brev.template.Language.*
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
-import no.nav.pensjon.brev.template.dsl.expression.and
-import no.nav.pensjon.brev.template.dsl.expression.equalTo
-import no.nav.pensjon.brev.template.dsl.expression.expr
-import no.nav.pensjon.brev.template.dsl.expression.format
-import no.nav.pensjon.brev.template.dsl.expression.greaterThan
-import no.nav.pensjon.brev.template.dsl.expression.ifElse
-import no.nav.pensjon.brev.template.dsl.expression.isNotEmpty
-import no.nav.pensjon.brev.template.dsl.expression.not
-import no.nav.pensjon.brev.template.dsl.expression.or
-import no.nav.pensjon.brev.template.dsl.expression.plus
+import no.nav.pensjon.brev.template.dsl.expression.*
 import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
 import no.nav.pensjon.brev.template.dsl.newText
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.dsl.textExpr
 import no.nav.pensjon.brevbaker.api.model.Kroner
-import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregning
+import no.nav.pensjon.etterlatte.maler.*
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningSelectors.antallBarn
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningSelectors.beregningsperioder
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningSelectors.bruktTrygdetid
@@ -36,15 +21,11 @@ import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningSelectors.grunnbeloe
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningSelectors.harForskjelligMetode
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningSelectors.innhold
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningSelectors.trygdetid
-import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiode
-import no.nav.pensjon.etterlatte.maler.BeregningsMetode
-import no.nav.pensjon.etterlatte.maler.ForskjelligTrygdetid
 import no.nav.pensjon.etterlatte.maler.ForskjelligTrygdetidSelectors.erForskjellig
 import no.nav.pensjon.etterlatte.maler.ForskjelligTrygdetidSelectors.foersteTrygdetid
 import no.nav.pensjon.etterlatte.maler.ForskjelligTrygdetidSelectors.foersteVirkningsdato
 import no.nav.pensjon.etterlatte.maler.ForskjelligTrygdetidSelectors.senereVirkningsdato
 import no.nav.pensjon.etterlatte.maler.ForskjelligTrygdetidSelectors.tilOgIkkeMedSenereVirkningsdato
-import no.nav.pensjon.etterlatte.maler.IntBroek
 import no.nav.pensjon.etterlatte.maler.TrygdetidSelectors.beregnetTrygdetidAar
 import no.nav.pensjon.etterlatte.maler.TrygdetidSelectors.beregningsMetodeAnvendt
 import no.nav.pensjon.etterlatte.maler.TrygdetidSelectors.beregningsMetodeFraGrunnlag
@@ -52,9 +33,6 @@ import no.nav.pensjon.etterlatte.maler.TrygdetidSelectors.mindreEnnFireFemtedele
 import no.nav.pensjon.etterlatte.maler.TrygdetidSelectors.navnAvdoed
 import no.nav.pensjon.etterlatte.maler.TrygdetidSelectors.prorataBroek
 import no.nav.pensjon.etterlatte.maler.TrygdetidSelectors.trygdetidsperioder
-import no.nav.pensjon.etterlatte.maler.Trygdetidsperiode
-import no.nav.pensjon.etterlatte.maler.formatBroek
-import no.nav.pensjon.etterlatte.maler.konverterElementerTilBrevbakerformat
 import no.nav.pensjon.etterlatte.maler.vedlegg.Trygdetidstabell
 
 
@@ -90,7 +68,9 @@ val beregningAvBarnepensjonGammeltOgNyttRegelverk: AttachmentTemplate<LangBokmal
     }
     forEach(trygdetid) {
         showIf(it.trygdetidsperioder.isNotEmpty()) {
-            perioderMedRegistrertTrygdetid(it.navnAvdoed, it.trygdetidsperioder, it.beregningsMetodeAnvendt)
+            ifNotNull(it.navnAvdoed) { navnAvdoed ->
+                perioderMedRegistrertTrygdetid(navnAvdoed, it.trygdetidsperioder, it.beregningsMetodeAnvendt)
+            }
         }
     }
     meldFraTilNav()
@@ -147,7 +127,9 @@ val beregningAvBarnepensjonNyttRegelverk: AttachmentTemplate<LangBokmalNynorskEn
     }
     forEach(trygdetid){
 	    showIf(it.trygdetidsperioder.isNotEmpty()) {
-		    perioderMedRegistrertTrygdetid(it.navnAvdoed, it.trygdetidsperioder, it.beregningsMetodeAnvendt)
+            ifNotNull(it.navnAvdoed) { navnAvdoed ->
+		        perioderMedRegistrertTrygdetid(navnAvdoed, it.trygdetidsperioder, it.beregningsMetodeAnvendt)
+            }
 	    }
     }
     meldFraTilNav()
@@ -291,7 +273,7 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
 }
 
 private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, BarnepensjonBeregning>.trygdetid(
-    navnAvdoed: Expression<String>,
+    navnAvdoed: Expression<String?>,
     aarTrygdetid: Expression<Int>,
     prorataBroek: Expression<IntBroek?>,
     beregningsMetodeFraGrunnlag: Expression<BeregningsMetode>,
@@ -338,49 +320,57 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                             "The deceased's total calculated contribution time is " + aarTrygdetid.format() + " years.",
                 )
             }.orIfNotNull(forskjelligTrygdetid) { tidligTrygdetidPeriode ->
-                val foersteNavn = tidligTrygdetidPeriode.foersteTrygdetid.navnAvdoed
-                val foersteVirkningsdato = tidligTrygdetidPeriode.foersteVirkningsdato.format()
-                val senereVirkningsdato = tidligTrygdetidPeriode.senereVirkningsdato.format()
+                ifNotNull(tidligTrygdetidPeriode.foersteTrygdetid.navnAvdoed, navnAvdoed) { foersteNavn, nesteNavn ->
+                    val foersteVirkningsdato = tidligTrygdetidPeriode.foersteVirkningsdato.format()
+                    val senereVirkningsdato = tidligTrygdetidPeriode.senereVirkningsdato.format()
 
-                textExpr(
-                    Bokmal to "For å få full pensjon må avdødes trygdetid være beregnet til minst 40 år. ".expr() +
-                            "Når begge foreldrene er døde, må minst en av foreldrene ha minst 40 års trygdetid. " +
-                            "Trygdetid over 40 år blir ikke tatt med i beregningen. " +
-                            "Pensjonen din er beregnet etter " + foersteNavn + " fra " +
-                            foersteVirkningsdato + ". Fra " + senereVirkningsdato + " er pensjonen din beregnet " +
-                            "etter trygdetiden til " + navnAvdoed + ". Avdødes samlede " +
-                            "trygdetid er beregnet til " + aarTrygdetid.format() +  " år. ",
-                    Nynorsk to "For å få full pensjon må den utrekna trygdetida til avdøde vere minst 40 år. ".expr() +
-                            "For at det skal kunne betalast ut full pensjon når begge foreldra er død, må minst éin " +
-                            "av foreldra ha hatt minimum 40 års trygdetid. " +
-                            "Pensjonen din er rekna ut etter trygdetida til " + foersteNavn  + " frå " +
-                            foersteVirkningsdato + ". Frå " + senereVirkningsdato + " er pensjonen rekna ut etter " +
-                            "trygdetida til " + navnAvdoed + ". " +
-                            "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år.",
-                    English to "To be entitled to a full pension, the deceased must have accumulated at ".expr() +
-                            "least 40 years of contribution time. When both parents are dead, at least one of the " +
-                            "parents must have at least 40 years of National Insurance coverage. Contribution time " +
-                            "above 40 years of coverage is not included in the calculation." +
-                            "Your pension has been calculated based on the contribution time of " + foersteNavn +
-                            " from " + foersteVirkningsdato + ". From the " + senereVirkningsdato + " your pension " +
-                            "is calculated based on the contribution time of " + navnAvdoed +
-                            ". The deceased's total contribution time amounts to " + aarTrygdetid.format() + " years.",
-                )
+                    textExpr(
+                        Bokmal to "For å få full pensjon må avdødes trygdetid være beregnet til minst 40 år. ".expr() +
+                                "Når begge foreldrene er døde, må minst en av foreldrene ha minst 40 års trygdetid. " +
+                                "Trygdetid over 40 år blir ikke tatt med i beregningen. " +
+                                "Pensjonen din er beregnet etter " + foersteNavn + " fra " +
+                                foersteVirkningsdato + ". Fra " + senereVirkningsdato + " er pensjonen din beregnet " +
+                                "etter trygdetiden til " + nesteNavn + ". Avdødes samlede " +
+                                "trygdetid er beregnet til " + aarTrygdetid.format() +  " år. ",
+                        Nynorsk to "For å få full pensjon må den utrekna trygdetida til avdøde vere minst 40 år. ".expr() +
+                                "For at det skal kunne betalast ut full pensjon når begge foreldra er død, må minst éin " +
+                                "av foreldra ha hatt minimum 40 års trygdetid. " +
+                                "Pensjonen din er rekna ut etter trygdetida til " + foersteNavn  + " frå " +
+                                foersteVirkningsdato + ". Frå " + senereVirkningsdato + " er pensjonen rekna ut etter " +
+                                "trygdetida til " + nesteNavn + ". " +
+                                "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år.",
+                        English to "To be entitled to a full pension, the deceased must have accumulated at ".expr() +
+                                "least 40 years of contribution time. When both parents are dead, at least one of the " +
+                                "parents must have at least 40 years of National Insurance coverage. Contribution time " +
+                                "above 40 years of coverage is not included in the calculation." +
+                                "Your pension has been calculated based on the contribution time of " + foersteNavn +
+                                " from " + foersteVirkningsdato + ". From the " + senereVirkningsdato + " your pension " +
+                                "is calculated based on the contribution time of " + nesteNavn +
+                                ". The deceased's total contribution time amounts to " + aarTrygdetid.format() + " years.",
+                    )
+                }.orShow {
+                    // TODO mangler tekster ved ukjent avdød
+                }
+
             }.orShow {
-                textExpr(
-                    Bokmal to "For å få full pensjon må minst en av foreldrene ha hatt minst 40 års trygdetid. ".expr() +
-                            "Trygdetid over 40 år blir ikke tatt med i beregningen. Pensjonen din er beregnet " +
-                            "etter trygdetiden til " + navnAvdoed + ". Avdødes samlede trygdetid er " +
-                            "beregnet til " + aarTrygdetid.format() + " år.",
-                    Nynorsk to "For at det skal kunne betalast ut full pensjon, må minst éin av foreldra ".expr() +
-                            "ha hatt minimum 40 års trygdetid. Trygdetid over 40 år blir ikkje teken med i utrekninga. " +
-                            "Pensjonen din er rekna ut etter trygdetida til " + navnAvdoed  + ". " +
-                            "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år",
-                    English to "To achieve a full pension, at least one of the parents must have accumulated 40 years ".expr() +
-                            "of contribution time. Contribution time above 40 years of coverage is not included in the calculation. " +
-                            "Your pension has been calculated based on the contribution time of " + navnAvdoed + ". " +
-                            "The deceased's total contribution time amounts to " + aarTrygdetid.format() + " years.",
-                )
+                ifNotNull(navnAvdoed) { navnAvdoed ->
+                    textExpr(
+                        Bokmal to "For å få full pensjon må minst en av foreldrene ha hatt minst 40 års trygdetid. ".expr() +
+                                "Trygdetid over 40 år blir ikke tatt med i beregningen. Pensjonen din er beregnet " +
+                                "etter trygdetiden til " + navnAvdoed + ". Avdødes samlede trygdetid er " +
+                                "beregnet til " + aarTrygdetid.format() + " år.",
+                        Nynorsk to "For at det skal kunne betalast ut full pensjon, må minst éin av foreldra ".expr() +
+                                "ha hatt minimum 40 års trygdetid. Trygdetid over 40 år blir ikkje teken med i utrekninga. " +
+                                "Pensjonen din er rekna ut etter trygdetida til " + navnAvdoed  + ". " +
+                                "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år",
+                        English to "To achieve a full pension, at least one of the parents must have accumulated 40 years ".expr() +
+                                "of contribution time. Contribution time above 40 years of coverage is not included in the calculation. " +
+                                "Your pension has been calculated based on the contribution time of " + navnAvdoed + ". " +
+                                "The deceased's total contribution time amounts to " + aarTrygdetid.format() + " years.",
+                    )
+                }.orShow {
+                    // TODO mangler tekster ved ukjent avdød
+                }
             }
         }
         showIf(mindreEnnFireFemtedelerAvOpptjeningstiden) {
@@ -429,20 +419,25 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                             "years of coverage is not included in the calculation.",
                 )
             }.orShow {
-                textExpr(
-                    Bokmal to "For å få full pensjon må minst en av foreldrene ha hatt minst 40 års trygdetid. ".expr() +
-                            "Trygdetid over 40 år blir ikke tatt med i beregningen. Pensjonen din er beregnet etter " +
-                            "trygdetiden til " + navnAvdoed + ". Avdødes samlede trygdetid er beregnet " +
-                            "til " + aarTrygdetid.format() + " år.",
-                    Nynorsk to "For at det skal kunne betalast ut full pensjon, må minst éin av foreldra ha hatt ".expr() +
-                            "minimum 40 års trygdetid. Trygdetid over 40 år blir ikkje teken med i utrekninga. " +
-                            "Pensjonen din er rekna ut etter trygdetida til " + navnAvdoed + ". " +
-                            "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år.",
-                    English to "To achieve a full pension, at least one of the parents must have accumulated ".expr() +
-                            "40 years of contribution time. Contribution time above 40 years of coverage is not included " +
-                            "in the calculation. Your pension has been calculated based on the contribution time " +
-                            "of " + navnAvdoed + ". The deceased total contribution time amounts to " + aarTrygdetid.format() + " years.",
-                )
+                ifNotNull(navnAvdoed) { navnAvdoed ->
+                    textExpr(
+                        Bokmal to "For å få full pensjon må minst en av foreldrene ha hatt minst 40 års trygdetid. ".expr() +
+                                "Trygdetid over 40 år blir ikke tatt med i beregningen. Pensjonen din er beregnet etter " +
+                                "trygdetiden til " + navnAvdoed + ". Avdødes samlede trygdetid er beregnet " +
+                                "til " + aarTrygdetid.format() + " år.",
+                        Nynorsk to "For at det skal kunne betalast ut full pensjon, må minst éin av foreldra ha hatt ".expr() +
+                                "minimum 40 års trygdetid. Trygdetid over 40 år blir ikkje teken med i utrekninga. " +
+                                "Pensjonen din er rekna ut etter trygdetida til " + navnAvdoed + ". " +
+                                "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år.",
+                        English to "To achieve a full pension, at least one of the parents must have accumulated ".expr() +
+                                "40 years of contribution time. Contribution time above 40 years of coverage is not included " +
+                                "in the calculation. Your pension has been calculated based on the contribution time " +
+                                "of " + navnAvdoed + ". The deceased total contribution time amounts to " + aarTrygdetid.format() + " years.",
+                    )
+                }.orShow {
+                    // TODO mangler tekster ved ukjent avdød
+                }
+
             }
         }
         ifNotNull(forskjelligTrygdetid) { forskjelligTrygdetid ->
@@ -549,22 +544,26 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                     )
                 }
             }.orShow {
-                paragraph {
-                    textExpr(
-                        Bokmal to "For å få full pensjon må avdødes trygdetid være beregnet til minst 40 år. ".expr() +
-                                "Trygdetid over 40 år blir ikke tatt med i beregningen. Pensjonen din er beregnet etter " +
-                                "trygdetiden til " + navnAvdoed + ". Avdødes samlede trygdetid er beregnet " +
-                                "til " + aarTrygdetid.format() + " år.",
-                        Nynorsk to "For at det skal kunne betalast ut full pensjon, må minst éin av foreldra ha hatt ".expr() +
-                                "minimum 40 års trygdetid. Trygdetid over 40 år blir ikkje teken med i utrekninga. " +
-                                "Pensjonen din er rekna ut etter trygdetida til " + navnAvdoed + ". " +
-                                "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år.",
-                        English to "To achieve a full pension, at least one of the parents must have accumulated ".expr() +
-                                "40 years of contribution time. Contribution time above 40 years of coverage is not " +
-                                "included in the calculation. Your pension has been calculated based on the contribution " +
-                                "time of " + navnAvdoed + ". The deceased total contribution time amounts to " +
-                                aarTrygdetid.format() + " years. ",
-                    )
+                ifNotNull(navnAvdoed) { navnAvdoed ->
+                    paragraph {
+                        textExpr(
+                            Bokmal to "For å få full pensjon må avdødes trygdetid være beregnet til minst 40 år. ".expr() +
+                                    "Trygdetid over 40 år blir ikke tatt med i beregningen. Pensjonen din er beregnet etter " +
+                                    "trygdetiden til " + navnAvdoed + ". Avdødes samlede trygdetid er beregnet " +
+                                    "til " + aarTrygdetid.format() + " år.",
+                            Nynorsk to "For at det skal kunne betalast ut full pensjon, må minst éin av foreldra ha hatt ".expr() +
+                                    "minimum 40 års trygdetid. Trygdetid over 40 år blir ikkje teken med i utrekninga. " +
+                                    "Pensjonen din er rekna ut etter trygdetida til " + navnAvdoed + ". " +
+                                    "Avdøde hadde ei samla trygdetid på " + aarTrygdetid.format() + " år.",
+                            English to "To achieve a full pension, at least one of the parents must have accumulated ".expr() +
+                                    "40 years of contribution time. Contribution time above 40 years of coverage is not " +
+                                    "included in the calculation. Your pension has been calculated based on the contribution " +
+                                    "time of " + navnAvdoed + ". The deceased total contribution time amounts to " +
+                                    aarTrygdetid.format() + " years. ",
+                        )
+                    }
+                }.orShow {
+                    // TODO mangler tekster ved ukjent avdød
                 }
             }
             paragraph {
@@ -609,8 +608,10 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
                                     "trygdetid som er brukt i beregningen. Avdødes samlede trygdetid er beregnet til " +
                                     aarTrygdetid.format() + " år ved nasjonal opptjening. Dette gir den beste " +
                                     "beregningen av trygdetid.",
-                            Nynorsk to "Pensjonen din er rekna ut etter trygdetida til ".expr() +
-                                    navnAvdoed + " frå " + andreVirk.format() + " fordi den gir beste utrekning av trygdetid.",
+                            Nynorsk to "Frå ".expr() + andreVirk.format() + " er det den andre forelderen sin " +
+                                    "trygdetid som er brukt i beregningen. Avdødes samlede trygdetid er beregnet til " +
+                                    aarTrygdetid.format() + " år ved nasjonal opptjening. Dettefordi den gir beste " +
+                                    "utrekning av trygdetid.",
                             English to "From ".expr() + andreVirk.format() + " it is the other parent's total " +
                                     "contribution time that has been used in the calculation. The deceased's total " +
                                     "calculated contribution time is " + aarTrygdetid.format() + " years of national " +


### PR DESCRIPTION
Legger til støtte for en ukjent avdød i barnepensjonsbrev.

Gjelder innledning i følgende brev, samt beregningsvedlegg 
- Innvilgelse barnepensjon
- Innvilgelse barnepensjon foreldreløs
- Omregning barnepensjon