### PR TITLE
EY-4731: Vise både land på norsk og landkode i trygdetidstabell

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -90,7 +90,8 @@ enum class BeregningsMetode {
 data class Trygdetidsperiode(
     val datoFOM: LocalDate,
     val datoTOM: LocalDate?,
-    val land: String,
+    val landkode: String,
+    val land: String?,
     val opptjeningsperiode: Periode?,
     val type: TrygdetidType,
 )

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/Trygdetidstabell.kt
@@ -11,6 +11,7 @@ import no.nav.pensjon.etterlatte.maler.Trygdetidsperiode
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.datoFOM
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.datoTOM
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.land
+import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.landkode
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.opptjeningsperiode
 import no.nav.pensjon.etterlatte.maler.TrygdetidsperiodeSelectors.type
 import no.nav.pensjon.etterlatte.maler.fraser.common.PeriodeITabell
@@ -49,11 +50,19 @@ data class Trygdetidstabell(
                     row {
                         cell { includePhrase(PeriodeITabell(periode.datoFOM, periode.datoTOM)) }
                         cell {
-                            textExpr(
-                                Language.Bokmal to periode.land,
-                                Language.Nynorsk to periode.land,
-                                Language.English to periode.land,
-                            )
+                            ifNotNull(periode.land) { land ->
+                                textExpr(
+                                    Language.Bokmal to land + " (" + periode.landkode + ")",
+                                    Language.Nynorsk to land + " (" + periode.landkode + ")",
+                                    Language.English to land + " (" + periode.landkode + ")",
+                                )
+                            }.orShow {
+                                textExpr(
+                                    Language.Bokmal to periode.landkode,
+                                    Language.Nynorsk to periode.landkode,
+                                    Language.English to periode.landkode,
+                                )
+                            }
                         }
                         cell {
                             ifNotNull(periode.opptjeningsperiode) {

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonForeldreloes.kt
@@ -25,14 +25,16 @@ fun createBarnepensjonForeldreloesDTO(): BarnepensjonForeldreloesDTO {
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2004, 1, 1),
                 datoTOM = LocalDate.of(2024, 1, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(20, 0, 0),
                 type = TrygdetidType.FAKTISK
             ),
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2024, 1, 1),
                 datoTOM = LocalDate.of(2044, 1, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(20, 0, 0),
                 type = TrygdetidType.FREMTIDIG
             )
@@ -50,21 +52,24 @@ fun createBarnepensjonForeldreloesDTO(): BarnepensjonForeldreloesDTO {
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2004, 1, 1),
                 datoTOM = LocalDate.of(2014, 1, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(10, 0, 0),
                 type = TrygdetidType.FAKTISK
             ),
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2014, 1, 1),
                 datoTOM = LocalDate.of(2023, 10, 1),
-                land = "SWE",
+                land = "Sverige",
+                landkode = "SWE",
                 opptjeningsperiode = Periode(10, 0, 0),
                 type = TrygdetidType.FAKTISK
             ),
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2023, 11, 1),
                 datoTOM = LocalDate.of(2044, 1, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(20, 0, 0),
                 type = TrygdetidType.FREMTIDIG
             )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonInnvilgelse.kt
@@ -21,14 +21,16 @@ fun createBarnepensjonInnvilgelseDTO(): BarnepensjonInnvilgelseDTO {
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2004, 1, 1),
                 datoTOM = LocalDate.of(2024, 1, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(20, 0, 0),
                 type = TrygdetidType.FAKTISK
             ),
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2024, 1, 1),
                 datoTOM = LocalDate.of(2044, 1, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(20, 0, 0),
                 type = TrygdetidType.FREMTIDIG
             )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonOmregnetNyttRegelverk.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonOmregnetNyttRegelverk.kt
@@ -61,14 +61,16 @@ internal fun lagBeregning() = BarnepensjonBeregning(
                 Trygdetidsperiode(
                     datoFOM = LocalDate.of(2004, 1, 1),
                     datoTOM = LocalDate.of(2024, 1, 1),
-                    land = "NOR",
+                    land = "Norge",
+                    landkode = "NOR",
                     opptjeningsperiode = Periode(20, 0, 0),
                     type = TrygdetidType.FAKTISK
                 ),
                 Trygdetidsperiode(
                     datoFOM = LocalDate.of(2024, 1, 1),
                     datoTOM = LocalDate.of(2044, 1, 1),
-                    land = "NOR",
+                    land = "Norge",
+                    landkode = "NOR",
                     opptjeningsperiode = Periode(20, 0, 0),
                     type = TrygdetidType.FREMTIDIG
                 )
@@ -86,14 +88,16 @@ internal fun lagBeregning() = BarnepensjonBeregning(
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2004, 1, 1),
                 datoTOM = LocalDate.of(2024, 1, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(20, 0, 0),
                 type = TrygdetidType.FAKTISK
             ),
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2024, 1, 1),
                 datoTOM = LocalDate.of(2044, 1, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(20, 0, 0),
                 type = TrygdetidType.FREMTIDIG
             )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonRevurdering.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/BarnepensjonRevurdering.kt
@@ -21,14 +21,16 @@ fun createBarnepensjonRevurderingDTO():BarnepensjonRevurderingDTO {
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2004, 1, 1),
                 datoTOM = LocalDate.of(2024, 3, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(20, 2, 0),
                 type = TrygdetidType.FAKTISK
             ),
             Trygdetidsperiode(
                 datoFOM = LocalDate.of(2024, 4, 1),
                 datoTOM = LocalDate.of(2044, 1, 1),
-                land = "NOR",
+                land = "Norge",
+                landkode = "NOR",
                 opptjeningsperiode = Periode(19, 10, 0),
                 type = TrygdetidType.FREMTIDIG
             )
@@ -83,14 +85,16 @@ fun createBarnepensjonRevurderingDTO():BarnepensjonRevurderingDTO {
                         Trygdetidsperiode(
                             datoFOM = LocalDate.of(2014, 1, 1),
                             datoTOM = LocalDate.of(2024, 1, 1),
-                            land = "NOR",
+                            land = "Norge",
+                            landkode = "NOR",
                             opptjeningsperiode = Periode(10, 0, 0),
                             type = TrygdetidType.FAKTISK
                         ),
                         Trygdetidsperiode(
                             datoFOM = LocalDate.of(2024, 1, 1),
                             datoTOM = LocalDate.of(2044, 1, 1),
-                            land = "NOR",
+                            land = "Norge",
+                            landkode = "NOR",
                             opptjeningsperiode = Periode(20, 0, 0),
                             type = TrygdetidType.FREMTIDIG
                         )

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadInntektsjusteringVedtakDTO.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadInntektsjusteringVedtakDTO.kt
@@ -53,14 +53,16 @@ fun createOmstillingsstoenadInntektsjusteringVedtakDTO() = AarligInntektsjusteri
                 Trygdetidsperiode(
                     datoFOM = LocalDate.of(2004, 1, 1),
                     datoTOM = LocalDate.of(2024, 1, 1),
-                    land = "NOR",
+                    land = "Norge",
+                    landkode = "NOR",
                     opptjeningsperiode = Periode(20, 0, 0),
                     type = TrygdetidType.FAKTISK,
                 ),
                 Trygdetidsperiode(
                     datoFOM = LocalDate.of(2024, 1, 1),
                     datoTOM = LocalDate.of(2044, 1, 1),
-                    land = "NOR",
+                    land = "Norge",
+                    landkode = "NOR",
                     opptjeningsperiode = Periode(20, 0, 0),
                     type = TrygdetidType.FREMTIDIG,
                 ),

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadInnvilgelse.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadInnvilgelse.kt
@@ -76,14 +76,16 @@ fun createOmstillingsstoenadInnvilgelseDTO() =
                     Trygdetidsperiode(
                         datoFOM = LocalDate.of(2004, 1, 1),
                         datoTOM = LocalDate.of(2024, 1, 1),
-                        land = "NOR",
+                        land = "Norge",
+                        landkode = "NOR",
                         opptjeningsperiode = Periode(20, 0, 0),
                         type = TrygdetidType.FAKTISK,
                     ),
                     Trygdetidsperiode(
                         datoFOM = LocalDate.of(2024, 1, 1),
                         datoTOM = LocalDate.of(2044, 1, 1),
-                        land = "NOR",
+                        land = "Norge",
+                        landkode = "NOR",
                         opptjeningsperiode = Periode(20, 0, 0),
                         type = TrygdetidType.FREMTIDIG,
                     ),

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadRevurdering.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/etterlatte/fixtures/OmstillingsstoenadRevurdering.kt
@@ -71,14 +71,16 @@ fun createOmstillingsstoenadRevurderingDTO() =
                                 Trygdetidsperiode(
                                     datoFOM = LocalDate.of(2000, 1, 1),
                                     datoTOM = LocalDate.of(2023, 12, 31),
-                                    land = "NOR",
+                                    land = "Norge",
+                                    landkode = "NOR",
                                     opptjeningsperiode = Periode(23, 0, 0),
                                     type = TrygdetidType.FAKTISK,
                                 ),
                                 Trygdetidsperiode(
                                     datoFOM = LocalDate.of(2024, 1, 1),
                                     datoTOM = LocalDate.of(2050, 12, 31),
-                                    land = "NOR",
+                                    land = "Norge",
+                                    landkode = "NOR",
                                     opptjeningsperiode = Periode(26, 0, 0),
                                     type = TrygdetidType.FREMTIDIG,
                                 ),


### PR DESCRIPTION
Viser nå feks `Norge (NOR)` i stedet for bare `NOR`.