### PR TITLE
Rullet tilbake deler av forenkling.

### DIFF
--- a/pensjon-brevbaker-api-model/gradle.properties
+++ b/pensjon-brevbaker-api-model/gradle.properties
@@ -1,1 +1,1 @@
-version=249
+version=250

--- a/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/redigerbar/EndringAvAlderspensjonSivilstandSaerskiltSatsDto.kt
+++ b/pensjon-brevbaker-api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/redigerbar/EndringAvAlderspensjonSivilstandSaerskiltSatsDto.kt
@@ -78,6 +78,7 @@ data class EndringAvAlderspensjonSivilstandSaerskiltSatsDto(
     data class AlderspensjonVedVirk(
         val innvilgetFor67: Boolean,
         val minstenivaaIndividuellInnvilget: Boolean,
+        val saertilleggInnvilget: Boolean,
         val ufoereKombinertMedAlder: Boolean,
         val uttaksgrad: Int,
     )

--- a/pensjonsmaler/build.gradle.kts
+++ b/pensjonsmaler/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-val apiModelVersion = 249
+val apiModelVersion = 250
 
 val apiModelJavaTarget: String by System.getProperties()
 

--- a/pensjonsmaler/src/main/kotlin/no/nav/pensjon/brev/maler/alder/endring/sivilstand/fraser/SivilstandHjemler.kt
+++ b/pensjonsmaler/src/main/kotlin/no/nav/pensjon/brev/maler/alder/endring/sivilstand/fraser/SivilstandHjemler.kt
@@ -152,7 +152,7 @@ data class SivilstandHjemler(
     }
 }
 
-private data class SivilstandSamboerHjemler(
+data class SivilstandSamboerHjemler(
     val sivilstand: Expression<MetaforceSivilstand>,
 ) : TextOnlyPhrase<LangBokmalNynorskEnglish>() {
     override fun TextOnlyScope<LangBokmalNynorskEnglish, Unit>.template() {

--- a/pensjonsmaler/src/test/kotlin/no/nav/pensjon/brev/fixtures/redigerbar/EndringAvAlderspensjonSivilstandSaerskiltSatsDto.kt
+++ b/pensjonsmaler/src/test/kotlin/no/nav/pensjon/brev/fixtures/redigerbar/EndringAvAlderspensjonSivilstandSaerskiltSatsDto.kt
@@ -40,6 +40,7 @@ fun createEndringAvAlderspensjonSivilstandSaerskiltSatsDto() =
                             minstenivaaIndividuellInnvilget = true,
                             ufoereKombinertMedAlder = false,
                             uttaksgrad = 100,
+                            saertilleggInnvilget = true,
                         ),
                     beregnetPensjonPerManedVedVirk =
                         EndringAvAlderspensjonSivilstandSaerskiltSatsDto.BeregnetPensjonPerManedVedVirk(


### PR DESCRIPTION
Avklaringen om at det aldri er AP1967 ved kravårsakstype vurder særskilt sats viste seg å være feil. Ruller tilbake forenklinger rundt AP1967 innhold.