### PR TITLE
Skal skule konvertert exstream variant for alle utenom uføre.

### DIFF
--- a/pensjonsmaler/src/main/kotlin/no/nav/pensjon/brev/maler/redigerbar/ForhaandsvarselVedTilbakekreving.kt
+++ b/pensjonsmaler/src/main/kotlin/no/nav/pensjon/brev/maler/redigerbar/ForhaandsvarselVedTilbakekreving.kt
@@ -22,7 +22,7 @@ object ForhaandsvarselVedTilbakekreving : RedigerbarTemplate<EmptyRedigerbarBrev
     override val kode = Pesysbrevkoder.Redigerbar.PE_FORHAANDSVARSEL_VED_TILBAKEKREVING
     override val kategori = TemplateDescription.Brevkategori.FEILUTBETALING
     override val brevkontekst: TemplateDescription.Brevkontekst = TemplateDescription.Brevkontekst.ALLE
-    override val sakstyper: Set<Sakstype> = Sakstype.all
+    override val sakstyper: Set<Sakstype> = setOf(Sakstype.UFOREP)
 
     override val template = createTemplate(
         languages = languages(Bokmal, Nynorsk, English),


### PR DESCRIPTION
Tilsvarende doksysmal er konvertert og passer bedre i andre tilfeller. Den konverterte exstream varianten skal kun gjelde uføre-saker. Ref:  https://nav-it.slack.com/archives/C08H52KFD4Y/p1759833099631679?thread_ts=1759753630.046399&cid=C08H52KFD4Y