### PR TITLE
EY-4891 rydde opp i etterbetaling bp  

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -3,16 +3,6 @@ package no.nav.pensjon.etterlatte.maler
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.LocalDate
 
-data class BarnepensjonEtterbetaling(
-    val inneholderKrav: Boolean?,
-    val etterbetalingPeriodeValg: EtterbetalingPeriodeValg?,
-)
-
-enum class EtterbetalingPeriodeValg {
-    UNDER_3_MND,
-    FRA_3_MND,
-}
-
 data class OmstillingsstoenadEtterbetaling(
     val fraDato: LocalDate,
     val tilDato: LocalDate,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelse.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelse.kt
@@ -20,6 +20,7 @@ import no.nav.pensjon.etterlatte.maler.Hovedmal
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.beregning
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.bosattUtland
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.brukerUnder18Aar
+import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.erEtterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.erGjenoppretting
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.erMigrertYrkesskade
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.etterbetaling
@@ -45,7 +46,8 @@ data class BarnepensjonInnvilgelseDTO(
     val brukerUnder18Aar: Boolean,
     val erGjenoppretting: Boolean,
     val erMigrertYrkesskade: Boolean,
-    val etterbetaling: BarnepensjonEtterbetaling?,
+    val etterbetaling: BarnepensjonEtterbetaling?, // TODO: kan fjernes
+    val erEtterbetaling: Boolean,
     val frivilligSkattetrekk: Boolean,
     val harUtbetaling: Boolean,
     val kunNyttRegelverk: Boolean,
@@ -87,7 +89,7 @@ object BarnepensjonInnvilgelse : EtterlatteTemplate<BarnepensjonInnvilgelseDTO>,
             konverterElementerTilBrevbakerformat(innhold)
 
             showIf(harUtbetaling) {
-                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, bosattUtland, frivilligSkattetrekk))
+                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, erEtterbetaling, bosattUtland, frivilligSkattetrekk))
             }
             includePhrase(BarnepensjonFellesFraser.HvorLengeKanDuFaaBarnepensjon(erMigrertYrkesskade))
             includePhrase(BarnepensjonFellesFraser.MeldFraOmEndringer)

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelse.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelse.kt
@@ -13,7 +13,6 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.EtterlatteTemplate
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregning
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.Element
 import no.nav.pensjon.etterlatte.maler.FerdigstillingBrevDTO
 import no.nav.pensjon.etterlatte.maler.Hovedmal
@@ -23,7 +22,6 @@ import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnv
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.erEtterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.erGjenoppretting
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.erMigrertYrkesskade
-import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.etterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.frivilligSkattetrekk
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.harUtbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTOSelectors.innhold
@@ -46,7 +44,6 @@ data class BarnepensjonInnvilgelseDTO(
     val brukerUnder18Aar: Boolean,
     val erGjenoppretting: Boolean,
     val erMigrertYrkesskade: Boolean,
-    val etterbetaling: BarnepensjonEtterbetaling?, // TODO: kan fjernes
     val erEtterbetaling: Boolean,
     val frivilligSkattetrekk: Boolean,
     val harUtbetaling: Boolean,
@@ -89,7 +86,7 @@ object BarnepensjonInnvilgelse : EtterlatteTemplate<BarnepensjonInnvilgelseDTO>,
             konverterElementerTilBrevbakerformat(innhold)
 
             showIf(harUtbetaling) {
-                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, erEtterbetaling, bosattUtland, frivilligSkattetrekk))
+                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(erEtterbetaling, bosattUtland, frivilligSkattetrekk))
             }
             includePhrase(BarnepensjonFellesFraser.HvorLengeKanDuFaaBarnepensjon(erMigrertYrkesskade))
             includePhrase(BarnepensjonFellesFraser.MeldFraOmEndringer)

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelseForeldreloes.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelseForeldreloes.kt
@@ -13,7 +13,6 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.EtterlatteTemplate
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregning
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.Element
 import no.nav.pensjon.etterlatte.maler.FerdigstillingBrevDTO
 import no.nav.pensjon.etterlatte.maler.Hovedmal
@@ -23,7 +22,6 @@ import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonFore
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.erEtterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.erGjenoppretting
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.erMigrertYrkesskade
-import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.etterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.frivilligSkattetrekk
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.harUtbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.innhold
@@ -46,7 +44,6 @@ data class BarnepensjonForeldreloesDTO(
     val brukerUnder18Aar: Boolean,
     val erGjenoppretting: Boolean,
     val erMigrertYrkesskade: Boolean,
-    val etterbetaling: BarnepensjonEtterbetaling?, // TODO: kan fjernes
     val frivilligSkattetrekk: Boolean,
     val harUtbetaling: Boolean,
     val kunNyttRegelverk: Boolean,
@@ -96,7 +93,7 @@ object BarnepensjonInnvilgelseForeldreloes : EtterlatteTemplate<BarnepensjonFore
             konverterElementerTilBrevbakerformat(innhold)
 
             showIf(harUtbetaling) {
-                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, erEtterbetaling, bosattUtland, frivilligSkattetrekk))
+                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(erEtterbetaling, bosattUtland, frivilligSkattetrekk))
             }
             includePhrase(BarnepensjonFellesFraser.HvorLengeKanDuFaaBarnepensjon(erMigrertYrkesskade))
             includePhrase(BarnepensjonFellesFraser.MeldFraOmEndringer)

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelseForeldreloes.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/innvilgelse/BarnepensjonInnvilgelseForeldreloes.kt
@@ -20,6 +20,7 @@ import no.nav.pensjon.etterlatte.maler.Hovedmal
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.beregning
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.bosattUtland
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.brukerUnder18Aar
+import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.erEtterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.erGjenoppretting
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.erMigrertYrkesskade
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonForeldreloesDTOSelectors.etterbetaling
@@ -45,11 +46,12 @@ data class BarnepensjonForeldreloesDTO(
     val brukerUnder18Aar: Boolean,
     val erGjenoppretting: Boolean,
     val erMigrertYrkesskade: Boolean,
-    val etterbetaling: BarnepensjonEtterbetaling?,
+    val etterbetaling: BarnepensjonEtterbetaling?, // TODO: kan fjernes
     val frivilligSkattetrekk: Boolean,
     val harUtbetaling: Boolean,
     val kunNyttRegelverk: Boolean,
     val vedtattIPesys: Boolean,
+    val erEtterbetaling: Boolean
 ) : FerdigstillingBrevDTO
 
 
@@ -94,7 +96,7 @@ object BarnepensjonInnvilgelseForeldreloes : EtterlatteTemplate<BarnepensjonFore
             konverterElementerTilBrevbakerformat(innhold)
 
             showIf(harUtbetaling) {
-                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, bosattUtland, frivilligSkattetrekk))
+                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, erEtterbetaling, bosattUtland, frivilligSkattetrekk))
             }
             includePhrase(BarnepensjonFellesFraser.HvorLengeKanDuFaaBarnepensjon(erMigrertYrkesskade))
             includePhrase(BarnepensjonFellesFraser.MeldFraOmEndringer)

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/BarnepensjonOmregnetNyttRegelverkDTO.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/BarnepensjonOmregnetNyttRegelverkDTO.kt
@@ -18,7 +18,8 @@ data class BarnepensjonOmregnetNyttRegelverkFerdigDTO(
     override val innhold: List<Element>,
     val beregning: BarnepensjonBeregning,
     val frivilligSkattetrekk: Boolean,
-    val etterbetaling: BarnepensjonEtterbetaling?,
+    val etterbetaling: BarnepensjonEtterbetaling?, // TODO: kan fjernes
+    val erEtterbetaling: Boolean,
     val erUnder18Aar: Boolean,
     val erBosattUtlandet: Boolean,
 ) : FerdigstillingBrevDTO

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/BarnepensjonOmregnetNyttRegelverkDTO.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/BarnepensjonOmregnetNyttRegelverkDTO.kt
@@ -18,7 +18,6 @@ data class BarnepensjonOmregnetNyttRegelverkFerdigDTO(
     override val innhold: List<Element>,
     val beregning: BarnepensjonBeregning,
     val frivilligSkattetrekk: Boolean,
-    val etterbetaling: BarnepensjonEtterbetaling?, // TODO: kan fjernes
     val erEtterbetaling: Boolean,
     val erUnder18Aar: Boolean,
     val erBosattUtlandet: Boolean,

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/BarnepensjonOmregnetNyttRegelverkDTO.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/BarnepensjonOmregnetNyttRegelverkDTO.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.etterlatte.maler.barnepensjon.migrering
 
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregning
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.Element
 import no.nav.pensjon.etterlatte.maler.FerdigstillingBrevDTO
 import no.nav.pensjon.etterlatte.maler.RedigerbartUtfallBrevDTO

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverkFerdig.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverkFerdig.kt
@@ -18,7 +18,6 @@ import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregn
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.erBosattUtlandet
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.erEtterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.erUnder18Aar
-import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.etterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.frivilligSkattetrekk
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.innhold
 import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.BarnepensjonFellesFraser
@@ -55,7 +54,7 @@ object EnkeltVedtakOmregningNyttRegelverkFerdig : EtterlatteTemplate<Barnepensjo
         outline {
             konverterElementerTilBrevbakerformat(innhold)
 
-            includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, erEtterbetaling, erBosattUtlandet, frivilligSkattetrekk))
+            includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(erEtterbetaling, erBosattUtlandet, frivilligSkattetrekk))
             includePhrase(BarnepensjonFellesFraser.MeldFraOmEndringer)
             includePhrase(BarnepensjonFellesFraser.DuHarRettTilAaKlage)
             includePhrase(BarnepensjonFellesFraser.HarDuSpoersmaal(erUnder18Aar, erBosattUtlandet))

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverkFerdig.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/migrering/EnkeltVedtakOmregningNyttRegelverkFerdig.kt
@@ -16,6 +16,7 @@ import no.nav.pensjon.etterlatte.EtterlatteTemplate
 import no.nav.pensjon.etterlatte.maler.Hovedmal
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.beregning
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.erBosattUtlandet
+import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.erEtterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.erUnder18Aar
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.etterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTOSelectors.frivilligSkattetrekk
@@ -54,7 +55,7 @@ object EnkeltVedtakOmregningNyttRegelverkFerdig : EtterlatteTemplate<Barnepensjo
         outline {
             konverterElementerTilBrevbakerformat(innhold)
 
-            includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, erBosattUtlandet, frivilligSkattetrekk))
+            includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, erEtterbetaling, erBosattUtlandet, frivilligSkattetrekk))
             includePhrase(BarnepensjonFellesFraser.MeldFraOmEndringer)
             includePhrase(BarnepensjonFellesFraser.DuHarRettTilAaKlage)
             includePhrase(BarnepensjonFellesFraser.HarDuSpoersmaal(erUnder18Aar, erBosattUtlandet))

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/revurdering/BarnepensjonRevurdering.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/revurdering/BarnepensjonRevurdering.kt
@@ -9,7 +9,6 @@ import no.nav.pensjon.brev.template.dsl.expression.equalTo
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.expression.format
 import no.nav.pensjon.brev.template.dsl.expression.not
-import no.nav.pensjon.brev.template.dsl.expression.notNull
 import no.nav.pensjon.brev.template.dsl.expression.plus
 import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
 import no.nav.pensjon.brev.template.dsl.languages
@@ -19,7 +18,6 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.EtterlatteTemplate
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregning
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.Element
 import no.nav.pensjon.etterlatte.maler.FeilutbetalingType
 import no.nav.pensjon.etterlatte.maler.FerdigstillingBrevDTO
@@ -29,9 +27,9 @@ import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevu
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.brukerUnder18Aar
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.datoVedtakOmgjoering
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.erEndret
+import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.erEtterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.erMigrertYrkesskade
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.erOmgjoering
-import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.etterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.feilutbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.harFlereUtbetalingsperioder
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTOSelectors.harUtbetaling
@@ -60,7 +58,7 @@ data class BarnepensjonRevurderingDTO(
     val erEndret: Boolean,
     val erMigrertYrkesskade: Boolean,
     val erOmgjoering: Boolean,
-    val etterbetaling: BarnepensjonEtterbetaling?,
+    val erEtterbetaling: Boolean,
     val feilutbetaling: FeilutbetalingType,
     val frivilligSkattetrekk: Boolean,
     val harFlereUtbetalingsperioder: Boolean,
@@ -125,7 +123,7 @@ object BarnepensjonRevurdering : EtterlatteTemplate<BarnepensjonRevurderingDTO>,
                 BarnepensjonRevurderingFraser.RevurderingVedtak(
                 erEndret,
                 beregning,
-                etterbetaling.notNull(),
+                erEtterbetaling,
                 harFlereUtbetalingsperioder,
                 harUtbetaling
             ))

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/revurdering/BarnepensjonRevurderingRedigerbartUtfall.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/revurdering/BarnepensjonRevurderingRedigerbartUtfall.kt
@@ -15,6 +15,7 @@ import no.nav.pensjon.etterlatte.maler.Delmal
 import no.nav.pensjon.etterlatte.maler.FeilutbetalingType
 import no.nav.pensjon.etterlatte.maler.RedigerbartUtfallBrevDTO
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.bosattUtland
+import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.erEtterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.etterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.feilutbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.frivilligSkattetrekk
@@ -24,12 +25,13 @@ import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.BarnepensjonRevurderi
 import no.nav.pensjon.etterlatte.maler.fraser.common.Vedtak
 
 data class BarnepensjonRevurderingRedigerbartUtfallDTO(
-    val etterbetaling: BarnepensjonEtterbetaling?,
+    val etterbetaling: BarnepensjonEtterbetaling?, // TODO: kan fjernes
     val harUtbetaling: Boolean,
     val feilutbetaling: FeilutbetalingType,
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
     val frivilligSkattetrekk: Boolean,
+    val erEtterbetaling: Boolean
 ) : RedigerbartUtfallBrevDTO
 
 @TemplateModelHelpers
@@ -58,7 +60,7 @@ object BarnepensjonRevurderingRedigerbartUtfall : EtterlatteTemplate<Barnepensjo
             includePhrase(Vedtak.BegrunnelseForVedtaket)
             includePhrase(BarnepensjonRevurderingFraser.UtfallRedigerbart(etterbetaling.notNull(), feilutbetaling))
             showIf(harUtbetaling) {
-                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, bosattUtland, frivilligSkattetrekk))
+                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, erEtterbetaling, bosattUtland, frivilligSkattetrekk))
             }
             showIf(feilutbetaling.equalTo(FeilutbetalingType.FEILUTBETALING_MED_VARSEL)) {
                 includePhrase(BarnepensjonRevurderingFraser.FeilutbetalingMedVarselRevurdering)

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/revurdering/BarnepensjonRevurderingRedigerbartUtfall.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/revurdering/BarnepensjonRevurderingRedigerbartUtfall.kt
@@ -3,20 +3,17 @@ package no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering
 import no.nav.pensjon.brev.template.Language
 import no.nav.pensjon.brev.template.dsl.createTemplate
 import no.nav.pensjon.brev.template.dsl.expression.equalTo
-import no.nav.pensjon.brev.template.dsl.expression.notNull
 import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
 import no.nav.pensjon.brev.template.dsl.languages
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.EtterlatteTemplate
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.Delmal
 import no.nav.pensjon.etterlatte.maler.FeilutbetalingType
 import no.nav.pensjon.etterlatte.maler.RedigerbartUtfallBrevDTO
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.bosattUtland
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.erEtterbetaling
-import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.etterbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.feilutbetaling
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.frivilligSkattetrekk
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTOSelectors.harUtbetaling
@@ -25,7 +22,6 @@ import no.nav.pensjon.etterlatte.maler.fraser.barnepensjon.BarnepensjonRevurderi
 import no.nav.pensjon.etterlatte.maler.fraser.common.Vedtak
 
 data class BarnepensjonRevurderingRedigerbartUtfallDTO(
-    val etterbetaling: BarnepensjonEtterbetaling?, // TODO: kan fjernes
     val harUtbetaling: Boolean,
     val feilutbetaling: FeilutbetalingType,
     val brukerUnder18Aar: Boolean,
@@ -58,9 +54,9 @@ object BarnepensjonRevurderingRedigerbartUtfall : EtterlatteTemplate<Barnepensjo
         }
         outline {
             includePhrase(Vedtak.BegrunnelseForVedtaket)
-            includePhrase(BarnepensjonRevurderingFraser.UtfallRedigerbart(etterbetaling.notNull(), feilutbetaling))
+            includePhrase(BarnepensjonRevurderingFraser.UtfallRedigerbart(erEtterbetaling, feilutbetaling))
             showIf(harUtbetaling) {
-                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(etterbetaling, erEtterbetaling, bosattUtland, frivilligSkattetrekk))
+                includePhrase(BarnepensjonFellesFraser.UtbetalingAvBarnepensjon(erEtterbetaling, bosattUtland, frivilligSkattetrekk))
             }
             showIf(feilutbetaling.equalTo(FeilutbetalingType.FEILUTBETALING_MED_VARSEL)) {
                 includePhrase(BarnepensjonRevurderingFraser.FeilutbetalingMedVarselRevurdering)

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonFellesFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonFellesFraser.kt
@@ -209,7 +209,6 @@ object BarnepensjonFellesFraser {
     }
 
     data class UtbetalingAvBarnepensjon(
-        val etterbetaling: Expression<BarnepensjonEtterbetaling?>, // TODO: kan fjernes
         val erEtterbetaling: Expression<Boolean>,
         val bosattUtland: Expression<Boolean>,
         val frivilligSkattetrekk: Expression<Boolean>

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonFellesFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonFellesFraser.kt
@@ -209,7 +209,8 @@ object BarnepensjonFellesFraser {
     }
 
     data class UtbetalingAvBarnepensjon(
-        val etterbetaling: Expression<BarnepensjonEtterbetaling?>,
+        val etterbetaling: Expression<BarnepensjonEtterbetaling?>, // TODO: kan fjernes
+        val erEtterbetaling: Expression<Boolean>,
         val bosattUtland: Expression<Boolean>,
         val frivilligSkattetrekk: Expression<Boolean>
     ) : OutlinePhrase<LangBokmalNynorskEnglish>() {
@@ -303,28 +304,14 @@ object BarnepensjonFellesFraser {
                 )
             }
 
-            showIf(etterbetaling.notNull()) {
+            showIf(erEtterbetaling) {
                 paragraph {
                     text(
-                        Bokmal to "Du får etterbetalt pensjon. Vanligvis vil du få denne i løpet av tre uker. ",
-                        Nynorsk to "Du får etterbetalt pensjon. Vanlegvis vil du få denne i løpet av tre veker. ",
+                        Bokmal to "Du får etterbetalt pensjon. Vanligvis vil du få denne i løpet av tre uker. Hvis det er lagt inn krav i etterbetalingen kan denne bli forsinket. Beløpet som er trukket fra etterbetalingen vil gå frem av utbetalingsmeldingen.",
+                        Nynorsk to "Du får etterbetalt pensjon. Vanlegvis vil du få denne i løpet av tre veker. Dersom det er lagt inn krav i etterbetalinga, kan denne bli forseinka. Beløpet som er trekt frå etterbetalinga, vil gå fram av utbetalingsmeldinga.",
                         English to
-                            "You will receive a back payment on your pension. " +
-                            "You will usually receive this back payment within three weeks. ",
+                            "You will receive a back payment on your pension. You will usually receive this back payment within three weeks. If a claim has been submitted against your back payment, the payment to you may be delayed. Deductions from the back payment will be stated in the disbursement notice.",
                     )
-                    showIf(etterbetaling.inneholderKrav_safe.equalTo(true)) {
-                        text(
-                            Bokmal to
-                                "Hvis det er lagt inn krav i etterbetalingen kan denne bli forsinket. " +
-                                "Beløpet som er trukket fra etterbetalingen vil gå frem av utbetalingsmeldingen.",
-                            Nynorsk to
-                                "Dersom det er lagt inn krav i etterbetalinga, kan denne bli forseinka. " +
-                                "Beløpet som er trekt frå etterbetalinga, vil gå fram av utbetalingsmeldinga.",
-                            English to
-                                "If a claim has been submitted against your back payment, the payment to you may be delayed. " +
-                                "Deductions from the back payment will be stated in the disbursement notice.",
-                        )
-                    }
                 }
             }
         }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonFellesFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonFellesFraser.kt
@@ -7,11 +7,7 @@ import no.nav.pensjon.brev.template.Language.English
 import no.nav.pensjon.brev.template.Language.Nynorsk
 import no.nav.pensjon.brev.template.OutlinePhrase
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
-import no.nav.pensjon.brev.template.dsl.expression.equalTo
-import no.nav.pensjon.brev.template.dsl.expression.notNull
 import no.nav.pensjon.brev.template.dsl.text
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetalingSelectors.inneholderKrav_safe
 import no.nav.pensjon.etterlatte.maler.fraser.common.Constants
 import no.nav.pensjon.etterlatte.maler.fraser.common.kontakttelefonPensjon
 

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonRevurderingFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/fraser/barnepensjon/BarnepensjonRevurderingFraser.kt
@@ -146,7 +146,7 @@ object BarnepensjonRevurderingFraser {
     }
 
     data class UtfallRedigerbart(
-        val etterbetaling: Expression<Boolean>,
+        val erEtterbetaling: Expression<Boolean>,
         val feilutbetaling: Expression<FeilutbetalingType>
     ) : OutlinePhrase<LangBokmalNynorskEnglish>() {
         override fun OutlineOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {
@@ -158,9 +158,9 @@ object BarnepensjonRevurderingFraser {
 
             paragraph {
                 textExpr(
-                    Language.Bokmal to "Vedtaket er gjort etter bestemmelsene om barnepensjon i folketrygdloven §§ <riktig paragrafhenvisning>".expr() + ifElse(etterbetaling, ", 22-12 og § 22-13.", " og 22-12."),
-                    Language.Nynorsk to "Vedtaket er gjort etter føresegnene om barnepensjon i folketrygdlova §§ <riktig paragrafhenvisning>".expr() + ifElse(etterbetaling, ", 22-12 og § 22-13.", " og 22-12."),
-                    Language.English to "This decision has been made pursuant to the provisions regarding children's pensions in the National Insurance Act – sections <riktig paragrafhenvisning>".expr() + ifElse(etterbetaling, ", 22-12 and 22-13.", " and 22-12."),
+                    Language.Bokmal to "Vedtaket er gjort etter bestemmelsene om barnepensjon i folketrygdloven §§ <riktig paragrafhenvisning>".expr() + ifElse(erEtterbetaling, ", 22-12 og § 22-13.", " og 22-12."),
+                    Language.Nynorsk to "Vedtaket er gjort etter føresegnene om barnepensjon i folketrygdlova §§ <riktig paragrafhenvisning>".expr() + ifElse(erEtterbetaling, ", 22-12 og § 22-13.", " og 22-12."),
+                    Language.English to "This decision has been made pursuant to the provisions regarding children's pensions in the National Insurance Act – sections <riktig paragrafhenvisning>".expr() + ifElse(erEtterbetaling, ", 22-12 and 22-13.", " and 22-12."),
                 )
             }
 

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
@@ -124,6 +124,7 @@ fun createBarnepensjonForeldreloesDTO(): BarnepensjonForeldreloesDTO {
         erGjenoppretting = false,
         vedtattIPesys = false,
         erMigrertYrkesskade = false,
+        erEtterbetaling = false
     )
 }
 

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
@@ -112,10 +112,6 @@ fun createBarnepensjonForeldreloesDTO(): BarnepensjonForeldreloesDTO {
             ),
             erForeldreloes = true,
         ),
-        etterbetaling = BarnepensjonEtterbetaling(
-            inneholderKrav = true,
-            etterbetalingPeriodeValg = EtterbetalingPeriodeValg.FRA_3_MND,
-        ),
         frivilligSkattetrekk = true,
         bosattUtland = true,
         brukerUnder18Aar = true,

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
@@ -4,9 +4,7 @@ import no.nav.pensjon.brevbaker.api.model.Kroner
 import no.nav.pensjon.etterlatte.maler.Avdoed
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregning
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiode
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.BeregningsMetode
-import no.nav.pensjon.etterlatte.maler.EtterbetalingPeriodeValg
 import no.nav.pensjon.etterlatte.maler.ForskjelligAvdoedPeriode
 import no.nav.pensjon.etterlatte.maler.ForskjelligTrygdetid
 import no.nav.pensjon.etterlatte.maler.IntBroek

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
@@ -79,6 +79,7 @@ fun createBarnepensjonInnvilgelseDTO(): BarnepensjonInnvilgelseDTO {
         erGjenoppretting = false,
         harUtbetaling = true,
         erMigrertYrkesskade = false,
+        erEtterbetaling = false
     )
 }
 

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
@@ -5,13 +5,11 @@ import no.nav.pensjon.etterlatte.maler.Avdoed
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregning
 import no.nav.pensjon.etterlatte.maler.BeregningsMetode
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiode
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.IntBroek
 import no.nav.pensjon.etterlatte.maler.Periode
 import no.nav.pensjon.etterlatte.maler.Trygdetid
 import no.nav.pensjon.etterlatte.maler.TrygdetidType
 import no.nav.pensjon.etterlatte.maler.Trygdetidsperiode
-import no.nav.pensjon.etterlatte.maler.EtterbetalingPeriodeValg
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseDTO
 import no.nav.pensjon.etterlatte.maler.barnepensjon.innvilgelse.BarnepensjonInnvilgelseRedigerbartUtfallDTO
 import java.time.LocalDate

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
@@ -68,10 +68,6 @@ fun createBarnepensjonInnvilgelseDTO(): BarnepensjonInnvilgelseDTO {
             trygdetid = listOf(bruktTrygdetid),
             bruktTrygdetid = bruktTrygdetid
         ),
-        etterbetaling = BarnepensjonEtterbetaling(
-            inneholderKrav = true,
-            etterbetalingPeriodeValg = EtterbetalingPeriodeValg.UNDER_3_MND,
-        ),
         frivilligSkattetrekk = true,
         bosattUtland = true,
         brukerUnder18Aar = true,

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonOmregnetNyttRegelverk.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonOmregnetNyttRegelverk.kt
@@ -32,6 +32,7 @@ fun createBarnepensjonOmregnetNyttRegelverkFerdigDTO() =
         frivilligSkattetrekk = true,
         erUnder18Aar = false,
         erBosattUtlandet = true,
+        erEtterbetaling = false
     )
 
 internal fun lagBeregning() = BarnepensjonBeregning(

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonOmregnetNyttRegelverk.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonOmregnetNyttRegelverk.kt
@@ -28,7 +28,6 @@ fun createBarnepensjonOmregnetNyttRegelverkFerdigDTO() =
     BarnepensjonOmregnetNyttRegelverkFerdigDTO(
         innhold = createPlaceholderForRedigerbartInnhold(),
         beregning = lagBeregning(),
-        etterbetaling = lagEtterbetaling(),
         frivilligSkattetrekk = true,
         erUnder18Aar = false,
         erBosattUtlandet = true,
@@ -106,9 +105,4 @@ internal fun lagBeregning() = BarnepensjonBeregning(
         mindreEnnFireFemtedelerAvOpptjeningstiden = false,
         navnAvdoed = "Elvis Presley"
     )
-)
-
-fun lagEtterbetaling() = BarnepensjonEtterbetaling(
-    inneholderKrav = true,
-    etterbetalingPeriodeValg = EtterbetalingPeriodeValg.FRA_3_MND,
 )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonOmregnetNyttRegelverk.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonOmregnetNyttRegelverk.kt
@@ -3,14 +3,12 @@ package no.nav.pensjon.etterlatte.fixtures
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregning
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiode
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.BeregningsMetode
 import no.nav.pensjon.etterlatte.maler.IntBroek
 import no.nav.pensjon.etterlatte.maler.Periode
 import no.nav.pensjon.etterlatte.maler.Trygdetid
 import no.nav.pensjon.etterlatte.maler.TrygdetidType
 import no.nav.pensjon.etterlatte.maler.Trygdetidsperiode
-import no.nav.pensjon.etterlatte.maler.EtterbetalingPeriodeValg
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkDTO
 import no.nav.pensjon.etterlatte.maler.barnepensjon.migrering.BarnepensjonOmregnetNyttRegelverkFerdigDTO
 import java.time.LocalDate

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonRevurdering.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonRevurdering.kt
@@ -122,10 +122,6 @@ fun createBarnepensjonRevurderingDTO():BarnepensjonRevurderingDTO {
 }
 
 fun createBarnepensjonRevurderingRedigerbartUtfallDTO() = BarnepensjonRevurderingRedigerbartUtfallDTO(
-    etterbetaling = BarnepensjonEtterbetaling(
-        inneholderKrav = true,
-        etterbetalingPeriodeValg = EtterbetalingPeriodeValg.FRA_3_MND,
-    ),
     harUtbetaling = true,
     feilutbetaling = FeilutbetalingType.FEILUTBETALING_MED_VARSEL,
     brukerUnder18Aar = true,

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonRevurdering.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonRevurdering.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.etterlatte.fixtures
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregning
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiode
-import no.nav.pensjon.etterlatte.maler.BarnepensjonEtterbetaling
 import no.nav.pensjon.etterlatte.maler.BeregningsMetode
 import no.nav.pensjon.etterlatte.maler.FeilutbetalingType
 import no.nav.pensjon.etterlatte.maler.IntBroek
@@ -11,7 +10,6 @@ import no.nav.pensjon.etterlatte.maler.Periode
 import no.nav.pensjon.etterlatte.maler.Trygdetid
 import no.nav.pensjon.etterlatte.maler.TrygdetidType
 import no.nav.pensjon.etterlatte.maler.Trygdetidsperiode
-import no.nav.pensjon.etterlatte.maler.EtterbetalingPeriodeValg
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingDTO
 import no.nav.pensjon.etterlatte.maler.barnepensjon.revurdering.BarnepensjonRevurderingRedigerbartUtfallDTO
 import java.time.LocalDate
@@ -106,10 +104,6 @@ fun createBarnepensjonRevurderingDTO():BarnepensjonRevurderingDTO {
             erForeldreloes = true,
             bruktTrygdetid = bruktTrygdetid
         ),
-        etterbetaling = BarnepensjonEtterbetaling(
-            inneholderKrav = true,
-            etterbetalingPeriodeValg = EtterbetalingPeriodeValg.FRA_3_MND,
-        ),
         frivilligSkattetrekk = true,
         brukerUnder18Aar = true,
         bosattUtland = false,
@@ -118,6 +112,7 @@ fun createBarnepensjonRevurderingDTO():BarnepensjonRevurderingDTO {
         harUtbetaling = true,
         feilutbetaling = FeilutbetalingType.FEILUTBETALING_MED_VARSEL,
         erMigrertYrkesskade = false,
+        erEtterbetaling = false,
     )
 }
 

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonRevurdering.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonRevurdering.kt
@@ -131,4 +131,5 @@ fun createBarnepensjonRevurderingRedigerbartUtfallDTO() = BarnepensjonRevurderin
     brukerUnder18Aar = true,
     bosattUtland = false,
     frivilligSkattetrekk = false,
+    erEtterbetaling = false
 )


### PR DESCRIPTION
Henger sammen med endringer i Gjenny

Vi har fjernet to felter i etterbretaling og endrer derfor litt på logikken i pensjonsbrev

Det er også lagt inn ny tekst ifm EY-4891

!! Denne endringen henger sammen med https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/6700