### PR TITLE
Nais-konsollet rapporterer om kritisk sårbarheit i wget. Vi bruker jo…

### DIFF
--- a/pdf-bygger/Dockerfile
+++ b/pdf-bygger/Dockerfile
@@ -10,6 +10,7 @@ ENV TEXINPUTS=".:/app/pensjonsbrev_latex//:"
 COPY containerFiles/fonts /usr/share/fonts
 RUN fc-cache /usr/share/fonts # Build font cache for faster latex compile time. About 400 ms faster per letter
 COPY containerFiles/latex /app/pensjonsbrev_latex
+RUN apt remove wget -y
 RUN apt update && apt -y install tzdata perl-tk && rm -rf /var/lib/apt/lists/*
 #To update TeXLive/XeLaTeX version, run the github workflow and replace the --from argument to newest release
 COPY --from=ghcr.io/navikt/pensjonsbrev/pensjon-latex:2024-12-30-14_56 /app /app


### PR DESCRIPTION
… ikkje wget uansett, så vi kan like godt berre ta det bort.

Ref https://console.nav.cloud.nais.io/team/pensjonsbrev/prod-gcp/app/pensjon-pdf-bygger/image