### PR TITLE
Fold addresse heller enn redigeringsknapp-neste-linje i brevbehandler

### DIFF
--- a/skribenten-web/frontend/src/routes/saksnummer_/$saksId/brevbehandler/-components/BrevbehandlerMeny.tsx
+++ b/skribenten-web/frontend/src/routes/saksnummer_/$saksId/brevbehandler/-components/BrevbehandlerMeny.tsx
@@ -198,7 +198,7 @@ const ActiveBrev = (props: { saksId: string; brev: BrevInfo }) => {
           overrideOppsummering={(edit) => (
             <div>
               <Detail textColor="subtle">Mottaker</Detail>
-              <HStack align="start" gap="8">
+              <HStack align="start" gap="8" wrap={false}>
                 <OppsummeringAvMottaker
                   mottaker={props.brev.mottaker ?? null}
                   saksId={props.saksId}


### PR DESCRIPTION
En-linje-fiks på at min-max bredde medførte at smal visning kunne gjøre at mottaker-presentasjonen i brevvelger dyttet redigeringsknappen ned på linjen under adressen der knappen ble stående helt alene og med redusert kontekst. Sånn kan vi ikke ha det 😄 Ved å fjerne wrapping på overordnet nivå vil adresselinjene foldes hvis det blir for trangt, i stedet for å folde knappen. 