### PR TITLE
Bruker konsekvent setup-gradle-actionen.

### DIFF
--- a/.github/workflows/brevbaker-api-model.yaml
+++ b/.github/workflows/brevbaker-api-model.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "gradle/actions/wrapper-validation@v4"
-      - name: "gradle/actions/setup-gradle@v4"
+      - uses: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"

--- a/.github/workflows/brevbaker-api-model.yaml
+++ b/.github/workflows/brevbaker-api-model.yaml
@@ -42,11 +42,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "gradle/actions/wrapper-validation@v4"
-      - uses: "actions/cache@v4"
-        with:
-          "path": "~/.gradle/caches"
-          "key": "${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}"
-          "restore-keys": "${{ runner.os }}-gradle-"
+      - name: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"
@@ -68,11 +64,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "gradle/actions/wrapper-validation@v4"
-      - uses: "actions/cache@v4"
-        with:
-          "path": "~/.gradle/caches"
-          "key": "${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}"
-          "restore-keys": "${{ runner.os }}-gradle-"
+      - uses: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"
@@ -92,11 +84,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "gradle/actions/wrapper-validation@v4"
-      - uses: "actions/cache@v4"
-        with:
-          "path": "~/.gradle/caches"
-          "key": "${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}"
-          "restore-keys": "${{ runner.os }}-gradle-"
+      - uses: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"

--- a/.github/workflows/pdfbygger-brevbaker.yml
+++ b/.github/workflows/pdfbygger-brevbaker.yml
@@ -44,11 +44,12 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "gradle/actions/wrapper-validation@v4"
+      - name: "Setup Gradle"
+        uses: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"
           "java-version": "17"
-          "cache": "gradle"
 
       - name: "compile and run tests"
         run: |
@@ -81,11 +82,11 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "gradle/actions/wrapper-validation@v4"
+      - uses: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"
           "java-version": "17"
-          "cache": "gradle"
       - name: "compile and run tests"
         run: |
           ./gradlew :brevbaker-api-model-common:publishToMavenLocal
@@ -143,11 +144,11 @@ jobs:
       packages: write
     steps:
       - uses: "actions/checkout@v4"
+      - uses: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"
           "java-version": "17"
-          "cache": "gradle"
       - name: "run integration tests"
         run: |
           ./gradlew :brevbaker-api-model-common:publishToMavenLocal 

--- a/.github/workflows/skribenten.yml
+++ b/.github/workflows/skribenten.yml
@@ -28,11 +28,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "gradle/actions/wrapper-validation@v4"
-      - uses: "actions/cache@v4"
-        with:
-          "path": "~/.gradle/caches"
-          "key": "${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}"
-          "restore-keys": "${{ runner.os }}-gradle-"
+      - uses: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"

--- a/.github/workflows/template-model-generator.yml
+++ b/.github/workflows/template-model-generator.yml
@@ -16,16 +16,10 @@ jobs:
       contents: "read"
       packages: "read"
       id-token: "write"
-    outputs:
-      image: ${{ steps.docker-push.outputs.image }}
     steps:
       - uses: "actions/checkout@v4"
       - uses: "gradle/actions/wrapper-validation@v4"
-      - uses: "actions/cache@v4"
-        with:
-          "path": "~/.gradle/caches"
-          "key": "${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}"
-          "restore-keys": "${{ runner.os }}-gradle-"
+      - uses: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"

--- a/.github/workflows/tjenestebuss-integrasjon.yml
+++ b/.github/workflows/tjenestebuss-integrasjon.yml
@@ -29,11 +29,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "gradle/actions/wrapper-validation@v4"
-      - uses: "actions/cache@v4"
-        with:
-          "path": "~/.gradle/caches"
-          "key": "${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}"
-          "restore-keys": "${{ runner.os }}-gradle-"
+      - uses: "gradle/actions/setup-gradle@v4"
       - uses: "actions/setup-java@v4"
         with:
           "distribution": "temurin"


### PR DESCRIPTION
Denne tar seg av caching, og er ifølgje Gradle-teamet å føretrekkje framfor feks setup-java-actionen, ref https://github.com/gradle/actions/blob/main/docs/setup-gradle.md