### PR TITLE
Får iblant feilmeldinga java.lang.IllegalStateException: Storage for …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ jacksonJsr310Version=2.18.2
 mockkVersion=1.13.13
 exposedVersion=0.58.0
 flywayVersion=11.2.0
+ksp.incremental=false


### PR DESCRIPTION
…[...\id-to-file.tab] is already registered.

Ved å skru av incremental mode for ksp forsvinn denne feilmeldinga, og alt ser ut til å fungere som normalt.