### PR TITLE
Potential fix for code scanning alert no. 28: Missing CSRF middleware

### DIFF
--- a/skribenten-web/bff/package-lock.json
+++ b/skribenten-web/bff/package-lock.json
@@ -15,6 +15,7 @@
         "express": "5.1.0",
         "http-proxy-middleware": "^3.0.5",
         "jwt-decode": "4.0.0",
+        "lusca": "^1.7.0",
         "morgan": "^1.10.1"
       },
       "devDependencies": {
@@ -3499,6 +3500,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "dependencies": {
+        "tsscmp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4894,6 +4906,15 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
       }
     },
     "node_modules/type-check": {

--- a/skribenten-web/bff/package-lock.json
+++ b/skribenten-web/bff/package-lock.json
@@ -23,6 +23,7 @@
         "@eslint/js": "9.30.0",
         "@types/cookie-parser": "^1.4.9",
         "@types/express": "5.0.3",
+        "@types/lusca": "^1.7.5",
         "@types/morgan": "^1.9.10",
         "@typescript-eslint/eslint-plugin": "8.35.1",
         "@typescript-eslint/parser": "8.35.1",
@@ -417,6 +418,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lusca": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/lusca/-/lusca-1.7.5.tgz",
+      "integrity": "sha512-l49gAf8pu2iMzbKejLcz6Pqj+51H2na6BgORv1ElnE8ByPFcBdh/eZ0WNR1Va/6ZuNSZa01Hoy1DTZ3IZ+y+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",

--- a/skribenten-web/bff/package.json
+++ b/skribenten-web/bff/package.json
@@ -19,14 +19,15 @@
     "express": "5.1.0",
     "http-proxy-middleware": "^3.0.5",
     "jwt-decode": "4.0.0",
-    "morgan": "^1.10.1",
-    "lusca": "^1.7.0"
+    "lusca": "^1.7.0",
+    "morgan": "^1.10.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.30.0",
     "@types/cookie-parser": "^1.4.9",
     "@types/express": "5.0.3",
+    "@types/lusca": "^1.7.5",
     "@types/morgan": "^1.9.10",
     "@typescript-eslint/eslint-plugin": "8.35.1",
     "@typescript-eslint/parser": "8.35.1",

--- a/skribenten-web/bff/package.json
+++ b/skribenten-web/bff/package.json
@@ -19,7 +19,8 @@
     "express": "5.1.0",
     "http-proxy-middleware": "^3.0.5",
     "jwt-decode": "4.0.0",
-    "morgan": "^1.10.1"
+    "morgan": "^1.10.1",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.3.1",

--- a/skribenten-web/bff/src/internalRoutes.ts
+++ b/skribenten-web/bff/src/internalRoutes.ts
@@ -3,6 +3,7 @@ import bodyParser from "body-parser";
 import cookieParser from "cookie-parser";
 import { Express } from "express";
 import { jwtDecode } from "jwt-decode";
+import lusca from "lusca";
 
 import config from "./config.js";
 
@@ -38,7 +39,7 @@ export const internalRoutes = (server: Express) => {
     });
   });
 
-  server.post("/bff/internal/logg", bodyParser.json(), cookieParser(), (request, response) => {
+  server.post("/bff/internal/logg", bodyParser.json(), cookieParser(), lusca.csrf(), (request, response) => {
     if (request.cookies["use-local-vite-server"] === "true") {
       response.status(200).end();
       return;


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/pensjonsbrev/security/code-scanning/28](https://github.com/navikt/pensjonsbrev/security/code-scanning/28)

To fix the missing CSRF middleware, we should add a well-known CSRF protection middleware to the `/bff/internal/logg` POST route. Since the recommendation mentions using `lusca`, we'll use `lusca.csrf()` middleware. This requires:
- Importing `lusca` at the top of the file.
- Adding `lusca.csrf()` as middleware to the POST `/bff/internal/logg` handler.
- The rest of the route logic should remain unchanged.

No other routes need to be modified unless they also use cookie-based authentication for state-changing actions, but as per the provided code, only this route is affected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
