### PR TITLE
Tar bort lengde på binær-array i exposed

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/EditLetterHash.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/EditLetterHash.kt
@@ -12,7 +12,7 @@ fun Column<Edit.Letter>.writeHashTo(hash: Column<ByteArray>) =
     WithEditLetterHash(this, hash)
 
 fun Table.hashColumn(name: String): Column<ByteArray> =
-    binary(name, 32)
+    binary(name)
 
 fun Column<ByteArray>.editLetterHash(): ValueClassWrapper<EditLetterHash, ByteArray> =
     wrap({ EditLetterHash(Hex.encodeHexString(it)) }, { Hex.decodeHex(it.hex) })


### PR DESCRIPTION
Å setje lengde på binær-tabellar i exposed har null effekt, og gir åtvaring (warn) i loggane, så tar det like godt bort. Under er koden frå biblioteket:

```
    override fun binaryType(): String = "bytea"
    override fun binaryType(length: Int): String {
        exposedLogger.warn("The length of the binary column is not required.")
        return binaryType()
    }
```