### PR TITLE
Databasemigrering for Skribenten

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@ apiModelVersion=116
 jacksonJsr310Version=2.18.2
 mockkVersion=1.13.13
 exposedVersion=0.58.0
+flywayVersion=11.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ micrometerVersion=1.14.1
 apiModelVersion=116
 jacksonJsr310Version=2.18.2
 mockkVersion=1.13.13
-exposedVersion=0.56.0
+exposedVersion=0.58.0

--- a/skribenten-backend/build.gradle.kts
+++ b/skribenten-backend/build.gradle.kts
@@ -11,6 +11,7 @@ val logbackVersion: String by project
 val logstashVersion: String by project
 val micrometerVersion: String by project
 val mockkVersion: String by project
+val flywayVersion: String by project
 
 plugins {
     application
@@ -82,6 +83,10 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
     implementation("org.postgresql:postgresql:42.7.4")
     implementation("com.zaxxer:HikariCP:6.2.1")
+
+
+    // Databasemigrering
+    implementation("org.flywaydb:flyway-database-postgresql:$flywayVersion")
 
     // Unleash
     implementation("io.getunleash:unleash-client-java:9.2.6")

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/DatabaseSchema.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/DatabaseSchema.kt
@@ -20,6 +20,7 @@ import no.nav.pensjon.brev.skribenten.model.Distribusjonstype
 import no.nav.pensjon.brev.skribenten.model.NavIdent
 import no.nav.pensjon.brev.skribenten.model.SaksbehandlerValg
 import no.nav.pensjon.brevbaker.api.model.LanguageCode
+import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
@@ -34,6 +35,7 @@ import org.jetbrains.exposed.sql.statements.api.ExposedBlob
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.Instant
 import java.time.LocalDate
+import javax.sql.DataSource
 
 @Suppress("unused")
 object Favourites : Table() {
@@ -168,22 +170,31 @@ fun initDatabase(config: Config) =
     }
 
 fun initDatabase(jdbcUrl: String, username: String, password: String) {
-    val database = Database.connect(
-        HikariDataSource(HikariConfig().apply {
-            this.jdbcUrl = jdbcUrl
-            this.username = username
-            this.password = password
-            this.initializationFailTimeout = 6000
-            maximumPoolSize = 2
-            validate()
-        }),
-    )
+    val database = HikariDataSource(HikariConfig().apply {
+        this.jdbcUrl = jdbcUrl
+        this.username = username
+        this.password = password
+        this.initializationFailTimeout = 6000
+        maximumPoolSize = 2
+        validate()
+    })
+        .also { konfigurerFlyway(it) }
+        .let { Database.connect(it) }
+
     transaction(database) {
         withDataBaseLock {
             SchemaUtils.createMissingTablesAndColumns(BrevredigeringTable, DocumentTable, Favourites, MottakerTable)
+
         }
     }
 }
+
+private fun konfigurerFlyway(dataSource: DataSource) = Flyway
+    .configure()
+    .dataSource(dataSource)
+    .baselineOnMigrate(true)
+    .load()
+    .migrate()
 
 
 private fun createJdbcUrl(config: Config): String =

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/DatabaseSchema.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/DatabaseSchema.kt
@@ -27,12 +27,10 @@ import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.sql.*
-import org.jetbrains.exposed.sql.SchemaUtils.withDataBaseLock
 import org.jetbrains.exposed.sql.javatime.date
 import org.jetbrains.exposed.sql.javatime.timestamp
 import org.jetbrains.exposed.sql.json.json
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
-import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.Instant
 import java.time.LocalDate
 import javax.sql.DataSource
@@ -169,8 +167,8 @@ fun initDatabase(config: Config) =
         initDatabase(createJdbcUrl(it), it.getString("username"), it.getString("password"))
     }
 
-fun initDatabase(jdbcUrl: String, username: String, password: String) {
-    val database = HikariDataSource(HikariConfig().apply {
+fun initDatabase(jdbcUrl: String, username: String, password: String) =
+    HikariDataSource(HikariConfig().apply {
         this.jdbcUrl = jdbcUrl
         this.username = username
         this.password = password
@@ -180,14 +178,6 @@ fun initDatabase(jdbcUrl: String, username: String, password: String) {
     })
         .also { konfigurerFlyway(it) }
         .let { Database.connect(it) }
-
-    transaction(database) {
-        withDataBaseLock {
-            SchemaUtils.createMissingTablesAndColumns(BrevredigeringTable, DocumentTable, Favourites, MottakerTable)
-
-        }
-    }
-}
 
 private fun konfigurerFlyway(dataSource: DataSource) = Flyway
     .configure()

--- a/skribenten-backend/src/main/resources/db/migration/V1__baseline.sql
+++ b/skribenten-backend/src/main/resources/db/migration/V1__baseline.sql
@@ -57,3 +57,8 @@ CREATE TABLE IF NOT EXISTS mottaker
     landkode           VARCHAR(2)  NULL,
     CONSTRAINT fk_mottaker_brevredigeringid__id FOREIGN KEY ("brevredigeringId") REFERENCES brevredigering (id) ON DELETE CASCADE ON UPDATE RESTRICT
 );
+
+CREATE TABLE IF NOT EXISTS busy
+(
+    busy BOOLEAN NOT NULL CONSTRAINT busy_busy_unique UNIQUE
+);

--- a/skribenten-backend/src/main/resources/db/migration/V1__baseline.sql
+++ b/skribenten-backend/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,60 @@
+CREATE TABLE IF NOT EXISTS brevredigering
+(
+    id                       BIGSERIAL PRIMARY KEY,
+    "saksId"                 BIGINT      NOT NULL,
+    "vedtaksId"              BIGINT      NULL,
+    brevkode                 VARCHAR(50) NOT NULL,
+    spraak                   VARCHAR(50) NOT NULL,
+    "avsenderEnhetId"        VARCHAR(50) NULL,
+    "saksbehandlerValg"      JSON        NOT NULL,
+    "redigertBrev"           JSON        NOT NULL,
+    "redigertBrevHash"       bytea       NOT NULL,
+    "laastForRedigering"     BOOLEAN     NOT NULL,
+    distribusjonstype        VARCHAR(50) NOT NULL,
+    "redigeresAvNavIdent"    VARCHAR(50) NULL,
+    "sistRedigertAvNavIdent" VARCHAR(50) NOT NULL,
+    "opprettetAvNavIdent"    VARCHAR(50) NOT NULL,
+    opprettet                TIMESTAMP   NOT NULL,
+    sistredigert             TIMESTAMP   NOT NULL,
+    "sistReservert"          TIMESTAMP   NULL,
+    "signaturSignerende"     VARCHAR(50) NOT NULL,
+    "signaturAttestant"      VARCHAR(50) NULL,
+    "journalpostId"          BIGINT      NULL,
+    "attestertAvNavIdent"    VARCHAR(50) NULL
+);
+CREATE INDEX brevredigering_saksid ON brevredigering ("saksId");
+CREATE INDEX brevredigering_opprettetavnavident ON brevredigering ("opprettetAvNavIdent");
+CREATE TABLE IF NOT EXISTS "Document"
+(
+    id                 BIGSERIAL PRIMARY KEY,
+    brevredigering     BIGINT NOT NULL,
+    "dokumentDato"     DATE   NOT NULL,
+    brevpdf            bytea  NOT NULL,
+    "redigertBrevHash" bytea  NOT NULL,
+    CONSTRAINT fk_document_brevredigering__id FOREIGN KEY (brevredigering) REFERENCES brevredigering (id) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+ALTER TABLE "Document"
+    ADD CONSTRAINT document_brevredigering_unique UNIQUE (brevredigering);
+CREATE TABLE IF NOT EXISTS favourites
+(
+    id            SERIAL,
+    "User Id"     VARCHAR(50) NOT NULL,
+    "Letter Code" VARCHAR(50) NOT NULL,
+    CONSTRAINT PK_Favourite_ID PRIMARY KEY (id)
+);
+CREATE TABLE IF NOT EXISTS mottaker
+(
+    "brevredigeringId" BIGINT PRIMARY KEY,
+    "type"             VARCHAR(50) NOT NULL,
+    "tssId"            VARCHAR(50) NULL,
+    navn               VARCHAR(50) NULL,
+    postnummer         VARCHAR(50) NULL,
+    poststed           TEXT        NULL,
+    adresselinje1      TEXT        NULL,
+    adresselinje2      TEXT        NULL,
+    adresselinje3      TEXT        NULL,
+    landkode           VARCHAR(2)  NULL,
+    CONSTRAINT fk_mottaker_brevredigeringid__id FOREIGN KEY ("brevredigeringId") REFERENCES brevredigering (id) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+ALTER TABLE mottaker
+    ADD CONSTRAINT mottaker_brevredigeringid_unique UNIQUE ("brevredigeringId");

--- a/skribenten-backend/src/main/resources/db/migration/V1__baseline.sql
+++ b/skribenten-backend/src/main/resources/db/migration/V1__baseline.sql
@@ -22,19 +22,19 @@ CREATE TABLE IF NOT EXISTS brevredigering
     "journalpostId"          BIGINT      NULL,
     "attestertAvNavIdent"    VARCHAR(50) NULL
 );
-CREATE INDEX brevredigering_saksid ON brevredigering ("saksId");
-CREATE INDEX brevredigering_opprettetavnavident ON brevredigering ("opprettetAvNavIdent");
+CREATE INDEX IF NOT EXISTS brevredigering_saksid ON brevredigering ("saksId");
+CREATE INDEX IF NOT EXISTS brevredigering_opprettetavnavident ON brevredigering ("opprettetAvNavIdent");
+
 CREATE TABLE IF NOT EXISTS "Document"
 (
     id                 BIGSERIAL PRIMARY KEY,
-    brevredigering     BIGINT NOT NULL,
+    brevredigering     BIGINT NOT NULL CONSTRAINT document_brevredigering_unique UNIQUE,
     "dokumentDato"     DATE   NOT NULL,
     brevpdf            bytea  NOT NULL,
     "redigertBrevHash" bytea  NOT NULL,
     CONSTRAINT fk_document_brevredigering__id FOREIGN KEY (brevredigering) REFERENCES brevredigering (id) ON DELETE CASCADE ON UPDATE RESTRICT
 );
-ALTER TABLE "Document"
-    ADD CONSTRAINT document_brevredigering_unique UNIQUE (brevredigering);
+
 CREATE TABLE IF NOT EXISTS favourites
 (
     id            SERIAL,
@@ -42,9 +42,10 @@ CREATE TABLE IF NOT EXISTS favourites
     "Letter Code" VARCHAR(50) NOT NULL,
     CONSTRAINT PK_Favourite_ID PRIMARY KEY (id)
 );
+
 CREATE TABLE IF NOT EXISTS mottaker
 (
-    "brevredigeringId" BIGINT PRIMARY KEY,
+    "brevredigeringId" BIGINT PRIMARY KEY CONSTRAINT mottaker_brevredigeringid_unique UNIQUE,
     "type"             VARCHAR(50) NOT NULL,
     "tssId"            VARCHAR(50) NULL,
     navn               VARCHAR(50) NULL,
@@ -56,5 +57,3 @@ CREATE TABLE IF NOT EXISTS mottaker
     landkode           VARCHAR(2)  NULL,
     CONSTRAINT fk_mottaker_brevredigeringid__id FOREIGN KEY ("brevredigeringId") REFERENCES brevredigering (id) ON DELETE CASCADE ON UPDATE RESTRICT
 );
-ALTER TABLE mottaker
-    ADD CONSTRAINT mottaker_brevredigeringid_unique UNIQUE ("brevredigeringId");


### PR DESCRIPTION
Bruker Flyway.

I nyaste Exposed-patchversjon (0.58.0) er metoden vi brukte for å halde databasen oppdatert (`SchemaUtils.createMissingTablesAndColumns`) deprecated, med kommentaren 
> "Execution of this function might lead to unpredictable state in the database if a failure occurs at any point. " +
>             "To prevent this, please use `MigrationUtils.statementsRequiredForDatabaseMigration` with a third-party migration tool (e.g., Flyway).",

`MigrationUtils.statementsRequiredForDatabaseMigration` returnerte lokalt kun `CREATE SEQUENCE`- og `DROP SEQUENCE`-kall. Det fins også ein metode `MigrationUtils.generateMigrationScript` som kan generere opp alt til filer, som returnerte fleire rader, men dette kjens knotete å jobbe med. I tillegg, og viktigare, er at å basere seg på Exposed si auto-oppdaging av endringar kjens sårbart og ustabilt, når den referte metoden ikkje funkar heilt, så vi må basere oss på workarounds, og ikkje noko eg er komfortabel med å basere oss på.

Dermed trur eg det er betre å bruke Flyway utan om og men. Det er velprøvd, etablert og stabilt. Som ein konsekvens gjer endringar i databasestrukturen at vi treng Flyway-migreringsskript, men her har vi ein ganske liten database med høgst sannsynleg små skript.

Endringar i data, viss det skulle bli behov for det, kan gjerast med akkurat tilsvarande Flyway-skript.


Har tatt ut DDL frå databasen i dev-gcp, og samanlikna med den som er i baseline-skriptet no, og det blir identisk. I praksis vil ingen av linjene i skriptet slå til under køyring, fordi det er tabellar som allereie fins, og `if not exists` på alt. Men dette vil gjera at testane startar med samme database-grunnlag som prodkoden, utan noko om og men.