### PR TITLE
Generaliserer så vi kan ha fleire element i tittel også i vedlegg, på…

### DIFF
--- a/brevbaker-dsl/api/brevbaker-dsl.api
+++ b/brevbaker-dsl/api/brevbaker-dsl.api
@@ -48,7 +48,7 @@ public final class no/nav/pensjon/brev/template/AttachmentTemplate : no/nav/pens
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIncludeSakspart ()Z
 	public final fun getOutline ()Ljava/util/List;
-	public final fun getTitle ()Lno/nav/pensjon/brev/template/ContentOrControlStructure;
+	public final fun getTitle ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun stableHashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/brevbaker-dsl/src/main/kotlin/no/nav/pensjon/brev/template/IncludeAttachment.kt
+++ b/brevbaker-dsl/src/main/kotlin/no/nav/pensjon/brev/template/IncludeAttachment.kt
@@ -11,7 +11,7 @@ fun <Lang : LanguageSupport, LetterData : Any> createAttachment(
     includeSakspart: Boolean = false,
     outline: OutlineOnlyScope<Lang, LetterData>.() -> Unit
 ) = AttachmentTemplate<Lang, LetterData>(
-    title,
+    listOf(title),
     OutlineOnlyScope<Lang, LetterData>().apply(outline).elements,
     includeSakspart
 )
@@ -21,14 +21,14 @@ fun <Lang : LanguageSupport, LetterData : Any> createAttachment(
     includeSakspart: Boolean = false,
     outline: OutlineOnlyScope<Lang, LetterData>.() -> Unit
 ) = AttachmentTemplate<Lang, LetterData>(
-    PlainTextOnlyScope<Lang, LetterData>().apply(title).elements.single(),
+    PlainTextOnlyScope<Lang, LetterData>().apply(title).elements,
     OutlineOnlyScope<Lang, LetterData>().apply(outline).elements,
     includeSakspart
 )
 
 fun TextScope<BaseLanguages, *>.namedReference(attachment: AttachmentTemplate<BaseLanguages, *>) {
     text(Language.Bokmal to "«", Language.Nynorsk to "«", Language.English to "'")
-    addTextContent(attachment.title)
+    attachment.title.forEach { addTextContent(it) }
     text(Language.Bokmal to "»", Language.Nynorsk to "»", Language.English to "'")
 }
 
@@ -46,10 +46,10 @@ class IncludeAttachment<out Lang : LanguageSupport, AttachmentData : Any> intern
 }
 
 class AttachmentTemplate<out Lang : LanguageSupport, AttachmentData : Any> internal constructor(
-    val title: TextElement<Lang>,
+    val title: List<TextElement<Lang>>,
     val outline: List<OutlineElement<Lang>>,
     val includeSakspart: Boolean = false,
-): HasModel<AttachmentData>, StableHash by StableHash.of(title, StableHash.of(outline), StableHash.of(includeSakspart)) {
+): HasModel<AttachmentData>, StableHash by StableHash.of(StableHash.of(title), StableHash.of(outline), StableHash.of(includeSakspart)) {
     override fun equals(other: Any?): Boolean {
         if (other !is AttachmentTemplate<*, *>) return false
         return title == other.title && outline == other.outline && includeSakspart == other.includeSakspart

--- a/brevbaker/src/main/kotlin/no/nav/brev/brevbaker/template/render/Letter2Markup.kt
+++ b/brevbaker/src/main/kotlin/no/nav/brev/brevbaker/template/render/Letter2Markup.kt
@@ -55,7 +55,7 @@ internal object Letter2Markup : LetterRenderer<LetterWithAttachmentsMarkup>() {
         render(scope, template.attachments) { scope, _, attachment ->
             add(
                 AttachmentImpl(
-                    renderText(scope, listOf(attachment.title)),
+                    renderText(scope, attachment.title),
                     renderOutline(scope, attachment.outline),
                     attachment.includeSakspart,
                 )

--- a/brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/CreateAttachmentTest.kt
+++ b/brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/CreateAttachmentTest.kt
@@ -1,0 +1,60 @@
+package no.nav.pensjon.brev.template.render
+
+import no.nav.pensjon.brev.template.LangNynorsk
+import no.nav.pensjon.brev.template.Language.Nynorsk
+import no.nav.pensjon.brev.template.LetterImpl
+import no.nav.pensjon.brev.template.createAttachment
+import no.nav.pensjon.brev.template.dsl.createTemplate
+import no.nav.pensjon.brev.template.dsl.expression.format
+import no.nav.pensjon.brev.template.dsl.expression.greaterThan
+import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
+import no.nav.pensjon.brev.template.dsl.languages
+import no.nav.pensjon.brev.template.dsl.text
+import no.nav.pensjon.brev.template.render.CreateAttachmentTestSelectors.LittInnholdSelectors.test1
+import no.nav.pensjon.brev.template.render.CreateAttachmentTestSelectors.LittInnholdSelectors.test2
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CreateAttachmentTest {
+    @TemplateModelHelpers
+    val vedlegg = createAttachment<LangNynorsk, LittInnhold>(
+        title = {
+            text(
+                Nynorsk to "Test vedlegg"
+            )
+            ifNotNull(test1) { eval(it) }
+            eval(test2.format())
+            showIf(test2.greaterThan(5)) {
+                text(Nynorsk to "parameteret er større enn 5")
+            }
+        },
+        includeSakspart = true
+    ) {
+        paragraph {
+            text(Nynorsk to "test")
+        }
+    }
+    @Test
+    fun `title may have several elements`() {
+        val testVedlegg = vedlegg
+
+        val testTemplate = createTemplate(
+            name = "test",
+            letterDataType = LittInnhold::class,
+            languages = languages(Nynorsk),
+            letterMetadata = testLetterMetadata,
+        ) {
+            title { text(Nynorsk to "tittel") }
+            outline {}
+            includeAttachment(testVedlegg, argument)
+        }
+
+        val tittel =
+            Letter2Markup.render(LetterImpl(testTemplate, LittInnhold("testtekst", 10), Nynorsk, Fixtures.felles)).attachments
+                .first()
+                .title
+        assertEquals(4, tittel.size)
+    }
+
+    data class LittInnhold(val test1: String?, val test2: Int)
+}

--- a/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/render/TemplateDocumentationRenderer.kt
+++ b/pensjon-brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/render/TemplateDocumentationRenderer.kt
@@ -24,7 +24,7 @@ object TemplateDocumentationRenderer {
 
     private fun renderAttachment(attachment: IncludeAttachment<*, *>, lang: Language): TemplateDocumentation.Attachment =
         TemplateDocumentation.Attachment(
-            title = renderText(listOf(attachment.template.title), lang),
+            title = renderText(attachment.template.title, lang),
             outline = renderOutline(attachment.template.outline, lang),
             include = renderExpression(attachment.predicate),
             attachmentData = renderExpression(attachment.data),


### PR DESCRIPTION
… samme måte som du vil forvente elles i brevbaker når du lager brev eller overskrifter. Opnar dermed også for å bruke strukturane som not null, showIf osv