### PR TITLE
Rullar midlertidig tilbake 50-teikns-grense, så ting ikkje trynar i prod for etterlatte

### DIFF
--- a/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/Brevkode.kt
+++ b/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/Brevkode.kt
@@ -11,16 +11,16 @@ interface Brevkode<T: Brevkode<T>> {
 
 @JvmInline
 value class RedigerbarBrevkode(private val kode: String) : Brevkode.Redigerbart {
-    init {
-        require(kode.length <= 50)
-    }
+//    init {
+//        require(kode.length <= 50)
+//    }
     override fun kode(): String = kode
 }
 
 @JvmInline
 value class AutomatiskBrevkode(private val kode: String): Brevkode.Automatisk {
-    init {
-        require(kode.length <= 50)
-    }
+//    init {
+//        require(kode.length <= 50)
+//    }
     override fun kode(): String = kode
 }

--- a/pensjon-brevbaker-api-model/src/test/kotlin/no/nav/pensjon/brev/api/model/maler/BrevkodeTest.kt
+++ b/pensjon-brevbaker-api-model/src/test/kotlin/no/nav/pensjon/brev/api/model/maler/BrevkodeTest.kt
@@ -15,7 +15,7 @@ class BrevkodeTest {
     @Test
     fun `tittel paa over 50 tegn feiler for redigerbar`() {
         val langTittel = IntStream.range(0, 51).mapToObj { "b" }.collect(Collectors.joining())
-        assertThrows(IllegalArgumentException::class.java) { RedigerbarBrevkode(langTittel) }
+//        assertThrows(IllegalArgumentException::class.java) { RedigerbarBrevkode(langTittel) }
     }
 
 
@@ -27,7 +27,7 @@ class BrevkodeTest {
     @Test
     fun `tittel paa over 50 tegn feiler for automatisk`() {
         val langTittel = IntStream.range(0, 51).mapToObj { "d" }.collect(Collectors.joining())
-        assertThrows(IllegalArgumentException::class.java) { AutomatiskBrevkode(langTittel) }
+//        assertThrows(IllegalArgumentException::class.java) { AutomatiskBrevkode(langTittel) }
     }
 
 }


### PR DESCRIPTION
Etterlatte har per no over 50 teikn kun for redigerbart innhald i malar, som ikkje i seg sjølv blir ferdigstilt eller arkivert, så det er ikkje problematisk på kort sikt.