### PR TITLE
Oppdaterer KRR-kall til å bruke nytt endepunkt

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
@@ -54,6 +54,7 @@ class KrrService(config: Config, authService: AzureADService, private val client
 
     data class KontaktinfoRequest(val personident: String)
 
+    // Dette er en workaround for å få testene til å fungere, pga denne buggen i mockk: https://github.com/mockk/mockk/issues/944
     suspend fun doPost(urlString: String, request: KontaktinfoRequest) = client.post(urlString) {
         headers {
             accept(ContentType.Application.Json)

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
@@ -52,18 +52,19 @@ class KrrService(config: Config, authService: AzureADService, private val client
         }
     }
 
-    data class KontaktinfoRequest(val personident: String)
+    data class KontaktinfoRequest(val personidenter: List<String>)
 
     // Dette er en workaround for å få testene til å fungere, pga denne buggen i mockk: https://github.com/mockk/mockk/issues/944
     suspend fun doPost(urlString: String, request: KontaktinfoRequest) = client.post(urlString) {
         headers {
+            contentType(ContentType.Application.Json)
             accept(ContentType.Application.Json)
             setBody(request)
         }
     }
 
     suspend fun getPreferredLocale(pid: String): KontaktinfoResponse {
-        return doPost("/rest/v1/personer", KontaktinfoRequest(pid))
+        return doPost("/rest/v1/personer", KontaktinfoRequest(listOf(pid)))
             .toServiceResult<KontaktinfoKRRResponse>()
             .map { response ->
                 if (response.feil.isEmpty()) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
@@ -31,7 +31,7 @@ class KrrService(config: Config, authService: AzureADService): ServiceStatus {
 
     @Suppress("EnumEntryName")
     @JsonIgnoreProperties(ignoreUnknown = true)
-    data class KontaktinfoKRRResponse(val spraak: SpraakKode? = null) {
+    data class KontaktinfoKRRResponseEnkeltperson(val spraak: SpraakKode? = null) {
         enum class SpraakKode {
             nb, // bokmål
             nn, //nynorsk
@@ -39,6 +39,21 @@ class KrrService(config: Config, authService: AzureADService): ServiceStatus {
             se, //nord-samisk
         }
     }
+
+    @Suppress("EnumEntryName")
+    // henta fra https://github.com/navikt/digdir-krr/wiki/Migrere-vekk-fra-GET%E2%80%90tjenesten-for-enkeltoppslag
+    enum class Feiltype {
+        person_ikke_funnet,
+        skjermet,
+        fortrolig_adresse,
+        strengt_fortrolig_adresse,
+        strengt_fortrolig_utenlandsk_adresse,
+        noen_andre
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class KontaktinfoKRRResponse(val personer: Map<String, KontaktinfoKRRResponseEnkeltperson>, val feil: Map<String, Feiltype>)
+
 
     data class KontaktinfoResponse(val spraakKode: SpraakKode?, val failure: FailureType?) {
         constructor(failure: FailureType) : this(null, failure)
@@ -50,32 +65,41 @@ class KrrService(config: Config, authService: AzureADService): ServiceStatus {
         }
     }
 
+    data class KontaktinfoRequest(val personident: String)
+
     suspend fun getPreferredLocale(pid: String): KontaktinfoResponse {
-        return client.get("/rest/v1/person") {
+        return client.post("/rest/v1/personer") {
             headers {
                 accept(ContentType.Application.Json)
-                header("Nav-Personident", pid)
+                setBody(KontaktinfoRequest(pid))
             }
         }.toServiceResult<KontaktinfoKRRResponse>()
-            .map {
-                KontaktinfoResponse(
-                    when (it.spraak) {
-                        KontaktinfoKRRResponse.SpraakKode.nb -> SpraakKode.NB
-                        KontaktinfoKRRResponse.SpraakKode.nn -> SpraakKode.NN
-                        KontaktinfoKRRResponse.SpraakKode.en -> SpraakKode.EN
-                        KontaktinfoKRRResponse.SpraakKode.se -> SpraakKode.SE
-                        null -> null
-                    }
-                )
+            .map { response ->
+                if (response.feil.isEmpty()) {
+                    KontaktinfoResponse(
+                        when (response.personer[pid]!!.spraak) {
+                            KontaktinfoKRRResponseEnkeltperson.SpraakKode.nb -> SpraakKode.NB
+                            KontaktinfoKRRResponseEnkeltperson.SpraakKode.nn -> SpraakKode.NN
+                            KontaktinfoKRRResponseEnkeltperson.SpraakKode.en -> SpraakKode.EN
+                            KontaktinfoKRRResponseEnkeltperson.SpraakKode.se -> SpraakKode.SE
+                            null -> null
+                        }
+                    )
+                } else {
+                    val feilen = response.feil[pid]!!
+                    KontaktinfoResponse(
+                        failure = when(feilen) {
+                            Feiltype.person_ikke_funnet -> KontaktinfoResponse.FailureType.NOT_FOUND
+                            Feiltype.fortrolig_adresse,
+                            Feiltype.strengt_fortrolig_adresse,
+                            Feiltype.strengt_fortrolig_utenlandsk_adresse,
+                            Feiltype.skjermet,
+                            Feiltype.noen_andre -> KontaktinfoResponse.FailureType.ERROR
+                        }
+                    )
+                }
             }.catch { message, status ->
-                KontaktinfoResponse(
-                    if (status == HttpStatusCode.NotFound) {
-                        KontaktinfoResponse.FailureType.NOT_FOUND
-                    } else {
-                        logger.error("Feil ved henting av kontaktinformasjon. Status: $status Melding: $message")
-                        KontaktinfoResponse.FailureType.ERROR
-                    }
-                )
+                KontaktinfoResponse(KontaktinfoResponse.FailureType.ERROR).also { logger.error("Feil ved henting av kontaktinformasjon. Status: $status Melding: $message") }
             }
     }
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
@@ -101,6 +101,7 @@ class KrrService(config: Config, authService: AzureADService, private val client
             .map { true }
 }
 
+// Denne er trekt ut for å kunne sette opp tester på denne klassa uten å måtte sette opp hele http-opplegget
 fun krrClientFactory(config: Config, authService: AzureADService): HttpClient = HttpClient(CIO) {
     defaultRequest {
         url(config.getString("url"))

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
@@ -1,0 +1,30 @@
+package no.nav.pensjon.brev.skribenten.services
+
+import no.nav.pensjon.brev.skribenten.auth.AzureADService
+import no.nav.pensjon.brev.skribenten.auth.JwtConfig
+import org.junit.jupiter.api.Test
+
+class KrrServiceTest {
+
+    private val jwtConfig = JwtConfig(
+        "navn",
+        "utsteder",
+        "jwks url",
+        "skribenten-client-id",
+        "http://localhost:9991/token",
+        "skribenten-secret",
+        emptyList(),
+        true
+    )
+
+    @Test
+    fun `kan kontakte KRR`() {
+        val config = com.typesafe.config.Config()
+        val service = KrrService(
+            config = TODO(),
+            authService = AzureADService(jwtConfig)
+        )
+
+        service.getPreferredLocale("12345")
+    }
+}

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
@@ -10,33 +10,74 @@ import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
 import no.nav.pensjon.brev.skribenten.services.KrrService.KontaktinfoKRRResponse
 import no.nav.pensjon.brev.skribenten.services.KrrService.KontaktinfoKRRResponseEnkeltperson
+import no.nav.pensjon.brev.skribenten.services.KrrService.KontaktinfoResponse
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 import kotlin.test.assertEquals
 
 class KrrServiceTest {
+    private val service = spyk(
+        KrrService(
+            config = mockk(),
+            authService = mockk(),
+            client = mockk()
+        )
+    )
 
     @Test
-    fun `kan kontakte KRR`() {
+    fun `kan hente foretrukket spraak fra KRR`() {
         val respons = KontaktinfoKRRResponse(
             personer = mapOf("12345" to KontaktinfoKRRResponseEnkeltperson(KontaktinfoKRRResponseEnkeltperson.SpraakKode.nn)),
             feil = mapOf()
         )
-        val service = spyk(
-            KrrService(
-                config = mockk(),
-                authService = mockk(),
-                client = mockk()
-            )
-        ).also {
-            coEvery { it.doPost(any(), any()) } returns mockk<HttpResponse>().also {
-                every { it.status } returns HttpStatusCode.OK
-                coEvery { it.body<KontaktinfoKRRResponse>() } returns respons
-            }
+
+        coEvery { service.doPost(any(), any()) } returns mockk<HttpResponse>().also {
+            every { it.status } returns HttpStatusCode.OK
+            coEvery { it.body<KontaktinfoKRRResponse>() } returns respons
         }
 
         runBlocking {
             val preferredLocale = service.getPreferredLocale("12345")
+            assertNull(preferredLocale.failure)
             assertEquals(SpraakKode.NN, preferredLocale.spraakKode)
+        }
+    }
+
+    @Test
+    fun `not found fra KRR gir not found ogsaa hos oss`() {
+        val respons = KontaktinfoKRRResponse(
+            personer = mapOf(),
+            feil = mapOf("12345" to KrrService.Feiltype.person_ikke_funnet)
+        )
+
+        coEvery { service.doPost(any(), any()) } returns mockk<HttpResponse>().also {
+            every { it.status } returns HttpStatusCode.OK
+            coEvery { it.body<KontaktinfoKRRResponse>() } returns respons
+        }
+
+        runBlocking {
+            val preferredLocale = service.getPreferredLocale("12345")
+            assertNull(preferredLocale.spraakKode)
+            assertEquals(KontaktinfoResponse.FailureType.NOT_FOUND, preferredLocale.failure)
+        }
+    }
+
+    @Test
+    fun `feil fra KRR gir feil ogsaa hos oss`() {
+        val respons = KontaktinfoKRRResponse(
+            personer = mapOf(),
+            feil = mapOf("12345" to KrrService.Feiltype.skjermet)
+        )
+
+        coEvery { service.doPost(any(), any()) } returns mockk<HttpResponse>().also {
+            every { it.status } returns HttpStatusCode.OK
+            coEvery { it.body<KontaktinfoKRRResponse>() } returns respons
+        }
+
+        runBlocking {
+            val preferredLocale = service.getPreferredLocale("12345")
+            assertNull(preferredLocale.spraakKode)
+            assertEquals(KontaktinfoResponse.FailureType.ERROR, preferredLocale.failure)
         }
     }
 }


### PR DESCRIPTION
Sia det gamle skal skruast av i juni.

Obs: tilsvarande endring må også til i dokdist. Tar det etter denne er merga inn.

Testa lokalt, returnerer tilsvarande som noverande endepunkt både for person som fins i krr og person som ikkje gjer det.