### PR TITLE
Tar bort eksplisitt typing av brevkode frå malane, for å få betre oversikt

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/ForhaandsvarselEtteroppgjoerUfoeretrygdAuto.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/ForhaandsvarselEtteroppgjoerUfoeretrygdAuto.kt
@@ -28,7 +28,7 @@ import no.nav.pensjon.brevbaker.api.model.*
 @TemplateModelHelpers
 object ForhaandsvarselEtteroppgjoerUfoeretrygdAuto : AutobrevTemplate<ForhaandsvarselEtteroppgjoerUfoeretrygdDto> {
 
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.UT_EO_FORHAANDSVARSEL_FEILUTBETALING_AUTO
+    override val kode = Brevkode.AutoBrev.UT_EO_FORHAANDSVARSEL_FEILUTBETALING_AUTO
 
     override val template = createTemplate(
             name = kode.name,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OmsorgEgenAuto.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OmsorgEgenAuto.kt
@@ -20,12 +20,11 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.dsl.textExpr
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata.Brevtype.INFORMASJONSBREV
-import no.nav.pensjon.brevbaker.api.model.LetterMetadata.Brevtype.VEDTAKSBREV
 
 @TemplateModelHelpers
 object OmsorgEgenAuto : AutobrevTemplate<OmsorgEgenAutoDto> {
 
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_OMSORG_EGEN_AUTO
+    override val kode = Brevkode.AutoBrev.PE_OMSORG_EGEN_AUTO
 
     override val template = createTemplate(
         name = kode.name,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAuto.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAuto.kt
@@ -66,7 +66,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata.Brevtype.VEDTAKSBREV
 @TemplateModelHelpers
 object OpphoerBarnetilleggAuto : AutobrevTemplate<OpphoerBarnetilleggAutoDto> {
 
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.UT_OPPHOER_BT_AUTO
+    override val kode = Brevkode.AutoBrev.UT_OPPHOER_BT_AUTO
 
     override val template = createTemplate(
         name = kode.name,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnslig.kt
@@ -58,7 +58,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata.Brevtype.VEDTAKSBREV
 @TemplateModelHelpers
 object UfoerOmregningEnslig : AutobrevTemplate<UfoerOmregningEnsligDto> {
 
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.UT_OMREGNING_ENSLIG_AUTO
+    override val kode = Brevkode.AutoBrev.UT_OMREGNING_ENSLIG_AUTO
 
     override val template = createTemplate(
         name = kode.name,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UngUfoerAuto.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/UngUfoerAuto.kt
@@ -31,7 +31,7 @@ import no.nav.pensjon.brevbaker.api.model.*
 @TemplateModelHelpers
 object UngUfoerAuto : AutobrevTemplate<UngUfoerAutoDto> {
 
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.UT_UNG_UFOER_20_AAR_AUTO
+    override val kode = Brevkode.AutoBrev.UT_UNG_UFOER_20_AAR_AUTO
 
     override val template = createTemplate(
         name = kode.name,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocAlderspensjonFraFolketrygden.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocAlderspensjonFraFolketrygden.kt
@@ -14,7 +14,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 
 object AdhocAlderspensjonFraFolketrygden : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_AP_ADHOC_2024_REGLERENDRET_GJR_AP_MNTINDV
+    override val kode = Brevkode.AutoBrev.PE_AP_ADHOC_2024_REGLERENDRET_GJR_AP_MNTINDV
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocAlderspensjonFraFolketrygden2.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocAlderspensjonFraFolketrygden2.kt
@@ -11,7 +11,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 @TemplateModelHelpers
 object AdhocAlderspensjonFraFolketrygden2 : AutobrevTemplate<EmptyBrevdata> {
 
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_AP_ADHOC_2024_GJR_AP_MNTINDV_2
+    override val kode = Brevkode.AutoBrev.PE_AP_ADHOC_2024_GJR_AP_MNTINDV_2
 
     override val template = createTemplate(
         name = kode.name,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocFeilEtteroppgjoer2023.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocFeilEtteroppgjoer2023.kt
@@ -12,7 +12,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 
 object AdhocFeilEtteroppgjoer2023 : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_ADHOC_2024_FEIL_ETTEROPPGJOER_2023
+    override val kode = Brevkode.AutoBrev.PE_ADHOC_2024_FEIL_ETTEROPPGJOER_2023
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocGjenlevendEtter1970.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocGjenlevendEtter1970.kt
@@ -14,7 +14,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 
 object AdhocGjenlevendEtter1970 : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_ADHOC_2024_VEDTAK_GJENLEVENDETTER1970
+    override val kode = Brevkode.AutoBrev.PE_ADHOC_2024_VEDTAK_GJENLEVENDETTER1970
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocInformasjonHvilendeRett4Aar.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocInformasjonHvilendeRett4Aar.kt
@@ -12,7 +12,7 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 object AdhocInformasjonHvilendeRett4Aar : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_UT_ADHOC_2024_INFO_HVILENDE_RETT_4_AAR
+    override val kode = Brevkode.AutoBrev.PE_UT_ADHOC_2024_INFO_HVILENDE_RETT_4_AAR
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocMidlertidigOpphoerHvilenderett10Aar.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocMidlertidigOpphoerHvilenderett10Aar.kt
@@ -13,7 +13,7 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 object AdhocMidlertidigOpphoerHvilenderett10Aar : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_UT_ADHOC_2024_MIDL_OPPHOER_HVILENDE_RETT_10_AAR
+    override val kode = Brevkode.AutoBrev.PE_UT_ADHOC_2024_MIDL_OPPHOER_HVILENDE_RETT_10_AAR
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocUfoeretrygdEtterbetalingDagpenger.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocUfoeretrygdEtterbetalingDagpenger.kt
@@ -15,7 +15,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 
 object AdhocUfoeretrygdEtterbetalingDagpenger : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.UT_ADHOC_UFOERETRYGD_ETTERBETALING_DAGPENGER
+    override val kode = Brevkode.AutoBrev.UT_ADHOC_UFOERETRYGD_ETTERBETALING_DAGPENGER
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocUfoeretrygdKombiDagpenger.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocUfoeretrygdKombiDagpenger.kt
@@ -13,7 +13,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 
 object AdhocUfoeretrygdKombiDagpenger : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.UT_ADHOC_UFOERETRYGD_KOMBI_DAGPENGER
+    override val kode = Brevkode.AutoBrev.UT_ADHOC_UFOERETRYGD_KOMBI_DAGPENGER
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocUfoeretrygdKombiDagpengerInntektsavkorting.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocUfoeretrygdKombiDagpengerInntektsavkorting.kt
@@ -13,7 +13,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 
 object AdhocUfoeretrygdKombiDagpengerInntektsavkorting : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.UT_ADHOC_UFOERETRYGD_KOMBI_DAGPENGER_AVKORTNING
+    override val kode = Brevkode.AutoBrev.UT_ADHOC_UFOERETRYGD_KOMBI_DAGPENGER_AVKORTNING
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocUfoeretrygdVarselOpphoerEktefelletillegg.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocUfoeretrygdVarselOpphoerEktefelletillegg.kt
@@ -11,7 +11,7 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 object AdhocUfoeretrygdVarselOpphoerEktefelletillegg : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.UT_ADHOC_VARSEL_OPPHOER_EKTEFELLETILLEGG
+    override val kode = Brevkode.AutoBrev.UT_ADHOC_VARSEL_OPPHOER_EKTEFELLETILLEGG
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocVarselOpphoerMedHvilendeRett.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocVarselOpphoerMedHvilendeRett.kt
@@ -12,7 +12,7 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 object AdhocVarselOpphoerMedHvilendeRett : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.UT_ADHOC_VARSEL_OPPHOER_MED_HVILENDE_RETT
+    override val kode = Brevkode.AutoBrev.UT_ADHOC_VARSEL_OPPHOER_MED_HVILENDE_RETT
     override val template: LetterTemplate<*, EmptyBrevdata> = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocVarselTilBrukerForsoergingstilleggIkkeTilUtbetaling.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocVarselTilBrukerForsoergingstilleggIkkeTilUtbetaling.kt
@@ -16,7 +16,7 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 object AdhocVarselTilBrukerForsoergingstilleggIkkeTilUtbetaling : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_AP_2024_IKKEUTBET_FT_VARSEL_OPPH
+    override val kode = Brevkode.AutoBrev.PE_AP_2024_IKKEUTBET_FT_VARSEL_OPPH
     override val template = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocVarselTilBrukerMedForsoergingstilleggTilUtbetaling.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocVarselTilBrukerMedForsoergingstilleggTilUtbetaling.kt
@@ -15,7 +15,7 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 object AdhocVarselTilBrukerMedForsoergingstilleggTilUtbetaling : AutobrevTemplate<EmptyBrevdata> {
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_AP_2024_UTBET_FT_VARSEL_OPPH
+    override val kode = Brevkode.AutoBrev.PE_AP_2024_UTBET_FT_VARSEL_OPPH
     override val template = createTemplate(
         name = kode.name,
         letterDataType = EmptyBrevdata::class,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/FeilUtsendingAvGjenlevenderett.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/adhoc/FeilUtsendingAvGjenlevenderett.kt
@@ -12,7 +12,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 @TemplateModelHelpers
 object FeilUtsendingAvGjenlevenderett : AutobrevTemplate<EmptyBrevdata> {
 
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_ADHOC_2024_FEIL_INFOBREV_AP_SENDT_BRUKER
+    override val kode = Brevkode.AutoBrev.PE_ADHOC_2024_FEIL_INFOBREV_AP_SENDT_BRUKER
 
     override val template = createTemplate(
         name = kode.name,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/AvslagUfoeretrygd.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/AvslagUfoeretrygd.kt
@@ -27,7 +27,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 object AvslagUfoeretrygd : RedigerbarTemplate<AvslagUfoeretrygdDto> {
 
     // PE_UT_04_104
-    override val kode: Brevkode.Redigerbar = Brevkode.Redigerbar.UT_AVSLAG_UFOERETRYGD
+    override val kode = Brevkode.Redigerbar.UT_AVSLAG_UFOERETRYGD
     override val kategori = TemplateDescription.Brevkategori.FOERSTEGANGSBEHANDLING
     override val brevkontekst = TemplateDescription.Brevkontekst.VEDTAK
     override val sakstyper = setOf(Sakstype.UFOREP)

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/example/DesignReferenceLetter.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/example/DesignReferenceLetter.kt
@@ -10,7 +10,7 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 
 object DesignReferenceLetter : AutobrevTemplate<LetterExampleDto> {
 
-    override val kode: Brevkode.AutoBrev = Brevkode.AutoBrev.PE_OMSORG_EGEN_AUTO
+    override val kode = Brevkode.AutoBrev.PE_OMSORG_EGEN_AUTO
 
     override val template = createTemplate(
         name = "EKSEMPEL_BREV", //Letter ID


### PR DESCRIPTION
Og for å få meir oversiktlege PR-ar når det kjem faktiske endringar igjen (typen må uansett endrast bort frå `Brevkode.AutoBrev` når vi går over til interfaces)