### PR TITLE
Bruker reg-simple-keygen-plugin istedenfor hash. 

### DIFF
--- a/.github/regsuitconfig.json
+++ b/.github/regsuitconfig.json
@@ -6,7 +6,8 @@
   },
   "plugins": {
     "reg-simple-keygen-plugin": {
-      "expectedKey": "main"
+      "expectedKey": "main",
+      "actualKey": "${ACTUAL_KEY}"
     },
     "reg-publish-gcs-plugin": {
       "bucketName": "no-nav-pensjonsbrev-reg-suit",

--- a/.github/regsuitconfig.json
+++ b/.github/regsuitconfig.json
@@ -5,7 +5,9 @@
     "threshold": 0
   },
   "plugins": {
-    "reg-keygen-git-hash-plugin": {},
+    "reg-simple-keygen-plugin": {
+      "expectedKey": "main"
+    },
     "reg-publish-gcs-plugin": {
       "bucketName": "no-nav-pensjonsbrev-reg-suit",
       "pathPrefix": "pdf-visual"

--- a/.github/workflows/pdfbygger.yml
+++ b/.github/workflows/pdfbygger.yml
@@ -200,7 +200,7 @@ jobs:
         working-directory: brevbaker/pdf-bygger/build/test_visual/png
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          ACTUAL_KEY: ${{ github.event_name == 'pull_request' && github.sha || 'main' }}
+          ACTUAL_KEY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
 
   deployPdfByggerToDev:
     name: "Deploy pdf-bygger to dev"

--- a/.github/workflows/pdfbygger.yml
+++ b/.github/workflows/pdfbygger.yml
@@ -161,22 +161,16 @@ jobs:
     name: "Analyze images"
     needs: [runIntegrationTests, changes]
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.brevmal-design == 'true' || (github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')) }}
+    if: ${{ needs.changes.outputs.brevmal-design == 'true' || (github.ref == 'refs/heads/main' && github.event_name == 'push') }}
     permissions:
       statuses: write
       checks: write
       pull-requests: write
       id-token: write
     steps:
-      # Checkout with an explicit ref so we get a named branch instead of a
-      # detached HEAD — reg-notify-github-plugin needs the branch name to find the PR to comment on.
-      # fetch-depth: 0 fetches the full history so reg-keygen-git-hash-plugin can
-      # walk back through commits to find a previously published snapshot.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.head_ref || github.ref_name }}
-          fetch-depth: 0
 
       - name: Download visuals
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -195,7 +189,7 @@ jobs:
         with:
           node-version-file: ".tool-versions"
       - name: Install reg-suit
-        run: npm install --no-save reg-suit reg-publish-gcs-plugin reg-notify-github-with-api-plugin reg-keygen-git-hash-plugin
+        run: npm install --no-save reg-suit reg-publish-gcs-plugin reg-notify-github-with-api-plugin reg-simple-keygen-plugin
       - name: Authenticate to Google Cloud
         uses: nais/login@c88ada9ce583928e1c84d2fd5c45cfacdd18d5de # v0
         with:
@@ -205,6 +199,7 @@ jobs:
         working-directory: brevbaker/pdf-bygger/build/test_visual/png
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          REG_SUIT_ACTUAL_KEY: ${{ github.event_name == 'pull_request' && github.sha || 'main' }}
 
   deployPdfByggerToDev:
     name: "Deploy pdf-bygger to dev"

--- a/.github/workflows/pdfbygger.yml
+++ b/.github/workflows/pdfbygger.yml
@@ -171,6 +171,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #  v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Download visuals
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -199,7 +200,7 @@ jobs:
         working-directory: brevbaker/pdf-bygger/build/test_visual/png
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          REG_SUIT_ACTUAL_KEY: ${{ github.event_name == 'pull_request' && github.sha || 'main' }}
+          ACTUAL_KEY: ${{ github.event_name == 'pull_request' && github.sha || 'main' }}
 
   deployPdfByggerToDev:
     name: "Deploy pdf-bygger to dev"

--- a/.github/workflows/pdfbygger.yml
+++ b/.github/workflows/pdfbygger.yml
@@ -151,7 +151,7 @@ jobs:
           fail_on_test_failures: true
           report_paths: "**/build/test-results/integrationTest/TEST-*.xml"
       - name: Upload images
-        if: ${{ needs.changes.outputs.brevmal-design == 'true' || (github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')) }}
+        if: ${{ needs.changes.outputs.brevmal-design == 'true' || (github.ref == 'refs/heads/main' && github.event_name == 'push') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: visuals


### PR DESCRIPTION
Skal alltid sammenligne med main. Trenger heller ikke å publisere bilde-analyse om man deployer pdf-byggeren til dev med workflow.