### PR TITLE
Flytte KronerText til dsl-en

### DIFF
--- a/brevbaker-dsl/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/common/KronerText.kt
+++ b/brevbaker-dsl/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/common/KronerText.kt
@@ -1,0 +1,26 @@
+package no.nav.pensjon.brev.maler.fraser.common
+
+import no.nav.pensjon.brev.model.format
+import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Text.FontType
+import no.nav.pensjon.brev.template.Expression
+import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
+import no.nav.pensjon.brev.template.Language.Bokmal
+import no.nav.pensjon.brev.template.Language.English
+import no.nav.pensjon.brev.template.Language.Nynorsk
+import no.nav.pensjon.brev.template.TextOnlyPhrase
+import no.nav.pensjon.brev.template.dsl.TextOnlyScope
+import no.nav.pensjon.brev.template.dsl.expression.expr
+import no.nav.pensjon.brev.template.dsl.expression.plus
+import no.nav.pensjon.brev.template.dsl.textExpr
+import no.nav.pensjon.brevbaker.api.model.Kroner
+
+data class KronerText(val kroner: Expression<Kroner>, val fontType: FontType = FontType.PLAIN) :
+    TextOnlyPhrase<LangBokmalNynorskEnglish>() {
+    override fun TextOnlyScope<LangBokmalNynorskEnglish, Unit>.template() =
+        textExpr(
+            Bokmal to kroner.format() + " kr",
+            Nynorsk to kroner.format() + " kr",
+            English to "NOK ".expr() + kroner.format(),
+            fontType,
+        )
+}

--- a/brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/common/KronerText.kt
+++ b/brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/common/KronerText.kt
@@ -1,12 +1,10 @@
 package no.nav.pensjon.brev.maler.fraser.common
 
 import no.nav.pensjon.brev.model.format
-import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Text.FontType
+import no.nav.pensjon.brev.template.Element
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
-import no.nav.pensjon.brev.template.Language.Bokmal
-import no.nav.pensjon.brev.template.Language.English
-import no.nav.pensjon.brev.template.Language.Nynorsk
+import no.nav.pensjon.brev.template.Language
 import no.nav.pensjon.brev.template.TextOnlyPhrase
 import no.nav.pensjon.brev.template.dsl.TextOnlyScope
 import no.nav.pensjon.brev.template.dsl.expression.expr
@@ -14,13 +12,13 @@ import no.nav.pensjon.brev.template.dsl.expression.plus
 import no.nav.pensjon.brev.template.dsl.textExpr
 import no.nav.pensjon.brevbaker.api.model.Kroner
 
-data class KronerText(val kroner: Expression<Kroner>, val fontType: FontType = FontType.PLAIN) :
+data class KronerText(val kroner: Expression<Kroner>, val fontType: Element.OutlineContent.ParagraphContent.Text.FontType = Element.OutlineContent.ParagraphContent.Text.FontType.PLAIN) :
     TextOnlyPhrase<LangBokmalNynorskEnglish>() {
     override fun TextOnlyScope<LangBokmalNynorskEnglish, Unit>.template() =
         textExpr(
-            Bokmal to kroner.format() + " kr",
-            Nynorsk to kroner.format() + " kr",
-            English to "NOK ".expr() + kroner.format(),
+            Language.Bokmal to kroner.format() + " kr",
+            Language.Nynorsk to kroner.format() + " kr",
+            Language.English to "NOK ".expr() + kroner.format(),
             fontType,
         )
 }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/VedleggMaanedligeUfoeretrgdFoerSkatt.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/VedleggMaanedligeUfoeretrgdFoerSkatt.kt
@@ -21,7 +21,7 @@ import no.nav.pensjon.brev.api.model.vedlegg.MaanedligUfoeretrygdFoerSkattDtoSel
 import no.nav.pensjon.brev.api.model.vedlegg.MaanedligUfoeretrygdFoerSkattDtoSelectors.UfoeretrygdPerMaanedSelectors.totalUTBeloepNetto
 import no.nav.pensjon.brev.api.model.vedlegg.MaanedligUfoeretrygdFoerSkattDtoSelectors.UfoeretrygdPerMaanedSelectors.virkningFraOgMed
 import no.nav.pensjon.brev.api.model.vedlegg.MaanedligUfoeretrygdFoerSkattDtoSelectors.UfoeretrygdPerMaanedSelectors.virkningTilOgMed
-import no.nav.pensjon.brev.maler.fraser.common.Felles.KronerText
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.*
 import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Text.FontType

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/VedleggOpplysningerOmEtteroppgjoeret.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/VedleggOpplysningerOmEtteroppgjoeret.kt
@@ -39,6 +39,7 @@ import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerOmEtteroppgjoeretDtoSel
 import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerOmEtteroppgjoeretDtoSelectors.InntektOgFratrekkSelectors.inntekt
 import no.nav.pensjon.brev.maler.fraser.common.Constants
 import no.nav.pensjon.brev.maler.fraser.common.Felles
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.model.ubestemtForm
 import no.nav.pensjon.brev.template.*
@@ -133,9 +134,9 @@ data class FikkSkulleFaattTabell(
                     ifNotNull(resultat) {
                         row {
                             cell { addTextContent(typeStoenad) }
-                            cell { includePhrase(Felles.KronerText(it.skulleFaatt)) }
-                            cell { includePhrase(Felles.KronerText(it.fikk)) }
-                            cell { includePhrase(Felles.KronerText(it.avvik)) }
+                            cell { includePhrase(KronerText(it.skulleFaatt)) }
+                            cell { includePhrase(KronerText(it.fikk)) }
+                            cell { includePhrase(KronerText(it.avvik)) }
                         }
                     }
                 }
@@ -178,7 +179,7 @@ data class FikkSkulleFaattTabell(
                     }
                     cell { }
                     cell { }
-                    cell { includePhrase(Felles.KronerText(totaltAvvik, FontType.BOLD)) }
+                    cell { includePhrase(KronerText(totaltAvvik, FontType.BOLD)) }
                 }
             }
         }
@@ -984,14 +985,14 @@ data class FratrekkTabell(
                         eval(fratrekkLinje.aarsak.format(LocalizedAarsak))
                     }
                     cell {
-                        includePhrase(Felles.KronerText(fratrekkLinje.beloep))
+                        includePhrase(KronerText(fratrekkLinje.beloep))
                     }
                 }
             }
             row {
                 cell { addTextContent(sumText) }
                 cell { }
-                cell { includePhrase(Felles.KronerText(fratrekk.sum, fontType = FontType.BOLD)) }
+                cell { includePhrase(KronerText(fratrekk.sum, fontType = FontType.BOLD)) }
             }
         }
 
@@ -1142,14 +1143,14 @@ data class InntektTabell(
                         eval(inntektLinje.registerKilde.format(LocalizedKilde))
                     }
                     cell {
-                        includePhrase(Felles.KronerText(inntektLinje.beloep))
+                        includePhrase(KronerText(inntektLinje.beloep))
                     }
                 }
             }
             row {
                 cell { addTextContent(sumText) }
                 cell { }
-                cell { includePhrase(Felles.KronerText(inntekt.sum, fontType = FontType.BOLD)) }
+                cell { includePhrase(KronerText(inntekt.sum, fontType = FontType.BOLD)) }
             }
         }
 

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/VedleggOpplysningerOmEtteroppgjoeret.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/VedleggOpplysningerOmEtteroppgjoeret.kt
@@ -38,7 +38,6 @@ import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerOmEtteroppgjoeretDtoSel
 import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerOmEtteroppgjoeretDtoSelectors.InntektOgFratrekkSelectors.fratrekk
 import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerOmEtteroppgjoeretDtoSelectors.InntektOgFratrekkSelectors.inntekt
 import no.nav.pensjon.brev.maler.fraser.common.Constants
-import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.model.ubestemtForm

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/opplysningerbruktiberegningufoere/OpplysningerOmBarnetillegg.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/opplysningerbruktiberegningufoere/OpplysningerOmBarnetillegg.kt
@@ -39,6 +39,7 @@ import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerBruktIBeregningUTDtoSel
 import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerBruktIBeregningUTDtoSelectors.BarnetilleggGjeldendeSelectors.foedselsdatoPaaBarnTilleggetGjelder
 import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerBruktIBeregningUTDtoSelectors.BarnetilleggGjeldendeSelectors.saerkullsbarn_safe
 import no.nav.pensjon.brev.maler.fraser.common.Felles
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.bestemtForm
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.model.ubestemtForm
@@ -394,7 +395,7 @@ data class OpplysningerOmBarnetillegg(
                             )
                         }
                         cell {
-                            includePhrase(Felles.KronerText(beloepAarBrutto))
+                            includePhrase(KronerText(beloepAarBrutto))
                         }
                     }
 
@@ -416,7 +417,7 @@ data class OpplysningerOmBarnetillegg(
                                 }
                             }
                             cell {
-                                includePhrase(Felles.KronerText(avkortningsbeloepAar))
+                                includePhrase(KronerText(avkortningsbeloepAar))
                             }
                         }
                     }
@@ -432,7 +433,7 @@ data class OpplysningerOmBarnetillegg(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(justeringsbeloepAar.absoluteValue()))
+                                includePhrase(KronerText(justeringsbeloepAar.absoluteValue()))
                             }
                         }
                     }
@@ -448,7 +449,7 @@ data class OpplysningerOmBarnetillegg(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(beloepAarNetto, BOLD))
+                                includePhrase(KronerText(beloepAarNetto, BOLD))
                             }
                         }
                     }
@@ -463,7 +464,7 @@ data class OpplysningerOmBarnetillegg(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(beloepNetto))
+                                includePhrase(KronerText(beloepNetto))
                             }
                         }
                     }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/opplysningerbruktiberegningufoere/TabellUfoereOpplysninger.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/vedlegg/opplysningerbruktiberegningufoere/TabellUfoereOpplysninger.kt
@@ -46,6 +46,7 @@ import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerBruktIBeregningUTDtoSel
 import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerBruktIBeregningUTDtoSelectors.YrkesskadeGjeldendeSelectors.skadetidspunkt
 import no.nav.pensjon.brev.api.model.vedlegg.OpplysningerBruktIBeregningUTDtoSelectors.YrkesskadeGjeldendeSelectors.yrkesskadegrad
 import no.nav.pensjon.brev.maler.fraser.common.Felles
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.tableFormat
 import no.nav.pensjon.brev.template.Element
 import no.nav.pensjon.brev.template.Expression
@@ -114,7 +115,7 @@ data class TabellUfoereOpplysninger(
                             )
                         }
                         cell {
-                            includePhrase(Felles.KronerText(ufoeretrygdGjeldende.beregningsgrunnlagBeloepAar))
+                            includePhrase(KronerText(ufoeretrygdGjeldende.beregningsgrunnlagBeloepAar))
                         }
                     }
                 }
@@ -129,7 +130,7 @@ data class TabellUfoereOpplysninger(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(beloep))
+                                includePhrase(KronerText(beloep))
                             }
                         }
                     }
@@ -144,7 +145,7 @@ data class TabellUfoereOpplysninger(
                             )
                         }
                         cell {
-                            includePhrase(Felles.KronerText(inntektFoerUfoereGjeldende.ifuInntekt))
+                            includePhrase(KronerText(inntektFoerUfoereGjeldende.ifuInntekt))
                         }
                     }
                 }
@@ -159,7 +160,7 @@ data class TabellUfoereOpplysninger(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(beloep))
+                                includePhrase(KronerText(beloep))
                             }
                         }
                     }
@@ -191,7 +192,7 @@ data class TabellUfoereOpplysninger(
                             )
                         }
                         cell {
-                            includePhrase(Felles.KronerText(inntektsAvkortingGjeldende.inntektsgrenseAar))
+                            includePhrase(KronerText(inntektsAvkortingGjeldende.inntektsgrenseAar))
                         }
                     }
                 }
@@ -205,7 +206,7 @@ data class TabellUfoereOpplysninger(
                             )
                         }
                         cell {
-                            includePhrase(Felles.KronerText(inntektsAvkortingGjeldende.forventetInntektAar))
+                            includePhrase(KronerText(inntektsAvkortingGjeldende.forventetInntektAar))
                         }
                     }
                 }
@@ -238,7 +239,7 @@ data class TabellUfoereOpplysninger(
                             )
                         }
                         cell {
-                            includePhrase(Felles.KronerText(inntektsAvkortingGjeldende.inntektstak))
+                            includePhrase(KronerText(inntektsAvkortingGjeldende.inntektstak))
                         }
                     }
                 }.orShow {
@@ -251,7 +252,7 @@ data class TabellUfoereOpplysninger(
                             )
                         }
                         cell {
-                            includePhrase(Felles.KronerText(inntektsAvkortingGjeldende.inntektsgrenseAar))
+                            includePhrase(KronerText(inntektsAvkortingGjeldende.inntektsgrenseAar))
                         }
                     }
                 }
@@ -384,7 +385,7 @@ data class TabellUfoereOpplysninger(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(yrkesskade.inntektVedSkadetidspunkt))
+                                includePhrase(KronerText(yrkesskade.inntektVedSkadetidspunkt))
                             }
                         }
                     }
@@ -707,7 +708,7 @@ data class TabellUfoereOpplysninger(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(saerkullsbarn.fribeloep))
+                                includePhrase(KronerText(saerkullsbarn.fribeloep))
                             }
                         }
                     }
@@ -721,7 +722,7 @@ data class TabellUfoereOpplysninger(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(fellesbarn.fribeloep))
+                                includePhrase(KronerText(fellesbarn.fribeloep))
                             }
                         }
                     }
@@ -741,9 +742,9 @@ data class TabellUfoereOpplysninger(
                             }
                             cell {
                                 showIf(samletInntektBruktIAvkortningFelles.greaterThan(0)) {
-                                    includePhrase(Felles.KronerText(samletInntektBruktIAvkortningFelles))
+                                    includePhrase(KronerText(samletInntektBruktIAvkortningFelles))
                                 }.orShow {
-                                    includePhrase(Felles.KronerText(inntektBruktIAvkortningSaerkull))
+                                    includePhrase(KronerText(inntektBruktIAvkortningSaerkull))
                                 }
                             }
                         }
@@ -759,7 +760,7 @@ data class TabellUfoereOpplysninger(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(fellesbarn.inntektAnnenForelder))
+                                includePhrase(KronerText(fellesbarn.inntektAnnenForelder))
                             }
                         }
                     }
@@ -776,7 +777,7 @@ data class TabellUfoereOpplysninger(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(inntektstakSaerkull))
+                                includePhrase(KronerText(inntektstakSaerkull))
                             }
                         }
                     }
@@ -791,7 +792,7 @@ data class TabellUfoereOpplysninger(
                                     )
                                 }
                                 cell {
-                                    includePhrase(Felles.KronerText(fellesBarn.beloepFratrukketAnnenForeldersInntekt))
+                                    includePhrase(KronerText(fellesBarn.beloepFratrukketAnnenForeldersInntekt))
                                 }
                             }
                         }
@@ -807,7 +808,7 @@ data class TabellUfoereOpplysninger(
                                 )
                             }
                             cell {
-                                includePhrase(Felles.KronerText(inntektstakFelles))
+                                includePhrase(KronerText(inntektstakFelles))
                             }
                         }
                     }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
@@ -1,6 +1,5 @@
 package no.nav.pensjon.etterlatte.maler.tilbakekreving
 
-import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Text.FontType

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/tilbakekreving/TilbakekrevingFraser.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.etterlatte.maler.tilbakekreving
 
 import no.nav.pensjon.brev.maler.fraser.common.Felles
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Text.FontType
 import no.nav.pensjon.brev.template.Expression
@@ -447,7 +448,7 @@ object TilbakekrevingVedleggFraser {
 							)
 						}
 						cell {
-							includePhrase(Felles.KronerText(summer.bruttoTilbakekreving))
+							includePhrase(KronerText(summer.bruttoTilbakekreving))
 						}
 					}
 					row {
@@ -459,7 +460,7 @@ object TilbakekrevingVedleggFraser {
 							)
 						}
 						cell {
-							includePhrase(Felles.KronerText(summer.fradragSkatt))
+							includePhrase(KronerText(summer.fradragSkatt))
 						}
 					}
 					row {
@@ -471,7 +472,7 @@ object TilbakekrevingVedleggFraser {
 							)
 						}
 						cell {
-							includePhrase(Felles.KronerText(summer.nettoTilbakekreving))
+							includePhrase(KronerText(summer.nettoTilbakekreving))
 						}
 					}
 					row {
@@ -483,7 +484,7 @@ object TilbakekrevingVedleggFraser {
 							)
 						}
 						cell {
-							includePhrase(Felles.KronerText(summer.renteTillegg))
+							includePhrase(KronerText(summer.renteTillegg))
 						}
 					}
 					row {
@@ -496,7 +497,7 @@ object TilbakekrevingVedleggFraser {
 							)
 						}
 						cell {
-							includePhrase(Felles.KronerText(summer.sumNettoRenter, FontType.BOLD))
+							includePhrase(KronerText(summer.sumNettoRenter, FontType.BOLD))
 						}
 					}
 				}
@@ -558,7 +559,7 @@ object TilbakekrevingVedleggFraser {
 								)
 							}
 							cell {
-								includePhrase(Felles.KronerText(periode.beloeper.feilutbetaling))
+								includePhrase(KronerText(periode.beloeper.feilutbetaling))
 							}
 							cell {
 								textExpr(
@@ -568,10 +569,10 @@ object TilbakekrevingVedleggFraser {
 								)
 							}
 							cell {
-								includePhrase(Felles.KronerText(periode.beloeper.bruttoTilbakekreving))
+								includePhrase(KronerText(periode.beloeper.bruttoTilbakekreving))
 							}
 							cell {
-								includePhrase(Felles.KronerText(periode.beloeper.nettoTilbakekreving))
+								includePhrase(KronerText(periode.beloeper.nettoTilbakekreving))
 							}
 						}
 					}

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/Beregningsperiodetabell.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/Beregningsperiodetabell.kt
@@ -1,27 +1,17 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg.barnepensjon
 
-import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.maler.fraser.common.KronerText
-import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
 import no.nav.pensjon.brev.template.Language
 import no.nav.pensjon.brev.template.OutlinePhrase
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
-import no.nav.pensjon.brev.template.dsl.expression.expr
-import no.nav.pensjon.brev.template.dsl.expression.plus
 import no.nav.pensjon.brev.template.dsl.text
-import no.nav.pensjon.brev.template.dsl.textExpr
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiode
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiodeSelectors.datoFOM
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiodeSelectors.datoTOM
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiodeSelectors.grunnbeloep
 import no.nav.pensjon.etterlatte.maler.BarnepensjonBeregningsperiodeSelectors.utbetaltBeloep
-import no.nav.pensjon.etterlatte.maler.OmstillingsstoenadBeregningsperiodeSelectors.datoFOM
-import no.nav.pensjon.etterlatte.maler.OmstillingsstoenadBeregningsperiodeSelectors.datoTOM
-import no.nav.pensjon.etterlatte.maler.OmstillingsstoenadBeregningsperiodeSelectors.inntekt
-import no.nav.pensjon.etterlatte.maler.OmstillingsstoenadBeregningsperiodeSelectors.utbetaltBeloep
-import no.nav.pensjon.etterlatte.maler.OmstillingsstoenadBeregningsperiodeSelectors.ytelseFoerAvkorting
 import no.nav.pensjon.etterlatte.maler.fraser.common.PeriodeITabell
 
 data class Beregningsperiodetabell(

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/Beregningsperiodetabell.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/Beregningsperiodetabell.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg.barnepensjon
 
 import no.nav.pensjon.brev.maler.fraser.common.Felles
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
@@ -56,8 +57,8 @@ data class Beregningsperiodetabell(
                 forEach(beregningsperioder) {
                     row {
                         cell { includePhrase(PeriodeITabell(it.datoFOM, it.datoTOM)) }
-                        cell { includePhrase(Felles.KronerText(it.grunnbeloep)) }
-                        cell { includePhrase(Felles.KronerText(it.utbetaltBeloep)) }
+                        cell { includePhrase(KronerText(it.grunnbeloep)) }
+                        cell { includePhrase(KronerText(it.utbetaltBeloep)) }
                     }
                 }
             }

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/Beregningsperiodetabell.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/Beregningsperiodetabell.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad
 
 import no.nav.pensjon.brev.maler.fraser.common.Felles
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
 import no.nav.pensjon.brev.template.Language
@@ -57,10 +58,10 @@ data class Beregningsperiodetabell(
                 forEach(beregningsperioder) { periode ->
                     row {
                         cell { includePhrase(PeriodeITabell(periode.datoFOM, periode.datoTOM)) }
-                        cell { includePhrase(Felles.KronerText(periode.ytelseFoerAvkorting)) }
-                        cell { includePhrase(Felles.KronerText(periode.inntekt)) }
+                        cell { includePhrase(KronerText(periode.ytelseFoerAvkorting)) }
+                        cell { includePhrase(KronerText(periode.inntekt)) }
                         cell {
-                            includePhrase(Felles.KronerText(periode.utbetaltBeloep))
+                            includePhrase(KronerText(periode.utbetaltBeloep))
                             showIf(periode.sanksjon) {
                                 text(
                                     Language.Bokmal to " - sanksjon",

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/Beregningsperiodetabell.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/Beregningsperiodetabell.kt
@@ -1,6 +1,5 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad
 
-import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/BeregningsperiodetabellEtterbetaling.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/BeregningsperiodetabellEtterbetaling.kt
@@ -1,17 +1,12 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad
 
-import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.maler.fraser.common.KronerText
-import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
 import no.nav.pensjon.brev.template.Language
 import no.nav.pensjon.brev.template.OutlinePhrase
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
-import no.nav.pensjon.brev.template.dsl.expression.expr
-import no.nav.pensjon.brev.template.dsl.expression.plus
 import no.nav.pensjon.brev.template.dsl.text
-import no.nav.pensjon.brev.template.dsl.textExpr
 import no.nav.pensjon.etterlatte.maler.OmstillingsstoenadBeregningsperiode
 import no.nav.pensjon.etterlatte.maler.OmstillingsstoenadBeregningsperiodeSelectors.datoFOM
 import no.nav.pensjon.etterlatte.maler.OmstillingsstoenadBeregningsperiodeSelectors.datoTOM

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/BeregningsperiodetabellEtterbetaling.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/BeregningsperiodetabellEtterbetaling.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.etterlatte.maler.vedlegg.omstillingsstoenad
 
 import no.nav.pensjon.brev.maler.fraser.common.Felles
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.Expression
 import no.nav.pensjon.brev.template.LangBokmalNynorskEnglish
@@ -59,9 +60,9 @@ data class BeregningsperiodetabellEtterbetaling(
                 forEach(beregningsperioder) {
                     row {
                         cell { includePhrase(PeriodeITabell(it.datoFOM, it.datoTOM)) }
-                        cell { includePhrase(Felles.KronerText(it.ytelseFoerAvkorting)) }
-                        cell { includePhrase(Felles.KronerText(it.inntekt)) }
-                        cell { includePhrase(Felles.KronerText(it.utbetaltBeloep)) }
+                        cell { includePhrase(KronerText(it.ytelseFoerAvkorting)) }
+                        cell { includePhrase(KronerText(it.inntekt)) }
+                        cell { includePhrase(KronerText(it.utbetaltBeloep)) }
                     }
                 }
             }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/example/EksempelbrevRedigerbart.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/example/EksempelbrevRedigerbart.kt
@@ -16,7 +16,7 @@ import no.nav.pensjon.brev.maler.example.ExampleTilleggDtoSelectors.navn
 import no.nav.pensjon.brev.maler.example.ExampleTilleggDtoSelectors.tillegg1
 import no.nav.pensjon.brev.maler.example.ExampleTilleggDtoSelectors.tillegg2
 import no.nav.pensjon.brev.maler.example.ExampleTilleggDtoSelectors.tillegg3
-import no.nav.pensjon.brev.maler.fraser.common.Felles.KronerText
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Table.ColumnAlignment.RIGHT
 import no.nav.pensjon.brev.template.Language.Bokmal

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/example/LetterExample.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/maler/example/LetterExample.kt
@@ -15,7 +15,7 @@ import no.nav.pensjon.brev.maler.example.LetterExampleDtoSelectors.pensjonInnvil
 import no.nav.pensjon.brev.maler.example.LetterExampleDtoSelectors.tilleggEksempel
 import no.nav.pensjon.brev.maler.example.TestVedleggDtoSelectors.testVerdi1
 import no.nav.pensjon.brev.maler.example.TestVedleggDtoSelectors.testVerdi2
-import no.nav.pensjon.brev.maler.fraser.common.Felles.KronerText
+import no.nav.pensjon.brev.maler.fraser.common.KronerText
 import no.nav.pensjon.brev.model.format
 import no.nav.pensjon.brev.template.AutobrevTemplate
 import no.nav.pensjon.brev.template.Element.OutlineContent.ParagraphContent.Table.ColumnAlignment.RIGHT

--- a/pensjonsmaler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/common/Felles.kt
+++ b/pensjonsmaler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/common/Felles.kt
@@ -108,17 +108,6 @@ object Felles {
         }
     }
 
-    data class KronerText(val kroner: Expression<Kroner>, val fontType: FontType = FontType.PLAIN) :
-        TextOnlyPhrase<LangBokmalNynorskEnglish>() {
-        override fun TextOnlyScope<LangBokmalNynorskEnglish, Unit>.template() =
-            textExpr(
-                Bokmal to kroner.format() + " kr",
-                Nynorsk to kroner.format() + " kr",
-                English to "NOK ".expr() + kroner.format(),
-                fontType,
-            )
-    }
-
     data class MaanederText(val antall: Expression<Int>) : TextOnlyPhrase<LangBokmalNynorskEnglish>() {
         override fun TextOnlyScope<LangBokmalNynorskEnglish, Unit>.template() =
             textExpr(


### PR DESCRIPTION
KronerText blir brukt frå både etterlatte og pesys, og det er eigentleg heilt greitt at vi har éin standard for korleis vi skriv ut kroner, så den tenkjer eg fint kan høyre heime i felles-kode, så flyttar inn i dsl-en.


Ei mogleg anna tilnærming er å seie at dette er opp til kvart team å ordne, og at vi dupliserer opp denne i hhv. etterlattemaler og pensjonsmaler.

Det må iallfall endrast anten den eine eller andre vegen før vi kan flytte etterlattemalane og pensjonsmalane dit dei skal.