### PR TITLE
Bruker kun activity-counter på LaTeX. Legger til cpu-skalering. 

### DIFF
--- a/brevbaker/pdf-bygger/.nais/hpa.yaml
+++ b/brevbaker/pdf-bygger/.nais/hpa.yaml
@@ -18,3 +18,9 @@ spec:
         target:
           type: AverageValue
           averageValue: "2" #PDF_BYGGER_LATEX_PARALLELISM / 2
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/PdfByggerApp.kt
+++ b/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/PdfByggerApp.kt
@@ -125,15 +125,14 @@ private fun Application.setUp() {
 
         post("/produserBrev") {
             val useTypst = call.request.queryParameters["typst"]?.toBoolean() == true
-            val result = activityCounter.count {
-                val request = call.receive<PDFRequest>()
-                if (useTypst) {
-                    typstCompileService.createLetter {
-                        TypstDocumentRenderer.render(request, it)
-                    }
-                } else {
-                    LatexDocumentRenderer.render(request)
-                        .let { blockingLatexService.producePDF(it.files) }
+            val request = call.receive<PDFRequest>()
+            val result = if (useTypst) {
+                typstCompileService.createLetter {
+                    TypstDocumentRenderer.render(request, it)
+                }
+            } else {
+                activityCounter.count {
+                    LatexDocumentRenderer.render(request).let { blockingLatexService.producePDF(it.files) }
                 }
             }
             handleResult(result, call.application.environment.log)


### PR DESCRIPTION
Tjenesten skalerer nå om enten cpu er gjennomsnittlig over 50% en periode, eller activitycounter er høy over en periode.