### PR TITLE
Aukar shutdown-timeout i Skribenten

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
@@ -53,7 +53,7 @@ fun main() {
                 port = skribentenConfig.getInt("port")
             })
             shutdownGracePeriod = 25.seconds.inWholeMilliseconds
-            shutdownTimeout = 30.seconds.inWholeMilliseconds
+            shutdownTimeout = 29.seconds.inWholeMilliseconds
         },
     ) {
         skribentenApp(skribentenConfig)


### PR DESCRIPTION
For å unngå A` task raised an exception. Task: io.netty.channel.AbstractChannel$AbstractUnsafe$8@6d71d9b9 `

Ser ut som det her skal halde, men vanskeleg å seie sikkert før vi har fått testa det ein del gongar. Funkar fint på tre-fire deploys til dev no, iallfall.