### PR TITLE
Kunne inkludere vedlegg som støttar alle tre målformer i eit brev som…

### DIFF
--- a/brevbaker-dsl/src/main/kotlin/no/nav/pensjon/brev/template/LanguageCombination.kt
+++ b/brevbaker-dsl/src/main/kotlin/no/nav/pensjon/brev/template/LanguageCombination.kt
@@ -1,5 +1,7 @@
 package no.nav.pensjon.brev.template
 
+import no.nav.pensjon.brev.template.dsl.TemplateRootScope
+import no.nav.pensjon.brev.template.dsl.expression.expr
 import java.util.Objects
 
 internal sealed class LanguageCombination {
@@ -52,3 +54,15 @@ internal sealed class LanguageCombination {
     }
 
 }
+
+fun <Lang1 : Language, Lang2 : Language, AttachmentData: Any, LetterData: Any>
+        TemplateRootScope<LanguageSupport.Double<Lang1, Lang2>, LetterData>.includeAttachment(
+    attachment: AttachmentTemplate<LanguageSupport.Triple<Lang1, *, Lang2>, AttachmentData>,
+    attachmentData: Expression<AttachmentData>,
+    predicate: Expression<Boolean> = true.expr(),
+) = includeAttachment(castAttachment(attachment), attachmentData, predicate)
+
+// Det er trygt å caste her fordi receiver og phrase begge har Lang1 og Lang2.
+@Suppress("UNCHECKED_CAST")
+private fun <Lang1 : Language, Lang2 : Language, AttachmentData: Any> castAttachment(attachment: AttachmentTemplate<LanguageSupport.Triple<Lang1, *, Lang2>, AttachmentData>) =
+    attachment as AttachmentTemplate<LanguageSupport.Double<Lang1, Lang2>, AttachmentData>


### PR DESCRIPTION
… kun støttar bokmål og engelsk.

Enkel fiks for å løyse problemet.


Testa ut ein meir omfattande variant, med å innføre interface for vedleggsdata, men det vart veldig mange endringar og kjentes litt malplassert. Er frista til å gå den vegen på sikt, men kanskje ikkje no.