### PR TITLE
Sletter spacing hack nå som typst klarer å sette tittel sammen med lister.

### DIFF
--- a/ufoere/maler/src/main/kotlin/no/nav/pensjon/brev/ufore/maler/info/InfobrevLovendringer2026.kt
+++ b/ufoere/maler/src/main/kotlin/no/nav/pensjon/brev/ufore/maler/info/InfobrevLovendringer2026.kt
@@ -67,9 +67,6 @@ object InfobrevLovendringer2026 : AutobrevTemplate<EmptyAutobrevdata> {
                 }
             }
 
-            paragraph { // TODO dette hacket er ikke lengre nødvendig i det typst er på lufta istedenfor LaTeX. Tittelen henger alltid sammen med innholdet under.
-                text(bokmal { +"\u200B" }) // unicode zero width space, workaround for å tvinge fram linjeskift
-            }
             title3 { text(bokmal { +"Du trenger ikke å gjøre noe" }) }
             paragraph {
                 list {


### PR DESCRIPTION
Legger denne ut etter jeg har skrudd på typst for autobrev.