### PR TITLE
Pensjonsmaler bruker ny kode frå modellmodulen utan å bruke nyaste ve…

### DIFF
--- a/pensjonsmaler/build.gradle.kts
+++ b/pensjonsmaler/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-val apiModelVersion = 194
+val apiModelVersion = 195
 
 val apiModelJavaTarget: String by System.getProperties()
 


### PR DESCRIPTION
…rsjon av modulen, det gir kompileringsfeil og krøll. Løysast enkelt ved å bruke nyaste versjon.