### PR TITLE
Dependabot-grupperinga oppførte seg ikkje som forventa

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,15 +38,32 @@ updates:
     groups:
       tjenestebuss:
         patterns:
-          - "org.apache.cxf:*"
+          - "org.apache.cxf*"
           - "com.sun.xml.messaging.saaj:saaj-impl"
           - "com.sun.xml.bind:jaxb-core"
-      backend:
-        patterns:
-          - "*"
       postgresql:
         patterns:
           - "org.postgresql:postgresql"
+      backend:
+        patterns:
+          - "ch.qos.logback:logback-classic"
+          - "com.fasterxml.jackson*"
+          - "com.google*"
+          - "commons-codec:commons-codec"
+          - "com.natpryce:hamkrest"
+          - "com.zaxxer:HikariCP"
+          - "dev.zacsweers.kctfork:ksp"
+          - "io.getunleash*"
+          - "io.ktor*"
+          - "io.micrometer*"
+          - "io.mockk*"
+          - "net.logstash.logback:logstash-logback-encoder"
+          - "no.nav*"
+          - "org.assertj:assertj-core"
+          - "org.flyway*"
+          - "org.jetbrains*"
+          - "org.junit*"
+          - "org.testcontainers:postgresql"
 
 
   # =============


### PR DESCRIPTION
Ref #1455

Skriv om til å heller bruke eksplisitt liste for alt vi vil samle opp i backend-PR. Kjens tryggare og bør fungere. Gjekk gjennom toml-fila vår med avhengnadar og brukte denne for å lage lista