### PR TITLE
Fiks feil når fonttype settes på en tom linje

### DIFF
--- a/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/switchFontType.ts
+++ b/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/switchFontType.ts
@@ -276,12 +276,12 @@ const switchFontTypeOfCurrentWord = (args: {
   }
 
   let wordStartPosition = cursorPosition;
-  while (wordStartPosition > 0 && text[wordStartPosition - 1].trim() !== "") {
+  while (wordStartPosition > 0 && text[wordStartPosition - 1]?.trim() !== "") {
     wordStartPosition--;
   }
 
   let wordEndPosition = cursorPosition;
-  while (wordEndPosition < text.length && text[wordEndPosition].trim() !== "") {
+  while (wordEndPosition < text.length && text[wordEndPosition]?.trim() !== "") {
     wordEndPosition++;
   }
 


### PR DESCRIPTION
Hvis man lager en ny linje i et brev, lar markøren stå på den tomme linjen, og så endrer fonttype (fet/kursiv), så får man en feilmelding.

Denne fiksen håndterer feilsituasjonen og setter fonttypen til den tomme linjen.