### PR TITLE
Oppsett for at integrasjonstestane skal køyre igjen

### DIFF
--- a/etterlattemaler/build.gradle.kts
+++ b/etterlattemaler/build.gradle.kts
@@ -72,7 +72,10 @@ tasks {
         }
     }
 
-    task<Test>("integrationTest") {
+    val test by testing.suites.existing(JvmTestSuite::class)
+    register<Test>("integrationTest") {
+        testClassesDirs = files(test.map { it.sources.output.classesDirs })
+        classpath = files(test.map { it.sources.runtimeClasspath })
         group = LifecycleBasePlugin.VERIFICATION_GROUP
         useJUnitPlatform {
             includeTags = setOf("integration-test")

--- a/pensjon-brevbaker/build.gradle.kts
+++ b/pensjon-brevbaker/build.gradle.kts
@@ -59,7 +59,10 @@ tasks {
         }
     }
 
+    val test by testing.suites.existing(JvmTestSuite::class)
     register<Test>("integrationTest") {
+        testClassesDirs = files(test.map { it.sources.output.classesDirs })
+        classpath = files(test.map { it.sources.runtimeClasspath })
         outputs.doNotCacheIf("Output of this task is pdf from pdf-bygger which is not cached") { true }
         systemProperties["junit.jupiter.execution.parallel.enabled"] = true
         systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"

--- a/pensjonsmaler/build.gradle.kts
+++ b/pensjonsmaler/build.gradle.kts
@@ -69,7 +69,10 @@ tasks {
         }
     }
 
-    task<Test>("integrationTest") {
+    val test by testing.suites.existing(JvmTestSuite::class)
+    register<Test>("integrationTest") {
+        testClassesDirs = files(test.map { it.sources.output.classesDirs })
+        classpath = files(test.map { it.sources.runtimeClasspath })
         group = LifecycleBasePlugin.VERIFICATION_GROUP
         useJUnitPlatform {
             includeTags = setOf("integration-test")


### PR DESCRIPTION
https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html#task_changes treff visst oss, sjølv om det som slår til ser ut til å vera "In previous releases, it was possible to create Test tasks without any additional configuration. By convention, Gradle used the classpath and test classes from the test source set." - og vi _har_ jo additional configuration. Men workarounden deira funka.