### PR TITLE
Fikser logikk slik at manglende 4/5-dels avsnitt vises

### DIFF
--- a/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
+++ b/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/EtterlatteBrev.kt
@@ -20,7 +20,7 @@ data class BarnepensjonBeregning(
     val trygdetid: List<Trygdetid>,
     val erForeldreloes: Boolean = false,
     val forskjelligTrygdetid: ForskjelligTrygdetid? = null,
-    val erYrkesskade: Boolean? = false,
+    val erYrkesskade: Boolean = false,
 ) : BrevDTO {
     val harForskjelligMetode = forskjelligTrygdetid?.harForskjelligMetode == true
 }
@@ -43,7 +43,7 @@ data class OmstillingsstoenadBeregning(
     val trygdetid: Trygdetid,
     val oppphoersdato: LocalDate? = null,
     val opphoerNesteAar: Boolean,
-    val erYrkesskade: Boolean? = false,
+    val erYrkesskade: Boolean = false,
 ) : BrevDTO
 
 data class OmstillingsstoenadBeregningRevurderingRedigertbartUtfall(

--- a/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/BeregningAvBarnepensjon.kt
+++ b/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/barnepensjon/BeregningAvBarnepensjon.kt
@@ -287,7 +287,7 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
     mindreEnnFireFemtedelerAvOpptjeningstiden: Expression<Boolean>,
     forskjelligTrygdetid: Expression<ForskjelligTrygdetid?>,
     harForskjelligMetode: Expression<Boolean>,
-    erYrkesskade: Expression<Boolean?>,
+    erYrkesskade: Expression<Boolean>,
 ) {
     title2 {
         text(
@@ -391,24 +391,22 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, B
             }
         }
 
-        ifNotNull(erYrkesskade) { erYrkesskade ->
-            showIf(erYrkesskade) {
-                paragraph {
-                    text(
-                        Bokmal to "Det er bekreftet at dødsfallet skyldes en godkjent yrkesskade eller yrkessykdom. " +
-                                "Det gis derfor barnepensjon etter egne særbestemmelser. Selv om den avdøde hadde mindre enn " +
-                                "40 års trygdetid i Norge, er barnepensjonen beregnet med full trygdetid. Dette framkommer " +
-                                "ikke i tabellen nedenfor.",
-                        Nynorsk to "Det er stadfesta at dødsfallet kjem av ein godkjend yrkesskade eller yrkessjukdom. " +
-                                "Det blir derfor gitt barnepensjon etter eigne særreglar. Sjølv om den avdøde hadde mindre " +
-                                "enn 40 års trygdetid i Noreg, er barnepensjonen berekna med full trygdetid. " +
-                                "Dette kjem ikkje fram i tabellen nedanfor.",
-                        English to "It has been confirmed that the death was caused by an approved occupational injury " +
-                                "or disease. The children's pension is granted under special regulations. Although the " +
-                                "deceased had less than 40 years of social security coverage in Norway, the children's pension " +
-                                "is calculated based on a full social security period. This is not reflected in the table below.",
-                    )
-                }
+        showIf(erYrkesskade) {
+            paragraph {
+                text(
+                    Bokmal to "Det er bekreftet at dødsfallet skyldes en godkjent yrkesskade eller yrkessykdom. " +
+                            "Det gis derfor barnepensjon etter egne særbestemmelser. Selv om den avdøde hadde mindre enn " +
+                            "40 års trygdetid i Norge, er barnepensjonen beregnet med full trygdetid. Dette framkommer " +
+                            "ikke i tabellen nedenfor.",
+                    Nynorsk to "Det er stadfesta at dødsfallet kjem av ein godkjend yrkesskade eller yrkessjukdom. " +
+                            "Det blir derfor gitt barnepensjon etter eigne særreglar. Sjølv om den avdøde hadde mindre " +
+                            "enn 40 års trygdetid i Noreg, er barnepensjonen berekna med full trygdetid. " +
+                            "Dette kjem ikkje fram i tabellen nedanfor.",
+                    English to "It has been confirmed that the death was caused by an approved occupational injury " +
+                            "or disease. The children's pension is granted under special regulations. Although the " +
+                            "deceased had less than 40 years of social security coverage in Norway, the children's pension " +
+                            "is calculated based on a full social security period. This is not reflected in the table below.",
+                )
             }
         }.orShowIf(mindreEnnFireFemtedelerAvOpptjeningstiden) {
             paragraph {

--- a/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/BeregningAvOmstillingsstoenad.kt
+++ b/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/BeregningAvOmstillingsstoenad.kt
@@ -432,7 +432,7 @@ private fun OutlineOnlyScope<LangBokmalNynorskEnglish, OmstillingsstoenadBeregni
 private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, OmstillingsstoenadBeregning>.trygdetid(
     trygdetid: Expression<Trygdetid>,
     tidligereFamiliepleier: Expression<Boolean>,
-    erYrkesskade: Expression<Boolean?>,
+    erYrkesskade: Expression<Boolean>,
 ) {
     title2 {
         text(
@@ -502,24 +502,22 @@ private fun OutlineOnlyScope<LanguageSupport.Triple<Bokmal, Nynorsk, English>, O
             )
         }
 
-        ifNotNull(erYrkesskade){erYrkesskade ->
-            showIf(erYrkesskade) {
-                paragraph {
-                    text(
-                        Bokmal to "Det er bekreftet at dødsfallet skyldes en godkjent yrkesskade eller yrkessykdom. " +
-                                "Det gis derfor omstillingsstønad etter egne særbestemmelser. Selv om den avdøde hadde mindre " +
-                                "enn 40 års trygdetid i Norge, er omstillingsstønaden beregnet med full trygdetid. " +
-                                "Dette framkommer ikke i tabellen nedenfor.",
-                        Nynorsk to "Det er stadfesta at dødsfallet kjem av ein godkjend yrkesskade eller yrkessjukdom. " +
-                                "Det blir derfor gitt omstillingsstønad etter eigne særreglar. Sjølv om den avdøde hadde " +
-                                "mindre enn 40 års trygdetid i Noreg, er omstillingsstønaden berekna med full trygdetid. Dette kjem ikkje fram i tabellen nedanfor.",
-                        English to "It has been confirmed that the death was caused by an approved occupational " +
-                                "injury or disease. The adjustment allowance is granted under special regulations. " +
-                                "Although the deceased had less than 40 years of social security coverage in Norway, " +
-                                "the adjustment allowance is calculated based on a full social security period. " +
-                                "This is not reflected in the table below.",
-                    )
-                }
+        showIf(erYrkesskade) {
+            paragraph {
+                text(
+                    Bokmal to "Det er bekreftet at dødsfallet skyldes en godkjent yrkesskade eller yrkessykdom. " +
+                            "Det gis derfor omstillingsstønad etter egne særbestemmelser. Selv om den avdøde hadde mindre " +
+                            "enn 40 års trygdetid i Norge, er omstillingsstønaden beregnet med full trygdetid. " +
+                            "Dette framkommer ikke i tabellen nedenfor.",
+                    Nynorsk to "Det er stadfesta at dødsfallet kjem av ein godkjend yrkesskade eller yrkessjukdom. " +
+                            "Det blir derfor gitt omstillingsstønad etter eigne særreglar. Sjølv om den avdøde hadde " +
+                            "mindre enn 40 års trygdetid i Noreg, er omstillingsstønaden berekna med full trygdetid. Dette kjem ikkje fram i tabellen nedanfor.",
+                    English to "It has been confirmed that the death was caused by an approved occupational " +
+                            "injury or disease. The adjustment allowance is granted under special regulations. " +
+                            "Although the deceased had less than 40 years of social security coverage in Norway, " +
+                            "the adjustment allowance is calculated based on a full social security period. " +
+                            "This is not reflected in the table below.",
+                )
             }
         }.orShowIf(trygdetid.mindreEnnFireFemtedelerAvOpptjeningstiden) {
             paragraph {


### PR DESCRIPTION
Siden `erYrkesskade` alltid vil være en boolean ( og aldri `null`), ble aldri avsnittet om 4/5-regelen vist. Fikser på dette og endrer `erYrkesskade` til å ikke være nullable lenger (har sjekket mot brev-api).