### PR TITLE
Forbetre shutdown for Unleash

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/BrevbakerAppModule.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/BrevbakerAppModule.kt
@@ -42,6 +42,7 @@ fun Application.brevbakerModule(
 
     monitor.subscribe(ApplicationStopPreparing) {
         it.log.info("Application preparing to shutdown gracefully")
+        FeatureToggleHandler.shutdown()
     }
     monitor.subscribe(ServerReady) { it.log.info("Ferdig med å sette opp applikasjonen") }
 

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/FeatureToggleHandler.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/FeatureToggleHandler.kt
@@ -38,6 +38,8 @@ object FeatureToggleHandler {
             state = InitState.DONE
         }
     }
+
+    fun shutdown() = unleash.shutdown()
 }
 
 enum class InitState { NEW, DONE }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Features.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Features.kt
@@ -45,4 +45,6 @@ object Features {
         PrincipalInContext.get()
             ?.let { UnleashContext.builder().userId(it.navIdent.id).build() }
             ?: UnleashContext.builder().build()
+
+    fun shutdown() = unleash?.shutdown()
 }


### PR DESCRIPTION
Under avslutning av pod får vi ofte feilmelding frå Unleash om Could not fetch toggles - sjå feks https://logs.adeo.no/app/r/s/2PDTD. 

_Trur_ trikset for å unngå det er å kalle Unleash sin eigen shutdown-metode.