### PR TITLE
Fjerne unødige rocksdbjni-binærfiler

### DIFF
--- a/.github/workflows/pdfbygger-brevbaker.yml
+++ b/.github/workflows/pdfbygger-brevbaker.yml
@@ -98,7 +98,7 @@ jobs:
       - name: "compile and run tests"
         run: |
           ./gradlew :brevbaker-api-model-common:publishToMavenLocal
-          ./gradlew :pdf-bygger:build
+          ./gradlew :pdf-bygger:build :pdf-bygger:rydd
       - name: "Build and publish container image to GAR"
         uses: nais/docker-build-push@v0
         id: docker-push

--- a/pdf-bygger/build.gradle.kts
+++ b/pdf-bygger/build.gradle.kts
@@ -39,9 +39,7 @@ dependencies {
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.status.pages)
     implementation(libs.ktor.server.compression.jvm)
-    implementation(libs.kafka.streams) {
-//        exclude(group = "org.rocksdb", module = "rocksdbjni")
-    }
+    implementation(libs.kafka.streams)
     implementation(libs.connect.runtime)
 
     implementation(libs.bundles.metrics)

--- a/pdf-bygger/build.gradle.kts
+++ b/pdf-bygger/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.exclude
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 val javaTarget: String by System.getProperties()
@@ -38,7 +39,9 @@ dependencies {
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.status.pages)
     implementation(libs.ktor.server.compression.jvm)
-    implementation(libs.kafka.streams)
+    implementation(libs.kafka.streams) {
+//        exclude(group = "org.rocksdb", module = "rocksdbjni")
+    }
     implementation(libs.connect.runtime)
 
     implementation(libs.bundles.metrics)
@@ -65,5 +68,15 @@ application {
 ktor {
     fatJar {
         archiveFileName.set("${project.name}.jar")
+    }
+}
+
+tasks {
+    // Dette føles meningsløst å møtte gjøre, men rocksdb-biblioteket som kommer transitivt med kafka-streams trekker med seg alle disse binærfilene som vi ikke vil ha med i imaget - der vil vi kun ha for plattformen vi kjører på, altså linux/amd64.
+    // Dette er delvis henta fra https://robjohnson.dev/posts/thin-jars/
+    // Vi trigger denne oppgava fra GitHub Actions-arbeidsflyten, men den kan fint kjøres lokalt også - men den er tilpassa å fjerne alt unntatt amd64, så da er du avhengig av å ha rett plattform.
+    task<Exec>("rydd") {
+        commandLine("zip", "--delete", "./build/libs/pdf-bygger.jar",
+            "librocksdbjni-linux32-musl.so", "librocksdbjni-linux32.so", "librocksdbjni-linux64.so", "librocksdbjni-linux-ppc64le.so", "librocksdbjni-linux-ppc64le-musl.so", "librocksdbjni-linux-aarch64.so", "librocksdbjni-linux-aarch64-musl.so", "librocksdbjni-linux-s390x.so", "librocksdbjni-linux-s390x-musl.so", "librocksdbjni-win64.dll", "librocksdbjni-osx-arm64.jnilib", "librocksdbjni-osx-x86_64.jnilib")
     }
 }


### PR DESCRIPTION
kafka-streams-biblioteket trekkjer med seg rocksdbjni-biblioteket transitivt

Dette biblioteket inneheld binærfiler for eit mylder av plattformar, men i containeren her køyrer vi jo kun på akkurat vår eine plattform, så dei er berre støy og fyllmasse.

Tar bort alle binærfiler vi ikkje bruker, som ein custom gradle-action, og triggar denne i byggejobben. Dette kuttar imaget med ca 50-60 megabyte.

Løyser https://trello.com/c/DRTYaR7M/186-rocksdb-avhengnaden-transitivt-gjennom-kafka-streams-er-sv%C3%A6r-og-inneheld-alt-mogleg-vi-ikkje-treng