### PR TITLE
Treng ikkje at dependabot gjer noko med brevbaker-api-model-common, d…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,8 @@ updates:
     open-pull-requests-limit: 10
     registries:
       - gradle-artifactory
+    ignore:
+      - dependency-name: "no.nav.pensjon.brevbaker:brevbaker-api-model-common"
     groups:
       tjenestebuss:
         patterns:


### PR DESCRIPTION
…en justerer vi sjølv