### PR TITLE
Bugfix/title behind table on page break

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ En strategi for overgangen kan se slik ut:
 For å fort kunne oppdatere latex filene i pdf-byggeren under kjøring, anbefales det å kjøre følgende kommando som before launch for LatexVisualITest.
 
 ```bash
-docker exec -u 0 -it pensjonsbrev_pdf-bygger_1 rm -rf /app/pensjonsbrev_latex && docker cp ./pdf-bygger/containerFiles/latex pensjonsbrev_pdf-bygger_1:/app/pensjonsbrev_latex/
+docker exec -u 0 -it pensjonsbrev-pdf-bygger-1 rm -rf /app/pensjonsbrev_latex && docker cp ./pdf-bygger/containerFiles/latex pensjonsbrev-pdf-bygger-1:/app/pensjonsbrev_latex/
 ```
 
 Da vil du kunne se på pensjon-brevbaker/build/test_visual/pdf resultatet av endringen fort.

--- a/pdf-bygger/Dockerfile
+++ b/pdf-bygger/Dockerfile
@@ -13,7 +13,7 @@ COPY containerFiles/latex /app/pensjonsbrev_latex
 RUN apt remove wget -y
 RUN apt update && apt -y install tzdata perl-tk && rm -rf /var/lib/apt/lists/*
 #To update TeXLive/XeLaTeX version, run the github workflow and replace the --from argument to newest release
-COPY --from=debian_latex:latest /app /app
+COPY --from=ghcr.io/navikt/pensjonsbrev/pensjon-latex:2024-12-30-14_56 /app /app
 
 USER apprunner
 COPY  build/libs/pdf-bygger.jar /app/app.jar

--- a/pdf-bygger/Dockerfile
+++ b/pdf-bygger/Dockerfile
@@ -13,7 +13,7 @@ COPY containerFiles/latex /app/pensjonsbrev_latex
 RUN apt remove wget -y
 RUN apt update && apt -y install tzdata perl-tk && rm -rf /var/lib/apt/lists/*
 #To update TeXLive/XeLaTeX version, run the github workflow and replace the --from argument to newest release
-COPY --from=ghcr.io/navikt/pensjonsbrev/pensjon-latex:2024-12-30-14_56 /app /app
+COPY --from=debian_latex:latest /app /app
 
 USER apprunner
 COPY  build/libs/pdf-bygger.jar /app/app.jar

--- a/pdf-bygger/containerFiles/latex/content/table.tex
+++ b/pdf-bygger/containerFiles/latex/content/table.tex
@@ -3,6 +3,8 @@
 \newfontfamily\tablecolumnheadertext[LetterSpace=0.2]{Source Sans 3 SemiBold}
 \newcommand{\tablecolumnheader}{\tablecolumnheadertext \fontsize{\standardtextsize}{\standardtextspacing} \selectfont}
 
+% uses the same spacing between titles and non-titles and formatting as title two.
+\newcommand{\tabletitle}{\spaceabovetitle\titletwo}
 \definecolor{columnheadercolor}{HTML}{E6F0FF}
 \definecolor{linecolor}{HTML}{7C8695}
 \definecolor{headersepcolor}{HTML}{000000}
@@ -10,13 +12,13 @@
 \definecolor{row2color}{HTML}{FFFFFF}
 
 \DefTblrTemplate{contfoot-text}{default}{\felttablenextpagecontinuation\hfill\space}
-\DefTblrTemplate{caption}{default}{} % remove built in header
+\DefTblrTemplate{caption}{default}{\InsertTblrText{caption}\hfill}
 \DefTblrTemplate{capcont}{default}{\felttablecontinuedfrompreviouspage}
 
-\newenvironment{letterTable}[1]{
+\newenvironment{letterTable}[2]{
     \setlength{\parskip}{0pt}
     \standardtext
-    \begin{longtblr}[presep={5.5mm},postsep={3.5mm},footsep={3.5mm}, headsep={3.5mm}]
+    \begin{longtblr}[presep={5.5mm},postsep={3.5mm},footsep={3.5mm}, headsep={3.5mm}, caption={#2}]
     {
         colspec=#1,
         colsep = 8pt,

--- a/pdf-bygger/containerFiles/latex/content/titles.tex
+++ b/pdf-bygger/containerFiles/latex/content/titles.tex
@@ -14,8 +14,10 @@
 \newlength{\spacebetweentitleandnontitle}
 \setlength{\spacebetweentitleandnontitle}{\dimexpr(25pt-\parskip) plus 8pt minus 8pt}
 
+%extra space is added between title and non title elements           % if previous was not title, add space and encourage page break
+\newcommand{\spaceabovetitle}{\ifdefstring{\previouselement}{title}{}{\pagebreak[3]\addvspace{\spacebetweentitleandnontitle}}}
 % do not split the command with newlines. It will be included in the content.
-\newcommand{\lettersectiontitle}[1]{\ifdefstring{\previouselement}{title}{}{\pagebreak[3]\addvspace{\spacebetweentitleandnontitle}}#1\nopagebreak\\[0pt]\addpenalty{10000}\addvspace{3pt}}
+\newcommand{\lettersectiontitle}[1]{\spaceabovetitle#1\nopagebreak\\[0pt]\addpenalty{10000}\addvspace{3pt}}
 
 % Title 1
 \newcommand{\lettersectiontitleone}[1]{\lettersectiontitle{\titleone #1}\setpreviouselement{title}}

--- a/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/latex/LatexDocumentRenderer.kt
+++ b/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/latex/LatexDocumentRenderer.kt
@@ -23,7 +23,7 @@ private const val DOCUMENT_PRODUCER = "brevbaker / pdf-bygger med LaTeX"
 
 internal object LatexDocumentRenderer {
 
-    internal fun render(pdfRequest: PDFRequest) : LatexDocument = render(
+    internal fun render(pdfRequest: PDFRequest): LatexDocument = render(
         letter = pdfRequest.letterMarkup,
         attachments = pdfRequest.attachments,
         language = pdfRequest.language.toLanguage(),
@@ -195,33 +195,46 @@ internal object LatexDocumentRenderer {
     }
 
     private fun LatexAppendable.renderIfNonEmptyText(content: List<Text>, render: LatexAppendable.(String) -> Unit) {
-        val text = String(StringBuilder().also { LatexAppendable(it).renderText(content) })
+        val text = renderTextsToString(content)
         if (text.isNotEmpty()) {
             render(text)
         }
     }
 
-    //
-    // Element rendering
-    //
-    private fun LatexAppendable.renderBlocks(blocks: List<LetterMarkup.Block>): Unit =
-        blocks.forEach { renderBlock(it) }
+    private fun LatexAppendable.renderBlocks(blocks: List<LetterMarkup.Block>) {
+        blocks.forEachIndexed { index, block ->
+            val previous = blocks.getOrNull(index - 1)
+            val next = blocks.getOrNull(index + 1)
+            renderBlock(block, previous, next)
+        }
+    }
 
     private fun LatexAppendable.renderText(elements: List<Text>): Unit =
         elements.forEach { renderTextContent(it) }
 
-    private fun LatexAppendable.renderBlock(block: LetterMarkup.Block): Unit =
+    private fun LatexAppendable.renderBlock(
+        block: LetterMarkup.Block,
+        previous: LetterMarkup.Block?,
+        next: LetterMarkup.Block?
+    ): Unit =
         when (block) {
-            is LetterMarkup.Block.Paragraph -> renderParagraph(block)
+            is LetterMarkup.Block.Paragraph -> renderParagraph(block, previous)
 
             is LetterMarkup.Block.Title1 -> renderIfNonEmptyText(block.content) { titleText ->
-                appendCmd("lettersectiontitleone", titleText)
+                if (!next.isTable()) {
+                    appendCmd("lettersectiontitleone", titleText)
+                }
             }
 
             is LetterMarkup.Block.Title2 -> renderIfNonEmptyText(block.content) { titleText ->
-                appendCmd("lettersectiontitletwo", titleText)
+                if (!next.isTable()) {
+                    appendCmd("lettersectiontitletwo", titleText)
+                }
             }
         }
+
+    private fun LetterMarkup.Block?.isTable(): Boolean =
+        (this as? LetterMarkup.Block.Paragraph)?.content?.firstOrNull()?.type == Type.TABLE
 
     private fun LatexAppendable.renderTextParagraph(text: List<Text>): Unit =
         appendCmd("templateparagraph") {
@@ -230,7 +243,10 @@ internal object LatexDocumentRenderer {
 
     //TODO depricate table/itemlist/form inside paragraph and make them available outside.
     // there should not be a different space between elements if within/outside paragraphs.
-    private fun LatexAppendable.renderParagraph(element: LetterMarkup.Block.Paragraph) {
+    private fun LatexAppendable.renderParagraph(
+        element: LetterMarkup.Block.Paragraph,
+        previous: LetterMarkup.Block?,
+    ) {
         var continousTextContent = mutableListOf<Text>()
 
         element.content.forEach { current ->
@@ -242,7 +258,7 @@ internal object LatexDocumentRenderer {
             when (current) {
                 is Form -> renderForm(current)
                 is ItemList -> renderList(current)
-                is Table -> renderTable(current)
+                is Table -> renderTable(current, previous)
                 is Text -> continousTextContent.add(current)
             }
         }
@@ -262,12 +278,14 @@ internal object LatexDocumentRenderer {
         }
     }
 
-    private fun LatexAppendable.renderTable(table: Table) {
+    private fun LatexAppendable.renderTable(table: Table, previous: LetterMarkup.Block?) {
         if (table.rows.isNotEmpty()) {
             val columnSpec = table.header.colSpec
-
-            appendCmd("begin", "letterTable", columnHeadersLatexString(columnSpec))
-
+            appendCmd(
+                "begin", "letterTable", columnHeadersLatexString(columnSpec),
+                titleTextOrNull(previous)?.let { "\\tabletitle $it" } ?: ""
+                , escape = false
+            )
             renderTableCells(columnSpec.map { it.headerContent }, columnSpec)
 
             table.rows.forEach {
@@ -277,6 +295,15 @@ internal object LatexDocumentRenderer {
             appendCmd("end", "letterTable")
         }
     }
+
+    private fun titleTextOrNull(previous: LetterMarkup.Block?): String? = when (previous) {
+        is LetterMarkup.Block.Title1 -> renderTextsToString(previous.content)
+        is LetterMarkup.Block.Title2 -> renderTextsToString(previous.content)
+        else -> null
+    }?.takeIf { it.isNotBlank() }
+
+    private fun renderTextsToString(texts: List<Text>): String =
+        String(StringBuilder().also { LatexAppendable(it).renderText(texts) })
 
     private fun LatexAppendable.renderTableCells(cells: List<Table.Cell>, colSpec: List<Table.ColumnSpec>) {
         cells.forEachIndexed { index, cell ->

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/LatexVisualITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/LatexVisualITest.kt
@@ -297,7 +297,7 @@ class LatexVisualITest {
     }
 
     @Test
-    fun `Table title`() {
+    fun `Table title should have the correct spacing when sticking to a table that was shipped to the next page`() {
         render {
             repeat(5) {
                 paragraph {
@@ -312,22 +312,25 @@ class LatexVisualITest {
             title1 {
                 text(Bokmal to "Test-tittel")
             }
-            paragraph {
-                table(
-                    header = {
-                        column { text(Bokmal to "Column A") }
-                        column { text(Bokmal to "Column B") }
-                    }
-                ) {
-                    for (i in 1..5) {
-                        row {
-                            cell { text(Bokmal to "Cell A-$i") }
-                            cell { text(Bokmal to "Cell B-$i") }
-                        }
-                    }
-                }
+            paragraph { testTable(5) }        }
+    }
 
-            }
+    @Test
+    fun `table title and other content`() {
+        render {
+            paragraph { text(Bokmal to "asdf") }
+            title1 { text(Bokmal to "Test-tittel") }
+            paragraph { testTable(5) }
+        }
+    }
+
+
+    @Test
+    fun `table title and other title`() {
+        render {
+            title1 { text(Bokmal to "Test-tittel") }
+            title1 { text(Bokmal to "Test-tittel") }
+            paragraph { testTable(5) }
         }
     }
 
@@ -374,16 +377,18 @@ class LatexVisualITest {
         }
     }
 
-    private fun ParagraphOnlyScope<LangBokmal, EmptyBrevdata>.testTable() {
+    private fun ParagraphOnlyScope<LangBokmal, EmptyBrevdata>.testTable(numRows: Int = 1) {
         table(
             header = {
                 column { text(Bokmal to "Column A") }
                 column { text(Bokmal to "Column B") }
             }
         ) {
-            row {
-                cell { text(Bokmal to "Cell A-1") }
-                cell { text(Bokmal to "Cell B-1") }
+            for (i in 1..numRows) {
+                row {
+                    cell { text(Bokmal to "Cell A-$i") }
+                    cell { text(Bokmal to "Cell B-$i") }
+                }
             }
         }
     }

--- a/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/LatexVisualITest.kt
+++ b/pensjon-brevbaker/src/test/kotlin/no/nav/pensjon/brev/template/render/LatexVisualITest.kt
@@ -296,6 +296,41 @@ class LatexVisualITest {
         }
     }
 
+    @Test
+    fun `Table title`() {
+        render {
+            repeat(5) {
+                paragraph {
+                    text(
+                        Bokmal to "Padding text bla bla. ".repeat(18),
+                    )
+                }
+            }
+            paragraph {
+                text(Bokmal to "Padding text bla bla. ".repeat(14))
+            }
+            title1 {
+                text(Bokmal to "Test-tittel")
+            }
+            paragraph {
+                table(
+                    header = {
+                        column { text(Bokmal to "Column A") }
+                        column { text(Bokmal to "Column B") }
+                    }
+                ) {
+                    for (i in 1..5) {
+                        row {
+                            cell { text(Bokmal to "Cell A-$i") }
+                            cell { text(Bokmal to "Cell B-$i") }
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+
     @ParameterizedTest
     @MethodSource("allElementCombinations")
     fun `Test unique content combinations`(elementA: ElementType, elementB: ElementType) {


### PR DESCRIPTION
Bugfix. Flytter titler over tabeller inn i innebyggd heading. På grunn av feil i tabularray https://github.com/lvjr/tabularray/issues/587 kan titler som forskyves til neste side for å henge sammen med tabeller komme bak selve tabellen. Putter heller titler over tabeller inn i dedikert heading-felt på tabellen. Dette gjør også at vi har mer kontroll over hvordan tabell-tittler formatteres. Alle "title1" over tabeller vil nå formatteres som "title2" med noe justert mellomrom. Før/etter:
![image](https://github.com/user-attachments/assets/6c8bbf4b-5d6b-4035-b696-74a2ccc8747f)
![image](https://github.com/user-attachments/assets/c9062109-0047-4382-a360-497cbd4dd14a)
