### PR TITLE
Skrur på tracing også for tjenestebuss-integrasjon

### DIFF
--- a/tjenestebuss-integrasjon/.nais/nais.yaml
+++ b/tjenestebuss-integrasjon/.nais/nais.yaml
@@ -31,6 +31,9 @@ spec:
     path: "/metrics"
     port: "8080"
   observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
     logging:
       destinations:
         - id: elastic


### PR DESCRIPTION
Ref https://nav-it.slack.com/archives/C05DXMSNSV8/p1725023816588279 , så er det også tilgjengeleg i fss, så greitt å ha det på plass der også.