### PR TITLE
Saksbehandlervalgskjema boolean-felter i brevvelger

### DIFF
--- a/skribenten-web/frontend/src/Brevredigering/ModelEditor/ModelEditor.tsx
+++ b/skribenten-web/frontend/src/Brevredigering/ModelEditor/ModelEditor.tsx
@@ -6,7 +6,7 @@ import { useModelSpecification } from "~/api/brev-queries";
 import type { FieldType, LetterModelSpecification } from "~/types/brevbakerTypes";
 
 import { FieldEditor } from "./components/ObjectEditor";
-import { isFieldNullableOrBoolean } from "./components/utils";
+import { isBooleanField, isFieldNullableOrBoolean } from "./components/utils";
 
 const useModelSpecificationForm = (brevkode: string) => {
   const brevKodeSpecification = useModelSpecification(brevkode, (s) => s);
@@ -102,22 +102,14 @@ export const SaksbehandlerValgModelEditor = (props: {
   switch (props.fieldsToRender) {
     case "required": {
       /**
-       * Boolean felter er spesielle
-       * Det at et felt er non-nullable, betyr at den er påkrevd ved innsending av skjemaet
-       * Derimot, så er boolean felter stort sett kun brukt for brev-tekst, og er ikke et påkrevd felt som saksbehandler skal
-       * forholde seg til ved opprettelse av brev.
+       * Boolean felter har spesialbehandling. De er (nesten) alltid non-nullable og er flagg som styrer tekstvalg i malene
+       * som regnes som utenfor normen. Vi ønsker derfor ikke å vise dem i Brevvelger, da det ikke er særlig relevant der.
        *
-       * Tidligere har vi mekket opp et objekt ved innsending som inneholdt boolean feltene ved opprettelse av brev, som ikke
-       * har vært registrert i formet.
-       *
-       * Dette er litt fordi at feltene blir først registrert når dem blit rendret, og boolean felter skal ikke bli rendret under opprettelse av brev.
-       *
-       * Derfor, så registrerer vi boolean felter her.
-       *
-       * Merk at dette er på mange måter bare en ny hack
+       * Siden disse feltene er non-nullable så betyr det at vi må sende med en verdi for dem i Saksbehandlervalg-objektet,
+       * og derfor må de registreres i form-et med false som verdi.
        */
       for (const field of optionalFields) {
-        if (field.fieldType.type === "scalar" && field.fieldType.kind === "BOOLEAN") {
+        if (isBooleanField(field.fieldType)) {
           register(`saksbehandlerValg.${field.field}`, { value: false });
         }
       }

--- a/skribenten-web/frontend/src/components/brevmalAlternativer/BrevmalAlternativer.tsx
+++ b/skribenten-web/frontend/src/components/brevmalAlternativer/BrevmalAlternativer.tsx
@@ -23,10 +23,15 @@ const BrevmalAlternativer = (props: {
 
   switch (specificationFormElements.status) {
     case "error": {
-      return <ApiError error={specificationFormElements.error} title={"En feil skjedde"} />;
+      return (
+        <ApiError
+          error={specificationFormElements.error}
+          title={"Feil oppstod ved henting av alternativer for brevmal"}
+        />
+      );
     }
     case "pending": {
-      return <BodyShort size="small">Henter skjema for saksbehandler valg...</BodyShort>;
+      return null;
     }
     case "success": {
       if (

--- a/skribenten-web/frontend/src/components/brevmalAlternativer/BrevmalAlternativer.tsx
+++ b/skribenten-web/frontend/src/components/brevmalAlternativer/BrevmalAlternativer.tsx
@@ -16,7 +16,7 @@ const BrevmalAlternativer = (props: {
   /**
    * Kan velge hvilke felter som skal vises. Default er at begge vises (dersom dem finnes, ellers bare den som finnes)
    */
-  displaySingle?: "required" | "optional";
+  onlyShowRequired?: boolean;
   withTitle?: boolean;
 }) => {
   const specificationFormElements = usePartitionedModelSpecification(props.brevkode);
@@ -33,16 +33,14 @@ const BrevmalAlternativer = (props: {
         specificationFormElements.optionalFields.length === 0 &&
         specificationFormElements.requiredfields.length === 0
       ) {
-        return (
-          <VStack gap="3">
-            {props.withTitle && <Heading size="xsmall">Brevmal alternativer</Heading>}
-            <BodyShort size="small">Det finnes ikke tekstalternativer i denne malen.</BodyShort>
-          </VStack>
-        );
+        return null;
       }
 
-      if (props.displaySingle) {
-        if (props.displaySingle === "required" && specificationFormElements.requiredfields.length > 0) {
+      if (props.onlyShowRequired) {
+        if (
+          specificationFormElements.requiredfields.length > 0 ||
+          specificationFormElements.optionalFields.length > 0
+        ) {
           return (
             <VStack gap="3">
               {props.withTitle && <Heading size="xsmall">Brevmal alternativer</Heading>}
@@ -54,20 +52,8 @@ const BrevmalAlternativer = (props: {
               />
             </VStack>
           );
-        }
-
-        if (props.displaySingle === "optional" && specificationFormElements.optionalFields.length > 0) {
-          return (
-            <VStack gap="3">
-              {props.withTitle && <Heading size="xsmall">Brevmal alternativer</Heading>}
-              <SaksbehandlerValgModelEditor
-                brevkode={props.brevkode}
-                fieldsToRender={"optional"}
-                specificationFormElements={specificationFormElements}
-                submitOnChange={props.submitOnChange}
-              />
-            </VStack>
-          );
+        } else {
+          return null;
         }
       } else {
         if (specificationFormElements.optionalFields.length === 0) {
@@ -161,7 +147,6 @@ const BrevmalAlternativer = (props: {
           </VStack>
         );
       }
-      return null;
     }
   }
 };

--- a/skribenten-web/frontend/src/components/brevmalAlternativer/BrevmalAlternativer.tsx
+++ b/skribenten-web/frontend/src/components/brevmalAlternativer/BrevmalAlternativer.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { BodyShort, Heading, Tabs, VStack } from "@navikt/ds-react";
+import { Heading, Tabs, VStack } from "@navikt/ds-react";
 
 import {
   SaksbehandlerValgModelEditor,

--- a/skribenten-web/frontend/src/routes/saksnummer_/$saksId/brevvelger/-components/brevmal/BrevmalBrevbaker.tsx
+++ b/skribenten-web/frontend/src/routes/saksnummer_/$saksId/brevvelger/-components/brevmal/BrevmalBrevbaker.tsx
@@ -220,7 +220,7 @@ const BrevmalBrevbaker = (props: {
             </VStack>
             <SelectEnhet />
             <SelectLanguage preferredLanguage={props.preferredLanguage} sorterteSpråk={props.displayLanguages} />
-            <BrevmalAlternativer brevkode={props.letterTemplate.id} displaySingle="required" />
+            <BrevmalAlternativer brevkode={props.letterTemplate.id} onlyShowRequired />
           </VStack>
           {opprettBrevMutation.isError && <ApiError error={opprettBrevMutation.error} title="Bestilling feilet" />}
         </BrevmalFormWrapper>


### PR DESCRIPTION
Toggles for boolean-felter skal ikke vises i brevvelger, men de må allikavel sendes med som false ved opprettelse av brev.
Fikser det slik at boolean-felter registreres i brevvelger saksbehandlervalg-form med false som verdi.