### PR TITLE
Bibliotek-forarbeid: Skriv om testane for enkeltbrev så dei ikkje bruker Letter direkte.

### DIFF
--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/ForhaandsvarselEtteroppgjoerUfoeretrygdAutoTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/ForhaandsvarselEtteroppgjoerUfoeretrygdAutoTest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.ForhaandsvarselEtteroppgjoerUfoeretry
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -14,21 +13,23 @@ import org.junit.jupiter.api.Test
 class ForhaandsvarselEtteroppgjoerUfoeretrygdAutoTest {
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             ForhaandsvarselEtteroppgjoerUfoeretrygdAuto.template,
             Fixtures.create<ForhaandsvarselEtteroppgjoerUfoeretrygdDto>(),
             Language.English,
-            Fixtures.fellesAuto
-        ).renderTestPDF("UT_EO_FORHAANDSVARSEL_FEILUTBETALING_AUTO")
+            Fixtures.fellesAuto,
+            "UT_EO_FORHAANDSVARSEL_FEILUTBETALING_AUTO"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             ForhaandsvarselEtteroppgjoerUfoeretrygdAuto.template,
             Fixtures.create<ForhaandsvarselEtteroppgjoerUfoeretrygdDto>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestHtml("UT_EO_FORHAANDSVARSEL_FEILUTBETALING_AUTO")
+            Fixtures.fellesAuto,
+            "UT_EO_FORHAANDSVARSEL_FEILUTBETALING_AUTO"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/OmsorgEgenAutoITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/OmsorgEgenAutoITest.kt
@@ -10,21 +10,23 @@ class OmsorgEgenAutoITest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             OmsorgEgenAuto.template,
             Fixtures.create<OmsorgEgenAutoDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("OMSORG_EGEN_AUTO_BOKMAL")
+            Fixtures.fellesAuto,
+            "OMSORG_EGEN_AUTO_BOKMAL"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             OmsorgEgenAuto.template,
             Fixtures.create<OmsorgEgenAutoDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestHtml("OMSORG_EGEN_AUTO_BOKMAL")
+            Fixtures.fellesAuto,
+            "OMSORG_EGEN_AUTO_BOKMAL"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAutoTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/OpphoerBarnetilleggAutoTest.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.brev.maler
 import no.nav.pensjon.brev.*
 import no.nav.pensjon.brev.api.model.maler.OpphoerBarnetilleggAutoDto
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -12,11 +11,12 @@ class OpphoerBarnetilleggAutoTest {
 
     @Test
     fun test() {
-        Letter(
+        renderTestPDF(
             OpphoerBarnetilleggAuto.template,
             Fixtures.create<OpphoerBarnetilleggAutoDto>(),
             Language.Bokmal,
             Fixtures.fellesAuto,
-        ).renderTestPDF("UT_OPPHOERER_BARNETILLEGG")
+            "UT_OPPHOERER_BARNETILLEGG"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnsligITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/UfoerOmregningEnsligITest.kt
@@ -11,21 +11,23 @@ class UfoerOmregningEnsligITest {
 
     @Test
     fun test() {
-        Letter(
+        renderTestPDF(
             UfoerOmregningEnslig.template,
             Fixtures.create<UfoerOmregningEnsligDto>(),
             Language.Bokmal,
             Fixtures.fellesAuto,
-        ).renderTestPDF("UT_DOD_ENSLIG_AUTO_BOKMAL")
+            "UT_DOD_ENSLIG_AUTO_BOKMAL"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             UfoerOmregningEnslig.template,
             Fixtures.create<UfoerOmregningEnsligDto>(),
             Language.Bokmal,
             Fixtures.fellesAuto,
-        ).renderTestHtml("UT_DOD_ENSLIG_AUTO_BOKMAL")
+            "UT_DOD_ENSLIG_AUTO_BOKMAL"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/UngUfoerAutoITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/UngUfoerAutoITest.kt
@@ -12,22 +12,24 @@ class UngUfoerAutoITest {
 
     @Test
     fun pdftest() {
-        Letter(
+        renderTestPDF(
             UngUfoerAuto.template,
             Fixtures.create<UngUfoerAutoDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("UNG_UFOER_AUTO_BOKMAL")
+            Fixtures.fellesAuto,
+        "UNG_UFOER_AUTO_BOKMAL"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             UngUfoerAuto.template,
             Fixtures.create<UngUfoerAutoDto>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestHtml("UNG_UFOER_AUTO_BOKMAL")
+            Fixtures.fellesAuto,
+            "UNG_UFOER_AUTO_BOKMAL"
+        )
     }
 
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/adhoc/AdhocTest.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.brev.maler.adhoc
 import no.nav.pensjon.brev.*
 import no.nav.pensjon.brev.template.Language
 import no.nav.pensjon.brev.template.Language.*
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.brev.template.LetterTemplate
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -12,13 +11,13 @@ import org.junit.jupiter.api.Test
 class AdhocTest {
     fun testHtml(template: LetterTemplate<*, *>, htmlName: String, vararg language: Language) {
         language.forEach {
-            Letter(template, Unit, it, Fixtures.fellesAuto).renderTestHtml(htmlName + "_${it}")
+            renderTestHtml(template, Unit, it, Fixtures.fellesAuto, htmlName + "_${it}")
         }
     }
 
     fun testAdhocPdf(template: LetterTemplate<*, *>, pdfName: String, vararg language: Language) {
         language.forEach {
-            Letter(template, Unit, it, Fixtures.fellesAuto).renderTestPDF(pdfName + "_${it}")
+            renderTestPDF(template, Unit, it, Fixtures.fellesAuto, pdfName + "_${it}")
         }
     }
 

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/alder/InfoAldersovergang67AarAutoTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/alder/InfoAldersovergang67AarAutoTest.kt
@@ -10,42 +10,46 @@ class InfoAldersovergang67AarAutoTest {
 
     @Test
     fun testPdfNB() {
-        Letter(
+        renderTestPDF(
             InfoAldersovergang67AarAuto.template,
             Fixtures.create<InfoAlderspensjonOvergang67AarAutoDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("INFO_ALDERSOVERGANG_67_AAR_AUTO_BOKMAL")
+            Fixtures.fellesAuto,
+            "INFO_ALDERSOVERGANG_67_AAR_AUTO_BOKMAL"
+        )
     }
 
     @Test
     fun testPdfNN() {
-        Letter(
+        renderTestPDF(
             InfoAldersovergang67AarAuto.template,
             Fixtures.create<InfoAlderspensjonOvergang67AarAutoDto>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestPDF("INFO_ALDERSOVERGANG_67_AAR_AUTO_NYNORSK")
+            Fixtures.fellesAuto,
+            "INFO_ALDERSOVERGANG_67_AAR_AUTO_NYNORSK"
+        )
     }
 
     @Test
     fun testPdfEN() {
-        Letter(
+        renderTestPDF(
             InfoAldersovergang67AarAuto.template,
             Fixtures.create<InfoAlderspensjonOvergang67AarAutoDto>(),
             Language.English,
-            Fixtures.fellesAuto
-        ).renderTestPDF("INFO_ALDERSOVERGANG_67_AAR_AUTO_ENGLISH")
+            Fixtures.fellesAuto,
+            "INFO_ALDERSOVERGANG_67_AAR_AUTO_ENGLISH"
+        )
     }
 
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             InfoAldersovergang67AarAuto.template,
             Fixtures.create<InfoAlderspensjonOvergang67AarAutoDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestHtml("INFO_ALDERSOVERGANG_67_AAR_AUTO_BOKMAL")
+            Fixtures.fellesAuto,
+            "INFO_ALDERSOVERGANG_67_AAR_AUTO_BOKMAL"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/example/LetterExampleTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/example/LetterExampleTest.kt
@@ -10,22 +10,24 @@ class LetterExampleTest {
 
     @Test
     fun test() {
-        Letter(
+        renderTestPDF(
             LetterExample.template,
             createLetterExampleDto(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("EKSEMPELBREV_BOKMAL")
+            Fixtures.fellesAuto,
+            "EKSEMPELBREV_BOKMAL"
+        )
     }
 
     @Test
     fun `test design reference letter`() {
-        Letter(
+        renderTestPDF(
             DesignReferenceLetter.template,
             createLetterExampleDto(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("DESIGN_REFERENCE_LETTER_BOKMAL")
+            Fixtures.fellesAuto,
+            "DESIGN_REFERENCE_LETTER_BOKMAL"
+        )
     }
 
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/EndretBarnetilleggUfoerertrygdTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/EndretBarnetilleggUfoerertrygdTest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.legacy.EndretBarnetilleggUfoeretrygdD
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -16,21 +15,23 @@ class EndretBarnetilleggUfoerertrygdTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             EndretBarnetilleggUfoerertrygd.template,
             Fixtures.create<EndretBarnetilleggUfoeretrygdDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("UT_ENDRET_BARNETILLEGG")
+            Fixtures.fellesAuto,
+            "UT_ENDRET_BARNETILLEGG"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             EndretBarnetilleggUfoerertrygd.template,
             Fixtures.create<EndretBarnetilleggUfoeretrygdDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestHtml("UT_ENDRET_BARNETILLEGG")
+            Fixtures.fellesAuto,
+            "UT_ENDRET_BARNETILLEGG"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/EndretUfoeretrygdPGAInntektTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/EndretUfoeretrygdPGAInntektTest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.legacy.EndretUfoeretrygdPGAInntektDto
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -15,21 +14,23 @@ class EndretUfoeretrygdPGAInntektTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             EndretUfoeretrygdPGAInntektLegacy.template,
             Fixtures.create<EndretUfoeretrygdPGAInntektDto>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestPDF("UT_ENDRET_PGA_INNTEKT")
+            Fixtures.fellesAuto,
+            "UT_ENDRET_PGA_INNTEKT"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             EndretUfoeretrygdPGAInntektLegacy.template,
             Fixtures.create<EndretUfoeretrygdPGAInntektDto>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestHtml("UT_ENDRET_PGA_INNTEKT")
+            Fixtures.fellesAuto,
+            "UT_ENDRET_PGA_INNTEKT"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/EndretUforetrygdPGAOpptjeningLegacyTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/EndretUforetrygdPGAOpptjeningLegacyTest.kt
@@ -5,7 +5,6 @@ import no.nav.pensjon.brev.TestTags
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -14,21 +13,23 @@ class EndretUforetrygdPGAOpptjeningLegacyTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             EndretUforetrygdPGAOpptjeningLegacy.template,
             Fixtures.create<EndretUforetrygdPGAOpptjeningLegacy>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestPDF(EndretUforetrygdPGAOpptjeningLegacy.kode.name)
+            Fixtures.fellesAuto,
+            EndretUforetrygdPGAOpptjeningLegacy.kode.name
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             EndretUforetrygdPGAOpptjeningLegacy.template,
             Fixtures.create<EndretUforetrygdPGAOpptjeningLegacy>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestHtml(EndretUforetrygdPGAOpptjeningLegacy.kode.name)
+            Fixtures.fellesAuto,
+            EndretUforetrygdPGAOpptjeningLegacy.kode.name
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/EtteroppgjoerEtterbetalingAutoTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/EtteroppgjoerEtterbetalingAutoTest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.EtteroppgjoerEtterbetalingAutoDto
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -15,21 +14,23 @@ class EtteroppgjoerEtterbetalingAutoTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             EtteroppgjoerEtterbetalingAutoLegacy.template,
             Fixtures.create<EtteroppgjoerEtterbetalingAutoDto>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestPDF("UT_ENDRET_PGA_INNTEKT")
+            Fixtures.fellesAuto,
+            "UT_ENDRET_PGA_INNTEKT"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             EtteroppgjoerEtterbetalingAutoLegacy.template,
             Fixtures.create<EtteroppgjoerEtterbetalingAutoDto>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestHtml("UT_ENDRET_PGA_INNTEKT")
+            Fixtures.fellesAuto,
+            "UT_ENDRET_PGA_INNTEKT"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/AvslagUfoeretrygdTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/AvslagUfoeretrygdTest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.AvslagUfoeretrygdDt
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -15,21 +14,23 @@ class AvslagUfoeretrygdTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             AvslagUfoeretrygd.template,
             Fixtures.create<AvslagUfoeretrygdDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("UT_AVSLAG_UFOERTRYGD")
+            Fixtures.fellesAuto,
+            "UT_AVSLAG_UFOERTRYGD"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             AvslagUfoeretrygd.template,
             Fixtures.create<AvslagUfoeretrygdDto>(),
             Language.Nynorsk,
-            Fixtures.fellesAuto
-        ).renderTestHtml("UT_AVSLAG_UFOERTRYGD")
+            Fixtures.fellesAuto,
+            "UT_AVSLAG_UFOERTRYGD"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/vedlegg/OpplysningerBruktIBeregningUTLegacyTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/legacy/vedlegg/OpplysningerBruktIBeregningUTLegacyTest.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.brev.maler.legacy.vedlegg
 import no.nav.pensjon.brev.*
 import no.nav.pensjon.brev.api.model.maler.legacy.PE
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.brev.template.createVedleggTestTemplate
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.languages
@@ -20,12 +19,13 @@ class OpplysningerBruktIBeregningUTLegacyTest {
             Fixtures.create(PE::class).expr(),
             languages(Language.Bokmal, Language.Nynorsk, Language.English),
         )
-        Letter(
+        renderTestPDF(
             template,
             Unit,
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("OpplysningerBruktIBeregningUfoereLegacy")
+            Fixtures.fellesAuto,
+            "OpplysningerBruktIBeregningUfoereLegacy"
+        )
 
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/ForespoerselOmDokumentasjonAvBotidINorgeTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/ForespoerselOmDokumentasjonAvBotidINorgeTest.kt
@@ -5,7 +5,6 @@ import no.nav.pensjon.brev.TestTags
 import no.nav.pensjon.brev.api.model.maler.EmptyBrevdata
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -14,11 +13,12 @@ class ForespoerselOmDokumentasjonAvBotidINorgeTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             ForespoerselOmDokumentasjonAvBotidINorgeAlder.template,
             Fixtures.create<EmptyBrevdata>(),
             Language.Bokmal,
-            Fixtures.felles
-        ).renderTestPDF(ForespoerselOmDokumentasjonAvBotidINorgeAlder.kode.name)
+            Fixtures.felles,
+            ForespoerselOmDokumentasjonAvBotidINorgeAlder.kode.name
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/ForhaandsvarselVedTilbakekrevingTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/ForhaandsvarselVedTilbakekrevingTest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.EmptyBrevdata
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -15,21 +14,23 @@ class ForhaandsvarselVedTilbakekrevingTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             ForhaandsvarselVedTilbakekreving.template,
             Fixtures.create<EmptyBrevdata>(),
             Language.Bokmal,
-            Fixtures.felles
-        ).renderTestPDF(ForhaandsvarselVedTilbakekreving.kode.name)
+            Fixtures.felles,
+            ForhaandsvarselVedTilbakekreving.kode.name
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             ForhaandsvarselVedTilbakekreving.template,
             Fixtures.create<EmptyBrevdata>(),
             Language.Bokmal,
-            Fixtures.felles
-        ).renderTestHtml(ForhaandsvarselVedTilbakekreving.kode.name)
+            Fixtures.felles,
+            ForhaandsvarselVedTilbakekreving.kode.name
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/InformasjonOmSaksbehandlingstidITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/InformasjonOmSaksbehandlingstidITest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.EmptyBrevdata
 import no.nav.pensjon.brev.api.model.maler.redigerbar.InformasjonOmSaksbehandlingstidDto
 import no.nav.pensjon.brev.api.toLanguage
 import no.nav.pensjon.brev.renderTestPDF
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.brevbaker.api.model.LanguageCode.*
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -42,12 +41,13 @@ class InformasjonOmSaksbehandlingstidITest {
 
     private fun writeAllLanguages(testNavn: String, data: InformasjonOmSaksbehandlingstidDto) {
         listOf(BOKMAL, NYNORSK, ENGLISH).forEach { lang ->
-            Letter(
+            renderTestPDF(
                 InformasjonOmSaksbehandlingstid.template,
                 data,
                 lang.toLanguage(),
-                Fixtures.felles
-            ).renderTestPDF("000130-$testNavn-${lang.name}")
+                Fixtures.felles,
+            "000130-$testNavn-${lang.name}"
+            )
         }
     }
 

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/OrienteringOmForlengetSaksbehandlingTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/OrienteringOmForlengetSaksbehandlingTest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.EmptyBrevdata
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -15,21 +14,23 @@ class OrienteringOmForlengetSaksbehandlingTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             OrienteringOmForlengetSaksbehandlingstid.template,
             Fixtures.create<EmptyBrevdata>(),
             Language.English,
-            Fixtures.felles
-        ).renderTestPDF(OrienteringOmForlengetSaksbehandlingstid.kode.name)
+            Fixtures.felles,
+            OrienteringOmForlengetSaksbehandlingstid.kode.name
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             OrienteringOmForlengetSaksbehandlingstid.template,
             Fixtures.create<EmptyBrevdata>(),
             Language.Bokmal,
-            Fixtures.felles
-        ).renderTestHtml(OrienteringOmForlengetSaksbehandlingstid.kode.name)
+            Fixtures.felles,
+            OrienteringOmForlengetSaksbehandlingstid.kode.name
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/OversettelseAvDokumenterTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/OversettelseAvDokumenterTest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.EmptyBrevdata
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -15,21 +14,23 @@ class OversettelseAvDokumenterTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             OversettelseAvDokumenter.template,
             Fixtures.create<EmptyBrevdata>(),
             Language.Bokmal,
-            Fixtures.felles
-        ).renderTestPDF(OversettelseAvDokumenter.kode.name)
+            Fixtures.felles,
+            OversettelseAvDokumenter.kode.name
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             OversettelseAvDokumenter.template,
             Fixtures.create<EmptyBrevdata>(),
             Language.Bokmal,
-            Fixtures.felles
-        ).renderTestHtml(OversettelseAvDokumenter.kode.name)
+            Fixtures.felles,
+            OversettelseAvDokumenter.kode.name
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/VarselOmMuligAvslagTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/redigerbar/VarselOmMuligAvslagTest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.api.model.maler.EmptyBrevdata
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -15,21 +14,23 @@ class VarselOmMuligAvslagTest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             VarselOmMuligAvslag.template,
             Fixtures.create<EmptyBrevdata>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF(VarselOmMuligAvslag.kode.name)
+            Fixtures.fellesAuto,
+            VarselOmMuligAvslag.kode.name
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             VarselOmMuligAvslag.template,
             Fixtures.create<EmptyBrevdata>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestHtml(VarselOmMuligAvslag.kode.name)
+            Fixtures.fellesAuto,
+            VarselOmMuligAvslag.kode.name
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/ufoere/VarselSaksbehandlingstidTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/ufoere/VarselSaksbehandlingstidTest.kt
@@ -13,22 +13,24 @@ class VarselSaksbehandlingstidTest {
 
     @Test
     fun pdftest() {
-        Letter(
+        renderTestPDF(
             VarselSaksbehandlingstidAuto.template,
             Fixtures.create<VarselSaksbehandlingstidAutoDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("UT_VARSEL_SAKSBEHANDLINGSTID_AUTO")
+            Fixtures.fellesAuto,
+            "UT_VARSEL_SAKSBEHANDLINGSTID_AUTO"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             VarselSaksbehandlingstidAuto.template,
             Fixtures.create<VarselSaksbehandlingstidAutoDto>(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestHtml("UT_VARSEL_SAKSBEHANDLINGSTID_AUTO_BOKMAL")
+            Fixtures.fellesAuto,
+            "UT_VARSEL_SAKSBEHANDLINGSTID_AUTO_BOKMAL"
+        )
     }
 
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/MaanedligUfoeretrygdFoerSkattITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/MaanedligUfoeretrygdFoerSkattITest.kt
@@ -57,21 +57,23 @@ class MaanedligUfoeretrygdFoerSkattITest {
 
     @Test
     fun testPdf() {
-        Letter(
+        renderTestPDF(
             template,
             Unit,
             Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("MaanedligUfoeretrygdFoerSkatt")
+            Fixtures.fellesAuto,
+            "MaanedligUfoeretrygdFoerSkatt"
+        )
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             template,
             Unit,
             Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestHtml("MaanedligUfoeretrygdFoerSkatt")
+            Fixtures.fellesAuto,
+            "MaanedligUfoeretrygdFoerSkatt"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerBruktIBeregningUTTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerBruktIBeregningUTTest.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.brev.maler.vedlegg
 import no.nav.pensjon.brev.*
 import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerBruktIBeregningUTDto
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.brev.template.createVedleggTestTemplate
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.languages
@@ -20,12 +19,13 @@ class OpplysningerBruktIBeregningUTTest {
             Fixtures.create(OpplysningerBruktIBeregningUTDto::class).expr(),
             languages(Language.Bokmal, Language.Nynorsk, Language.English),
         )
-        Letter(
+        renderTestPDF(
             template,
             Unit,
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("OpplysningerBruktIBeregningUfoere")
+            Fixtures.fellesAuto,
+            "OpplysningerBruktIBeregningUfoere"
+        )
 
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerOmEtteropgjoeretTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/OpplysningerOmEtteropgjoeretTest.kt
@@ -13,7 +13,6 @@ import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerOmEtteroppgjoeretDto.In
 import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerOmEtteroppgjoeretDto.InntektOgFratrekk.Inntekt.InntektLinje
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language.Bokmal
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.brev.template.createVedleggTestTemplate
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.languages
@@ -103,12 +102,13 @@ class OpplysningerOmEtteropgjoeretTest {
             ).expr(),
             languages(Bokmal),
         )
-        Letter(
+        renderTestPDF(
             template,
             Unit,
             Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("OpplysningerOmEtteroppgjoeret")
+            Fixtures.fellesAuto,
+            "OpplysningerOmEtteroppgjoeret"
+        )
 
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/OrienteringOmRettigheterUfoereTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/OrienteringOmRettigheterUfoereTest.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.brev.maler.vedlegg
 import no.nav.pensjon.brev.*
 import no.nav.pensjon.brev.api.model.vedlegg.OrienteringOmRettigheterUfoereDto
 import no.nav.pensjon.brev.template.Language.*
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.brev.template.createVedleggTestTemplate
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.languages
@@ -20,12 +19,13 @@ class OrienteringOmRettigheterUfoereTest {
             Fixtures.create(OrienteringOmRettigheterUfoereDto::class).expr(),
             languages(Bokmal, Nynorsk, English),
         )
-        Letter(
+        renderTestPDF(
             template,
             Unit,
             Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("OrienteringOmRettigheterUfoere")
+            Fixtures.fellesAuto,
+            "OrienteringOmRettigheterUfoere"
+        )
 
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/PraktiskInformasjonEtteroppgjoer.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/vedlegg/PraktiskInformasjonEtteroppgjoer.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.brev.maler.vedlegg
 
 import no.nav.pensjon.brev.*
 import no.nav.pensjon.brev.template.Language.*
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.brev.template.createVedleggTestTemplate
 import no.nav.pensjon.brev.template.dsl.expression.expr
 import no.nav.pensjon.brev.template.dsl.languages
@@ -19,11 +18,12 @@ class PraktiskInformasjonEtteroppgjoerTest {
             Unit.expr(),
             languages(Bokmal)
         )
-        Letter(
+        renderTestPDF(
             template,
             Unit,
             Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestPDF("PraktiskInformasjonEtteroppgjoer")
+            Fixtures.fellesAuto,
+            "PraktiskInformasjonEtteroppgjoer"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/GenererAlleMaleneTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/GenererAlleMaleneTest.kt
@@ -34,9 +34,8 @@ class GenererAlleMaleneTest {
             println("Mal ${template.name} fins ikke på språk $spraak, tester ikke denne")
             return
         }
-        val letter = Letter(template, fixtures, spraak, Fixtures.felles)
 
-        letter.renderTestPDF(filnavn(brevkode, spraak))
+        renderTestPDF(template, fixtures, spraak, Fixtures.felles, filnavn(brevkode, spraak))
     }
 
     @ParameterizedTest(name = "{1}, {3}")
@@ -51,12 +50,13 @@ class GenererAlleMaleneTest {
             println("Mal ${template.name} fins ikke på språk $spraak, tester ikke denne")
             return
         }
-        Letter(
+        renderTestHtml(
             template,
             fixtures,
             spraak,
             Fixtures.felles,
-        ).renderTestHtml(filnavn(brevkode, spraak))
+            filnavn(brevkode, spraak)
+        )
     }
 
     private fun filnavn(brevkode: Brevkode<*>, spraak: Language) =

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/HTMLDocumentRendererTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/HTMLDocumentRendererTest.kt
@@ -9,11 +9,12 @@ import org.junit.jupiter.api.Test
 class HTMLDocumentRendererTest {
     @Test
     fun renderDesignReference() {
-        Letter(
+        renderTestHtml(
             DesignReferenceLetter.template,
             createLetterExampleDto(),
             Language.Bokmal,
-            Fixtures.fellesAuto
-        ).renderTestHtml("DESIGN_REFERENCE_LETTER")
+            Fixtures.fellesAuto,
+            "DESIGN_REFERENCE_LETTER"
+        )
     }
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/LatexVisualITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/LatexVisualITest.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.brev.maler.example.lipsums
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.LangBokmal
 import no.nav.pensjon.brev.template.Language.Bokmal
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.brev.template.dsl.*
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import org.junit.jupiter.api.Tag
@@ -30,8 +29,7 @@ class LatexVisualITest {
             }
             outline { outlineInit() }
         }
-        val letter = Letter(template, Unit, Bokmal, Fixtures.fellesAuto)
-        letter.renderTestPDF(testName, Path.of("build/test_visual/pdf"))
+        renderTestPDF(template, Unit, Bokmal, Fixtures.fellesAuto, testName, Path.of("build/test_visual/pdf"))
     }
 
     private fun ParagraphOnlyScope<LangBokmal, Unit>.ipsumText() = text(Bokmal to lipsums.first())

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/PensjonLatexITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/PensjonLatexITest.kt
@@ -48,7 +48,7 @@ class PensjonLatexITest {
                 }
             }
         }
-        Letter(template, brevData, Bokmal, Fixtures.felles).renderTestPDF("pensjonLatexITest_canRender")
+        renderTestPDF(template, brevData, Bokmal, Fixtures.felles, "pensjonLatexITest_canRender")
     }
 
     @Test
@@ -122,8 +122,7 @@ class PensjonLatexITest {
                 }
             }
 
-            Letter(testTemplate, brevData, Bokmal, Fixtures.felles)
-                .renderTestPDF("LATEX_ESCAPE_TEST_$startChar-$endChar")
+            renderTestPDF(testTemplate, brevData, Bokmal, Fixtures.felles, "LATEX_ESCAPE_TEST_$startChar-$endChar")
 
             return true
         } catch (e: Throwable) {

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/TemplateResourceTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/TemplateResourceTest.kt
@@ -31,9 +31,7 @@ class TemplateResourceTest {
         fixtures: T,
         spraak: Language,
     ) {
-        val letter = Letter(template, fixtures, spraak, Fixtures.felles)
-
-        letter.renderTestPDF(filnavn(etterlatteBrevKode, spraak))
+        renderTestPDF(template, fixtures, spraak, Fixtures.felles, filnavn(etterlatteBrevKode, spraak))
     }
 
     @ParameterizedTest(name = "{index} => template={0}, etterlatteBrevKode={1}, fixtures={2}, spraak={3}")
@@ -44,12 +42,13 @@ class TemplateResourceTest {
         fixtures: T,
         spraak: Language,
     ) {
-        Letter(
+        renderTestHtml(
             template,
             fixtures,
             spraak,
             Fixtures.felles,
-        ).renderTestHtml(filnavn(etterlatteBrevKode, spraak))
+            filnavn(etterlatteBrevKode, spraak)
+        )
     }
 
     private fun filnavn(brevkode: Brevkode<*>, spraak: Language) =

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/maler/andre/TomMalInformasjonsbrevTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/maler/andre/TomMalInformasjonsbrevTest.kt
@@ -4,7 +4,6 @@ import no.nav.pensjon.brev.TestTags
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.Fixtures
 import no.nav.pensjon.etterlatte.maler.ManueltBrevMedTittelDTO
@@ -16,23 +15,24 @@ internal class TomMalInformasjonsbrevTest {
 
     @Test
     fun pdftest() {
-        val letter = Letter(
+        renderTestPDF(
             TomMalInformasjonsbrev.template,
             Fixtures.create<ManueltBrevMedTittelDTO>(),
             Language.Bokmal,
-            Fixtures.felles
+            Fixtures.felles,
+            EtterlatteBrevKode.TOM_MAL_INFORMASJONSBREV.name
         )
-        letter.renderTestPDF(EtterlatteBrevKode.TOM_MAL_INFORMASJONSBREV.name)
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             TomMalInformasjonsbrev.template,
             Fixtures.create<ManueltBrevMedTittelDTO>(),
             Language.Bokmal,
-            Fixtures.felles
-        ).renderTestHtml(EtterlatteBrevKode.TOM_MAL_INFORMASJONSBREV.name)
+            Fixtures.felles,
+            EtterlatteBrevKode.TOM_MAL_INFORMASJONSBREV.name
+        )
     }
 
 }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/BarnepensjonFellesFraserAvslagTest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/maler/barnepensjon/BarnepensjonFellesFraserAvslagTest.kt
@@ -4,7 +4,6 @@ import no.nav.pensjon.brev.TestTags
 import no.nav.pensjon.brev.renderTestHtml
 import no.nav.pensjon.brev.renderTestPDF
 import no.nav.pensjon.brev.template.Language
-import no.nav.pensjon.brev.template.Letter
 import no.nav.pensjon.etterlatte.EtterlatteBrevKode
 import no.nav.pensjon.etterlatte.Fixtures
 import no.nav.pensjon.etterlatte.maler.barnepensjon.avslag.BarnepensjonAvslag
@@ -17,22 +16,23 @@ class BarnepensjonAvslagTest {
 
     @Test
     fun pdftest() {
-        val letter = Letter(
+        renderTestPDF(
             BarnepensjonAvslag.template,
             Fixtures.create<BarnepensjonAvslagDTO>(),
             Language.Bokmal,
             Fixtures.felles,
+            EtterlatteBrevKode.BARNEPENSJON_AVSLAG.name
         )
-        letter.renderTestPDF(EtterlatteBrevKode.BARNEPENSJON_AVSLAG.name)
     }
 
     @Test
     fun testHtml() {
-        Letter(
+        renderTestHtml(
             BarnepensjonAvslag.template,
             Fixtures.create<BarnepensjonAvslagDTO>(),
             Language.Bokmal,
             Fixtures.felles,
-        ).renderTestHtml(EtterlatteBrevKode.BARNEPENSJON_AVSLAG.name)
+            EtterlatteBrevKode.BARNEPENSJON_AVSLAG.name
+        )
     }
 }


### PR DESCRIPTION
Dermed kan vi (kanskje?) unngå å eksponere ut Letter i model-mal-pakka.

Synes også dette vart ein finare og betre signatur.