### PR TITLE
Rettar bruk av feil metode for å hente property

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/BrevbakerAppModule.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/BrevbakerAppModule.kt
@@ -138,5 +138,5 @@ private fun konfigurerUnleash(brevbakerConfig: ApplicationConfig) {
     }
 }
 
-private fun ApplicationConfig.booleanProperty(path: String, default: Boolean = false): Boolean = propertyOrNull(path)?.toString()?.toBoolean() ?: default
+private fun ApplicationConfig.booleanProperty(path: String, default: Boolean = false): Boolean = propertyOrNull(path)?.getString()?.toBoolean() ?: default
 private fun ApplicationConfig.stringProperty(path: String): String? = propertyOrNull(path)?.getString()

--- a/pensjon-brevbaker/src/test/resources/application.conf
+++ b/pensjon-brevbaker/src/test/resources/application.conf
@@ -16,8 +16,6 @@ brevbaker {
     }
 
     unleash {
-        useFakeUnleash = true
-        fakeUnleashEnableAll = true
         # Følgende må være med for å overstyre miljøvariabel-verdier fra main/resources/application.conf.
         appName = "brevbaker"
         environment = "test"


### PR DESCRIPTION
toString på ApplicationConfigValue returnerer lang string, det er getString som returnerer kun verdien.