### PR TITLE
Bruker DisplayText konsekvent for alle typar saksbehandlervalg-felt

### DIFF
--- a/skribenten-web/frontend/src/Brevredigering/ModelEditor/components/ObjectEditor.tsx
+++ b/skribenten-web/frontend/src/Brevredigering/ModelEditor/components/ObjectEditor.tsx
@@ -62,6 +62,8 @@ export const FieldEditor = ({
 
 export type ObjectEditorProperties = {
   brevkode: string;
+  // Denne er jo brukt, eslint som er forvirra
+  // eslint-disable-next-line react/no-unused-prop-types
   fieldType: FieldType;
   typeName: string;
   parentFieldName?: string;

--- a/skribenten-web/frontend/src/Brevredigering/ModelEditor/components/ObjectEditor.tsx
+++ b/skribenten-web/frontend/src/Brevredigering/ModelEditor/components/ObjectEditor.tsx
@@ -39,7 +39,6 @@ export const FieldEditor = ({
       ) : (
         <ObjectEditor
           brevkode={brevkode}
-          fieldType={fieldType}
           parentFieldName={prependedName ? `${prependedName}.${field}` : field}
           submitOnChange={submitOnChange}
           typeName={fieldType.typeName}
@@ -62,9 +61,6 @@ export const FieldEditor = ({
 
 export type ObjectEditorProperties = {
   brevkode: string;
-  // Denne er jo brukt, eslint som er forvirra
-  // eslint-disable-next-line react/no-unused-prop-types
-  fieldType: FieldType;
   typeName: string;
   parentFieldName?: string;
   submitOnChange?: () => void;
@@ -99,7 +95,7 @@ function ToggleableObjectEditor({
   typeName,
   fieldType,
   submitOnChange,
-}: ObjectEditorProperties & { parentFieldName: string }) {
+}: ObjectEditorProperties & { parentFieldName: string; fieldType: FieldType }) {
   const {
     formState: { defaultValues },
     unregister,
@@ -135,7 +131,6 @@ function ToggleableObjectEditor({
         >
           <ObjectEditor
             brevkode={brevkode}
-            fieldType={fieldType}
             parentFieldName={parentFieldName}
             submitOnChange={submitOnChange}
             typeName={typeName}

--- a/skribenten-web/frontend/src/Brevredigering/ModelEditor/components/ObjectEditor.tsx
+++ b/skribenten-web/frontend/src/Brevredigering/ModelEditor/components/ObjectEditor.tsx
@@ -31,6 +31,7 @@ export const FieldEditor = ({
       return fieldType.nullable ? (
         <ToggleableObjectEditor
           brevkode={brevkode}
+          fieldType={fieldType}
           parentFieldName={prependedName ? `${prependedName}.${field}` : field}
           submitOnChange={submitOnChange}
           typeName={fieldType.typeName}
@@ -38,6 +39,7 @@ export const FieldEditor = ({
       ) : (
         <ObjectEditor
           brevkode={brevkode}
+          fieldType={fieldType}
           parentFieldName={prependedName ? `${prependedName}.${field}` : field}
           submitOnChange={submitOnChange}
           typeName={fieldType.typeName}
@@ -60,6 +62,7 @@ export const FieldEditor = ({
 
 export type ObjectEditorProperties = {
   brevkode: string;
+  fieldType: FieldType;
   typeName: string;
   parentFieldName?: string;
   submitOnChange?: () => void;
@@ -92,6 +95,7 @@ function ToggleableObjectEditor({
   brevkode,
   parentFieldName,
   typeName,
+  fieldType,
   submitOnChange,
 }: ObjectEditorProperties & { parentFieldName: string }) {
   const {
@@ -115,7 +119,7 @@ function ToggleableObjectEditor({
   return (
     <>
       <Switch checked={open} onChange={handleToggle}>
-        {convertFieldToReadableLabel(parentFieldName)}
+        {fieldType.displayText ?? convertFieldToReadableLabel(parentFieldName)}
       </Switch>
       {open && (
         <div
@@ -129,6 +133,7 @@ function ToggleableObjectEditor({
         >
           <ObjectEditor
             brevkode={brevkode}
+            fieldType={fieldType}
             parentFieldName={parentFieldName}
             submitOnChange={submitOnChange}
             typeName={typeName}

--- a/skribenten-web/frontend/src/Brevredigering/ModelEditor/components/ScalarEditor.tsx
+++ b/skribenten-web/frontend/src/Brevredigering/ModelEditor/components/ScalarEditor.tsx
@@ -97,7 +97,7 @@ const SwitchField = (props: { prependName?: string; field: string; fieldType: TS
               props.onSubmit?.();
             }}
           >
-            {convertFieldToReadableLabel(props.field)}
+            {props.fieldType.displayText ?? convertFieldToReadableLabel(props.field)}
           </Switch>
         )}
       />
@@ -243,7 +243,7 @@ const ControlledDatePicker = (props: {
         <DatePickerEditor
           defaultValue={defaultValue}
           error={fieldState.error?.message}
-          label={convertFieldToReadableLabel(fieldName)}
+          label={props.fieldType.displayText ?? convertFieldToReadableLabel(fieldName)}
           onChange={field.onChange}
         />
       )}


### PR DESCRIPTION
Som det er i main no funkar det for number-type-felt, men ikkje for f.eks. brytarar