### PR TITLE
Fix mergeTextContent for edited Literal merged with rendered Variable

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/UpdateEditedLetter.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/UpdateEditedLetter.kt
@@ -159,7 +159,7 @@ class UpdateEditedLetter(private val edited: Edit.Letter, rendered: LetterMarkup
         when (edited) {
             is Edit.ParagraphContent.Text.Literal -> when (rendered) {
                 is Edit.ParagraphContent.Text.Literal -> rendered.copy(editedText = edited.editedText, editedFontType = edited.editedFontType)
-                is Edit.ParagraphContent.Text.Variable -> throw UpdateEditedLetterException("Edited literal and rendered variable has same ID, cannot merge: $edited - $rendered")
+                is Edit.ParagraphContent.Text.Variable -> edited
                 is Edit.ParagraphContent.Text.NewLine -> throw UpdateEditedLetterException("Edited literal and rendered newLine has same ID, cannot merge: $edited - $rendered")
             }
             is Edit.ParagraphContent.Text.Variable -> throw UpdateEditedLetterException("Variable should never be considered edited: $edited")

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/UpdateEditedLetter.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/UpdateEditedLetter.kt
@@ -159,7 +159,7 @@ class UpdateEditedLetter(private val edited: Edit.Letter, rendered: LetterMarkup
         when (edited) {
             is Edit.ParagraphContent.Text.Literal -> when (rendered) {
                 is Edit.ParagraphContent.Text.Literal -> rendered.copy(editedText = edited.editedText, editedFontType = edited.editedFontType)
-                is Edit.ParagraphContent.Text.Variable -> edited
+                is Edit.ParagraphContent.Text.Variable -> if (edited.editedText != null) edited else rendered
                 is Edit.ParagraphContent.Text.NewLine -> throw UpdateEditedLetterException("Edited literal and rendered newLine has same ID, cannot merge: $edited - $rendered")
             }
             is Edit.ParagraphContent.Text.Variable -> throw UpdateEditedLetterException("Variable should never be considered edited: $edited")

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/UpdateEditedLetterTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/UpdateEditedLetterTest.kt
@@ -1091,11 +1091,11 @@ class UpdateRenderedLetterTest {
         val editedLetter1 = editedLetter(
             E_Paragraph(1, true, listOf(
                 E_Literal(11, "fast tekst"),
-                E_Literal(12, "fritekst", editedText = "fyllt inn fritekst", tags = setOf(ElementTags.FRITEKST)),
+                E_Literal(12, "fritekst", editedText = "fylt inn fritekst", tags = setOf(ElementTags.FRITEKST)),
             ))
         )
 
-        val brevDataVariabelHarEnVerdi = letter(
+        val brevdataVariabelHarEnVerdi = letter(
             ParagraphImpl(1, true, listOf(
                 LiteralImpl(11, "fast tekst oppdatert"),
                 VariableImpl(12, "verdi fra brevdata"),
@@ -1106,11 +1106,11 @@ class UpdateRenderedLetterTest {
         val expected = editedLetter(
             E_Paragraph(1, true, listOf(
                 E_Literal(11, "fast tekst oppdatert"),
-                E_Literal(12, "fritekst", editedText = "fyllt inn fritekst", tags = setOf(ElementTags.FRITEKST)),
+                E_Literal(12, "fritekst", editedText = "fylt inn fritekst", tags = setOf(ElementTags.FRITEKST)),
             ))
         )
 
-        assertEquals(expected, editedLetter1.updateEditedLetter(brevDataVariabelHarEnVerdi))
+        assertEquals(expected, editedLetter1.updateEditedLetter(brevdataVariabelHarEnVerdi))
     }
 
 }

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/UpdateEditedLetterTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/UpdateEditedLetterTest.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.brev.skribenten.letter
 
 import no.nav.brev.Listetype
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Foedselsnummer
+import no.nav.pensjon.brevbaker.api.model.ElementTags
 import no.nav.pensjon.brevbaker.api.model.LetterMarkupImpl.BlockImpl.ParagraphImpl
 import no.nav.pensjon.brevbaker.api.model.LetterMarkupImpl.BlockImpl.Title1Impl
 import no.nav.pensjon.brevbaker.api.model.LetterMarkupImpl.BlockImpl.Title2Impl
@@ -230,29 +231,6 @@ class UpdateRenderedLetterTest {
         assertEquals(expected, edited.updateEditedLetter(next))
     }
 
-    @Test
-    fun `should fail when edited content has different type than the rendered content with same ID`() {
-        val next = letter(
-            Title1Impl(
-                1, true, listOf(
-                    VariableImpl(1, "En tittel "),
-                    VariableImpl(2, "for deg "),
-                    LiteralImpl(3, "og meg!")
-                )
-            )
-        )
-        val edited = editedLetter(
-            E_Title1(
-                1, true, listOf(
-                    E_Literal(1, "En tittel", E_FontType.PLAIN, "Her er det en ulovlig redigering"),
-                    E_Variable(2, "for deg ", E_FontType.PLAIN),
-                    E_Literal(3, "og meg!", E_FontType.PLAIN)
-                )
-            )
-        )
-
-        assertThrows<UpdateEditedLetterException> { edited.updateEditedLetter(next) }
-    }
 
     @Test
     fun `new edited literal added before a variable should be kept before that variable`() {
@@ -1105,6 +1083,34 @@ class UpdateRenderedLetterTest {
             )
         )
         assertEquals(edited, edited.updateEditedLetter(next))
+    }
+
+    @Test
+    fun `BrevdataEllerFritekst som begynner som fritekst og endres til variabel senere fordi saken oppdateres`() {
+        // Om et BrevdataEllerFritekst-expression i et brev ikke får brevdata ved første render, men får en verdi etter at saksbehandler har fylt inn fritekst så skal det ikke feile i Skribenten.
+        val editedLetter1 = editedLetter(
+            E_Paragraph(1, true, listOf(
+                E_Literal(11, "fast tekst"),
+                E_Literal(12, "fritekst", editedText = "fyllt inn fritekst", tags = setOf(ElementTags.FRITEKST)),
+            ))
+        )
+
+        val brevDataVariabelHarEnVerdi = letter(
+            ParagraphImpl(1, true, listOf(
+                LiteralImpl(11, "fast tekst oppdatert"),
+                VariableImpl(12, "verdi fra brevdata"),
+            ))
+        )
+
+        // Saksbehandlers redigering beholdes
+        val expected = editedLetter(
+            E_Paragraph(1, true, listOf(
+                E_Literal(11, "fast tekst oppdatert"),
+                E_Literal(12, "fritekst", editedText = "fyllt inn fritekst", tags = setOf(ElementTags.FRITEKST)),
+            ))
+        )
+
+        assertEquals(expected, editedLetter1.updateEditedLetter(brevDataVariabelHarEnVerdi))
     }
 
 }


### PR DESCRIPTION
## Problem

When a `BrevdataEllerFritekst` expression has no brevdata value it renders as a `Literal` (fritekst placeholder). If the caseworker fills in free text and brevdata later gets a value, the expression renders as a `Variable`. Previously `mergeTextContent` threw an `UpdateEditedLetterException` when encountering an edited `Literal` and a rendered `Variable` with the same ID:

> Edited literal and rendered variable has same ID, cannot merge ...

## Fix

Return `edited` (the `Literal` with the caseworker's free-text input) instead of throwing, so the caseworker's edits are preserved.

## Changes

- `UpdateEditedLetter.kt`: Handle the `Literal → Variable` case in `mergeTextContent` by returning `edited` instead of throwing.
- `UpdateEditedLetterTest.kt`: Remove the test that expected an exception for this case; add a new test `BrevdataEllerFritekst som begynner som fritekst og endres til variabel senere fordi saken oppdateres` that covers the full scenario.