### PR TITLE
Potential fix for code scanning alert no. 20: Deprecated method or constructor invocation

### DIFF
--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/Authorization.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/Authorization.kt
@@ -9,6 +9,7 @@ import io.ktor.server.config.*
 import no.nav.pensjon.brev.template.jacksonObjectMapper
 import org.slf4j.LoggerFactory
 import java.net.URL
+import java.net.URI
 
 private val logger = LoggerFactory.getLogger("no.nav.pensjon.brev.Authorization")
 
@@ -44,7 +45,7 @@ data class PreAuthorizedApp(val name: String, val clientId: String)
 fun AuthenticationConfig.brevbakerJwt(config: JwtConfig) =
     jwt(config.name) {
         realm = "brevbaker-latex-$name"
-        verifier(JwkProviderBuilder(URL(config.jwksUrl)).build(), config.issuer) {
+        verifier(JwkProviderBuilder(URI(config.jwksUrl).toURL()).build(), config.issuer) {
             withAnyOfAudience(*config.audience.toTypedArray())
             withIssuer(config.issuer)
 


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/pensjonsbrev/security/code-scanning/20](https://github.com/navikt/pensjonsbrev/security/code-scanning/20)

To fix the problem, we need to replace the deprecated `URL` constructor with a non-deprecated alternative. The recommended approach is to use `URI` instead of `URL`, as `URI` provides a more modern and flexible way to handle URLs.

1. Replace the `URL(config.jwksUrl)` constructor call with `URI(config.jwksUrl).toURL()`.
2. Ensure that the necessary import for `java.net.URI` is added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
