### PR TITLE
TexLive ser ut til å ha gått over frå x86_64 til aarch64, så oppdaterer dockerfila vår ut frå det

### DIFF
--- a/pdf-bygger/latex.Dockerfile
+++ b/pdf-bygger/latex.Dockerfile
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.source="https://github.com/navikt/pensjonsbrev/la
 LABEL org.opencontainers.image.description="XeLaTeX installation with required packages for Navs letter template"
 LABEL org.opencontainers.image.title="XeLaTeX"
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
-ENV PATH="${PATH}:/app/tex/bin/x86_64-linux/"
+ENV PATH="${PATH}:/app/tex/bin/aarch64-linux/"
 
 #Download and install tlmgr (texlive package manager)
 RUN apt -y --allow-releaseinfo-change -o Acquire::Check-Valid-Until=false update


### PR DESCRIPTION
Eksperimenterte litt lokalt og fekk feil under bygging av dockerfila på at tlmgr ikkje fantes, så fann eg etter litt leiting fila i aarch-mappa heller enn x86, og det gir jo ei slags meining i 2024.