### PR TITLE
NAV-28534 Rette tekst bosatt utland

### DIFF
--- a/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/InformasjonOmOmstillingsstoenad.kt
+++ b/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/InformasjonOmOmstillingsstoenad.kt
@@ -572,8 +572,8 @@ private fun OutlineOnlyScope<LangBokmalNynorskEnglish, InformasjonOmOmstillingss
             text(
                 bokmal {
                     +"Er du ikke skattemessig bosatt i Norge, skal du betale 15 prosent kildeskatt på brutto omstillingsstønad. " +
-                            "Bor du i et land med skatteavtale med Norge, kan du ha rett til fritak fra kildeskatt. Bor du i et land med skatteavtale med Norge, " +
-                            "kan du ha rett til fritak fra kildeskatt. Hvis du bor i et EU- eller EØS-land, kan du bli skatteberegnet som bosatt i Norge."
+                            "Bor du i et land med skatteavtale med Norge, kan du ha rett til fritak fra kildeskatt. Hvis du bor i et EU- eller EØS-land, " +
+                            "kan du bli skatteberegnet som bosatt i Norge."
                 },
                 nynorsk {
                     +"Er du ikkje skattemessig busett i Noreg, skal du betale 15 prosent kjeldeskatt av brutto omstillingsstønad. " +

--- a/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/InformasjonOmOmstillingsstoenad.kt
+++ b/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/InformasjonOmOmstillingsstoenad.kt
@@ -551,11 +551,6 @@ private fun OutlineOnlyScope<LangBokmalNynorskEnglish, InformasjonOmOmstillingss
         }
         paragraph {
             text(
-                bokmal { +"Skattemessig bosatt i Norge:" },
-                nynorsk { +"Skattemessig busett i Noreg:" },
-                english { +"Tax reident in Norway:" }
-            )
-            text(
                 bokmal {
                     +"Hvis du er skattemessig bosatt i Norge, skal du betale skatt på all inntekt og formue. " +
                             "Husk å kontrollere skattekortet ditt på ${Constants.SKATTEETATEN_ENDRE_URL}. Ønsker du å avslutte skatteplikten, " +

--- a/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/InformasjonOmOmstillingsstoenad.kt
+++ b/etterlattemaler/src/main/kotlin/no/nav/pensjon/etterlatte/maler/vedlegg/omstillingsstoenad/InformasjonOmOmstillingsstoenad.kt
@@ -559,7 +559,7 @@ private fun OutlineOnlyScope<LangBokmalNynorskEnglish, InformasjonOmOmstillingss
                 bokmal {
                     +"Hvis du er skattemessig bosatt i Norge, skal du betale skatt på all inntekt og formue. " +
                             "Husk å kontrollere skattekortet ditt på ${Constants.SKATTEETATEN_ENDRE_URL}. Ønsker du å avslutte skatteplikten, " +
-                            "kan du søke om skattemessig emigrasjon"
+                            "kan du søke om skattemessig emigrasjon."
                 },
                 nynorsk {
                     +"Viss du er skattemessig busett i Norge, skal du betale skatt for all inntekt og formue. " +
@@ -575,13 +575,8 @@ private fun OutlineOnlyScope<LangBokmalNynorskEnglish, InformasjonOmOmstillingss
         }
         paragraph {
             text(
-                bokmal { +"Ikke skattemessig bosatt i Norge:" },
-                nynorsk { +"Ikkje skattemessig busett i Noreg:" },
-                english { +"Non-tax resident in Norway:" }
-            )
-            text(
                 bokmal {
-                    +"Er du ikke skattemessig bosatt i Norge, skal du betale 15 prosent kildeskatt på brutto omstillingsstønad." +
+                    +"Er du ikke skattemessig bosatt i Norge, skal du betale 15 prosent kildeskatt på brutto omstillingsstønad. " +
                             "Bor du i et land med skatteavtale med Norge, kan du ha rett til fritak fra kildeskatt. Bor du i et land med skatteavtale med Norge, " +
                             "kan du ha rett til fritak fra kildeskatt. Hvis du bor i et EU- eller EØS-land, kan du bli skatteberegnet som bosatt i Norge."
                 },
@@ -599,7 +594,7 @@ private fun OutlineOnlyScope<LangBokmalNynorskEnglish, InformasjonOmOmstillingss
         }
         paragraph {
             text(
-                bokmal { +"Les mer på ${Constants.SKATTEETATEN_KILDESKATTPENSJON_URL} eller kontakt Skatteetaten på telefon ${Constants.SKATTEETATEN_KONTAKTTELEFON_MED_LANDKODE} fra utlandet" },
+                bokmal { +"Les mer på ${Constants.SKATTEETATEN_KILDESKATTPENSJON_URL} eller kontakt Skatteetaten på telefon ${Constants.SKATTEETATEN_KONTAKTTELEFON_MED_LANDKODE} fra utlandet." },
                 nynorsk { +"Les meir på ${Constants.SKATTEETATEN_KILDESKATTPENSJON_URL} eller kontakt Skatteetaten på telefon ${Constants.SKATTEETATEN_KONTAKTTELEFON_MED_LANDKODE} frå utlandet." },
                 english { +"Read more at ${Constants.SKATTEETATEN_KILDESKATTPENSJON_URL} or contact the Norwegian Tax Administration by phone at ${Constants.SKATTEETATEN_KONTAKTTELEFON_MED_LANDKODE} from abroad." }
             )


### PR DESCRIPTION
Rettet opp i tekst knyttet til om mottaker er skattemessig bosatt i Norge. Retter opp noen punktumsfeil og manglende mellomrom.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28534)