### PR TITLE
Fiks copy-paste skriveleif

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/routing/AutobrevRoutes.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/routing/AutobrevRoutes.kt
@@ -9,7 +9,7 @@ import no.nav.pensjon.brev.api.model.BestillBrevRequest
 import no.nav.pensjon.brev.api.model.maler.Brevkode
 import no.nav.pensjon.brev.template.AutobrevTemplate
 
-private val BREV_KODE = AttributeKey<String>("CallStartTime")
+private val BREV_KODE = AttributeKey<String>("BrevKode")
 fun <T : Brevkode<T>> RoutingContext.installBrevkodeInCallContext(kode: Brevkode<T>) {
     call.attributes.put(BREV_KODE, kode.kode())
 }


### PR DESCRIPTION
Det er nok fra navnet på en call attribute fra ktor, så det kan skape konflikt om den brukes på et tidspunkt.

Jeg skulle også ønske at jeg skrev en kommentar med rasjonale for hvorfor det er kun /pdf-ruten som setter opp brevkode for call-logging.