### PR TITLE
Prøver å få dependabot til å takle interne avhengnadar.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 version: 2
 
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.GITHUB_TOKEN}}
+  gradle-artifactory:
+    type: maven-repository
+    url: https://maven.pkg.github.com/navikt/pensjonsbrev
+    username: ${{ github.repository_owner }}
+    password: ${{secrets.GITHUB_TOKEN}}
+
 updates:
   # ==============
   # KOTLIN BACKEND
@@ -18,6 +29,8 @@ updates:
       interval: "monthly"
       day: "sunday"
     open-pull-requests-limit: 10
+    registries:
+      - gradle-artifactory
     groups:
       tjenestebuss:
         patterns:


### PR DESCRIPTION
Gjeld vite-mode i frontend og brevbaker-api-model-common i gradle-backend, per no. Sett opp iht https://docs.github.com/en/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot#about-configuring-private-registries-for-dependabot