### PR TITLE
Viss det ikkje er overstyring eller tekstvalg å vise, skjul også fanene og overskriftene

### DIFF
--- a/skribenten-web/frontend/src/Brevredigering/ModelEditor/ModelEditor.tsx
+++ b/skribenten-web/frontend/src/Brevredigering/ModelEditor/ModelEditor.tsx
@@ -25,7 +25,7 @@ const useModelSpecificationForm = (brevkode: string) => {
   };
 };
 
-const usePartitionedModelSpecification = (brevkode: string) => {
+export const usePartitionedModelSpecification = (brevkode: string) => {
   const { status, specification, error } = useModelSpecificationForm(brevkode);
 
   const [optionalFields, requiredfields] = specification


### PR DESCRIPTION
Løyser https://trello.com/c/HypPITbQ/166-skjule-tekstvalg-og-overstyring-i-redigeringsskjermbildet-n%C3%A5r-det-ikke-finnes-noen-elementer-i-skjema

![image](https://github.com/user-attachments/assets/d9215d87-b99f-4447-ab2a-59d66f917318)
![image](https://github.com/user-attachments/assets/5eba7074-f793-48db-8a9c-7fc5cfdd9513)
