### PR TITLE
Midlertidig work-around fordi getSakContextQueryOptions er undefined

### DIFF
--- a/skribenten-web/frontend/src/routes/saksnummer_/$saksId/route.tsx
+++ b/skribenten-web/frontend/src/routes/saksnummer_/$saksId/route.tsx
@@ -24,22 +24,27 @@ export const Route = createFileRoute("/saksnummer_/$saksId")({
 
     return { getSakContextQueryOptions };
   },
-  loader: async ({ context: { queryClient, getSakContextQueryOptions } }) => {
-    const sakContext = await queryClient.ensureQueryData(getSakContextQueryOptions);
-
+  loaderDeps: ({ search: { vedtaksId } }) => ({ vedtaksId }),
+  loader: async ({ context: { queryClient, getSakContextQueryOptions }, params: { saksId }, deps: { vedtaksId } }) => {
     // Adresse is a slow query that will be needed later, therefore we prefetch it here as early as possible.
     queryClient.prefetchQuery({
-      queryKey: getKontaktAdresse.queryKey(sakContext.sak.saksId.toString()),
-      queryFn: () => getKontaktAdresse.queryFn(sakContext.sak.saksId.toString()),
+      queryKey: getKontaktAdresse.queryKey(saksId.toString()),
+      queryFn: () => getKontaktAdresse.queryFn(saksId.toString()),
     });
 
     queryClient.prefetchQuery(getFavoritter);
     queryClient.prefetchQuery({
-      queryKey: getPreferredLanguage.queryKey(sakContext.sak.saksId.toString()),
-      queryFn: () => getPreferredLanguage.queryFn(sakContext.sak.saksId.toString()),
+      queryKey: getPreferredLanguage.queryKey(saksId.toString()),
+      queryFn: () => getPreferredLanguage.queryFn(saksId.toString()),
     });
 
-    return sakContext;
+    // TODO: Dette er en work-around fordi getSakContextQueryOptions av en eller annen grunn er undefined når brukeren redirectes pga. encoding av search-parameters.
+    const queryOptions = getSakContextQueryOptions ?? {
+      ...getSakContext,
+      queryKey: getSakContext.queryKey(saksId, vedtaksId),
+      queryFn: () => getSakContext.queryFn(saksId, vedtaksId),
+    };
+    return await queryClient.ensureQueryData(queryOptions);
   },
   errorComponent: ({ error }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
Dette er en midlertidig workaround (slik at skribenten ikke er nede i flere dager) fordi av en eller annen grunn så er `getSakContextQueryOptions` undefined i noen tilfeller når `loader` kjører. Dette kan reproduseres ved å bruke en url med query-param `enhetsId` uten hermetegn (`"`) rundt verdien, f.eks [https://pensjon-skribenten-web-q2.intern.dev.nav.no/saksnummer/22941796/brevvelger?enhetsId=4817](https://pensjon-skribenten-web-q2.intern.dev.nav.no/saksnummer/22941796/brevvelger?enhetsId=4817).