### PR TITLE
Tar bort etterlatte-spesifikk exceptionklasse

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/LetterResource.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/LetterResource.kt
@@ -1,14 +1,13 @@
 package no.nav.pensjon.etterlatte
 
 import io.ktor.server.plugins.*
+import no.nav.pensjon.brev.api.ParseLetterDataException
 import no.nav.pensjon.brev.api.toLanguage
 import no.nav.pensjon.brev.template.Language
 import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.brev.template.LetterTemplate
 import no.nav.pensjon.brev.template.jacksonObjectMapper
 import no.nav.pensjon.brevbaker.api.model.Felles
-
-class ParseLetterDataException(msg: String, cause: Exception): Exception(msg, cause)
 
 class LetterResource(private val templateResource: TemplateResource = TemplateResource()) {
     private val objectMapper = jacksonObjectMapper()


### PR DESCRIPTION
Akkurat den samme fins generelt i brevbaker. Viss også etterlatte-koden heller bruker den, blir feilen plukka opp av exceptionhandteringa vår og returnert som ein bad request, som er betre å forholde seg til for etterlatte, og vi slepp at det kjem som støy i loggane våre