### PR TITLE
Send til verge også for exstream-brev

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Features.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Features.kt
@@ -16,6 +16,7 @@ data class UnleashToggle(val name: String) {
 object Features {
 //    val exampleToggle = UnleashToggle("exampleToggle")
     val hindreDuplikateAvsnitt = UnleashToggle("hindreDuplikateAvsnitt")
+    val vergeForExstream = UnleashToggle("vergeForExstream")
 
     private var unleash: Unleash? = null
     private val overrides = mutableMapOf<String, Boolean>()

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Routing.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Routing.kt
@@ -44,7 +44,7 @@ fun Application.configureRouting(
     val brevmetadataService = BrevmetadataServiceHttp(servicesConfig.getConfig("brevmetadata"))
     val samhandlerService = SamhandlerServiceHttp(servicesConfig.getConfig("samhandlerProxy"), authService, cache)
     val navansattService = NavansattServiceHttp(servicesConfig.getConfig("navansatt"), authService, cache)
-    val legacyBrevService = LegacyBrevServiceImpl(brevmetadataService, safService, penClient, navansattService)
+    val legacyBrevService = LegacyBrevServiceImpl(brevmetadataService, safService, penClient, navansattService, pensjonPersonDataService)
     val norg2Service = Norg2ServiceHttp(servicesConfig.getConfig("norg2"), cache)
     val p1Service = P1ServiceImpl(penClient)
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceImpl.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceImpl.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.brev.skribenten.fagsystem.pesys
 import io.ktor.http.*
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import no.nav.pensjon.brev.skribenten.Features
 import no.nav.pensjon.brev.skribenten.auth.PrincipalInContext
 import no.nav.pensjon.brev.skribenten.fagsystem.pesys.BrevdataDto.DokumentkategoriCode.SED
 import no.nav.pensjon.brev.skribenten.model.*
@@ -141,7 +142,7 @@ class LegacyBrevServiceImpl(
                         mottaker = when {
                             isEblankett || isNotat -> null
                             idTSSEkstern != null -> idTSSEkstern
-                            else -> {
+                            Features.vergeForExstream.isEnabled() -> {
                                 val adresse = pensjonPersonDataService.hentKontaktadresse(gjelderPid)
                                 if (adresse?.type == KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE && adresse.vergePid != null) {
                                     adresse.vergePid.value
@@ -149,6 +150,7 @@ class LegacyBrevServiceImpl(
                                     gjelderPid.value
                                 }
                             }
+                            else -> gjelderPid.value
                         },
                         sensitivt = false
                     ),

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceImpl.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceImpl.kt
@@ -117,8 +117,6 @@ class LegacyBrevServiceImpl(
         return if (!harTilgangTilEnhet(enhetsId)) {
             Api.BestillOgRedigerBrevResponse(failureType = ENHET_UNAUTHORIZED)
         } else {
-            val adresse = pensjonPersonDataService.hentKontaktadresse(gjelderPid)
-
             penClient.bestillExstreamBrev(
                 Pen.BestillExstreamBrevRequest(
                     brevKode = brevkode,
@@ -143,8 +141,14 @@ class LegacyBrevServiceImpl(
                         mottaker = when {
                             isEblankett || isNotat -> null
                             idTSSEkstern != null -> idTSSEkstern
-                            adresse?.type == KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE && adresse.vergePid != null -> adresse.vergePid?.value
-                            else -> gjelderPid.value
+                            else -> {
+                                val adresse = pensjonPersonDataService.hentKontaktadresse(gjelderPid)
+                                if (adresse?.type == KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE && adresse.vergePid != null) {
+                                    adresse.vergePid.value
+                                } else {
+                                    gjelderPid.value
+                                }
+                            }
                         },
                         sensitivt = false
                     ),

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceImpl.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceImpl.kt
@@ -143,7 +143,7 @@ class LegacyBrevServiceImpl(
                         mottaker = when {
                             isEblankett || isNotat -> null
                             idTSSEkstern != null -> idTSSEkstern
-                            adresse?.type == KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE -> adresse.vergePid?.value
+                            adresse?.type == KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE && adresse.vergePid != null -> adresse.vergePid?.value
                             else -> gjelderPid.value
                         },
                         sensitivt = false

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceImpl.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceImpl.kt
@@ -9,8 +9,10 @@ import no.nav.pensjon.brev.skribenten.model.*
 import no.nav.pensjon.brev.skribenten.model.Api.BestillOgRedigerBrevResponse.FailureType.*
 import no.nav.pensjon.brev.skribenten.services.EnhetId
 import no.nav.pensjon.brev.skribenten.services.JournalpostLoadingResult.*
+import no.nav.pensjon.brev.skribenten.services.KontaktAdresseResponseDto
 import no.nav.pensjon.brev.skribenten.services.Navansatt
 import no.nav.pensjon.brev.skribenten.services.NavansattService
+import no.nav.pensjon.brev.skribenten.services.PensjonPersonDataService
 import no.nav.pensjon.brev.skribenten.services.SafService
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Pid
 import org.slf4j.LoggerFactory
@@ -26,6 +28,7 @@ class LegacyBrevServiceImpl(
     private val safService: SafService,
     private val penClient: PenClient,
     private val navansattService: NavansattService,
+    private val pensjonPersonDataService: PensjonPersonDataService,
 ) : LegacyBrevService {
     private val logger = LoggerFactory.getLogger(LegacyBrevServiceImpl::class.java)
 
@@ -114,6 +117,8 @@ class LegacyBrevServiceImpl(
         return if (!harTilgangTilEnhet(enhetsId)) {
             Api.BestillOgRedigerBrevResponse(failureType = ENHET_UNAUTHORIZED)
         } else {
+            val adresse = pensjonPersonDataService.hentKontaktadresse(gjelderPid)
+
             penClient.bestillExstreamBrev(
                 Pen.BestillExstreamBrevRequest(
                     brevKode = brevkode,
@@ -135,7 +140,12 @@ class LegacyBrevServiceImpl(
                         saksbehandlerid = PrincipalInContext.require().navIdent.id,
                         kravtype = null, // TODO sett. Brukes dette for notater i det hele tatt?
                         land = landkode.takeIf { isEblankett },
-                        mottaker = if (isEblankett || isNotat) null else idTSSEkstern ?: gjelderPid.value,
+                        mottaker = when {
+                            isEblankett || isNotat -> null
+                            idTSSEkstern != null -> idTSSEkstern
+                            adresse?.type == KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE -> adresse.vergePid?.value
+                            else -> gjelderPid.value
+                        },
                         sensitivt = false
                     ),
                     vedtaksInformasjon = vedtaksId?.id?.toString()

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/routes/Sak.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/routes/Sak.kt
@@ -141,24 +141,24 @@ fun Route.sakRoute(
     }
 }
 
-private fun adresseTilDto(adresse: KontaktAdresseResponseDto) = KontaktadresseDto(
+private fun adresseTilDto(adresse: KontaktAdresseResponseDto) = KontaktAdresseDto(
     adresseString = adresse.adresseString,
     adresselinjer = adresse.adresselinjer,
     type = when (adresse.type) {
-        KontaktAdresseResponseDto.Adressetype.MATRIKKELADRESSE -> KontaktadresseDto.Adressetype.MATRIKKELADRESSE
-        KontaktAdresseResponseDto.Adressetype.POSTADRESSE_I_FRITT_FORMAT -> KontaktadresseDto.Adressetype.POSTADRESSE_I_FRITT_FORMAT
-        KontaktAdresseResponseDto.Adressetype.POSTBOKSADRESSE -> KontaktadresseDto.Adressetype.POSTBOKSADRESSE
-        KontaktAdresseResponseDto.Adressetype.REGOPPSLAG_ADRESSE -> KontaktadresseDto.Adressetype.REGOPPSLAG_ADRESSE
-        KontaktAdresseResponseDto.Adressetype.UKJENT_BOSTED -> KontaktadresseDto.Adressetype.UKJENT_BOSTED
-        KontaktAdresseResponseDto.Adressetype.UTENLANDSK_ADRESSE -> KontaktadresseDto.Adressetype.UTENLANDSK_ADRESSE
-        KontaktAdresseResponseDto.Adressetype.UTENLANDSK_ADRESSE_I_FRITT_FORMAT -> KontaktadresseDto.Adressetype.UTENLANDSK_ADRESSE_I_FRITT_FORMAT
-        KontaktAdresseResponseDto.Adressetype.VEGADRESSE -> KontaktadresseDto.Adressetype.VEGADRESSE
-        KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE -> KontaktadresseDto.Adressetype.VERGE_PERSON_POSTADRESSE
-        KontaktAdresseResponseDto.Adressetype.VERGE_SAMHANDLER_POSTADRESSE -> KontaktadresseDto.Adressetype.VERGE_SAMHANDLER_POSTADRESSE
+        KontaktAdresseResponseDto.Adressetype.MATRIKKELADRESSE -> KontaktAdresseDto.Adressetype.MATRIKKELADRESSE
+        KontaktAdresseResponseDto.Adressetype.POSTADRESSE_I_FRITT_FORMAT -> KontaktAdresseDto.Adressetype.POSTADRESSE_I_FRITT_FORMAT
+        KontaktAdresseResponseDto.Adressetype.POSTBOKSADRESSE -> KontaktAdresseDto.Adressetype.POSTBOKSADRESSE
+        KontaktAdresseResponseDto.Adressetype.REGOPPSLAG_ADRESSE -> KontaktAdresseDto.Adressetype.REGOPPSLAG_ADRESSE
+        KontaktAdresseResponseDto.Adressetype.UKJENT_BOSTED -> KontaktAdresseDto.Adressetype.UKJENT_BOSTED
+        KontaktAdresseResponseDto.Adressetype.UTENLANDSK_ADRESSE -> KontaktAdresseDto.Adressetype.UTENLANDSK_ADRESSE
+        KontaktAdresseResponseDto.Adressetype.UTENLANDSK_ADRESSE_I_FRITT_FORMAT -> KontaktAdresseDto.Adressetype.UTENLANDSK_ADRESSE_I_FRITT_FORMAT
+        KontaktAdresseResponseDto.Adressetype.VEGADRESSE -> KontaktAdresseDto.Adressetype.VEGADRESSE
+        KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE -> KontaktAdresseDto.Adressetype.VERGE_PERSON_POSTADRESSE
+        KontaktAdresseResponseDto.Adressetype.VERGE_SAMHANDLER_POSTADRESSE -> KontaktAdresseDto.Adressetype.VERGE_SAMHANDLER_POSTADRESSE
     }
 )
 
-data class KontaktadresseDto(
+data class KontaktAdresseDto(
     val adresseString: String,
     val adresselinjer: List<String>,
     val type: Adressetype

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/routes/Sak.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/routes/Sak.kt
@@ -116,7 +116,7 @@ fun Route.sakRoute(
             val adresse = pensjonPersonDataService.hentKontaktadresse(sak.pid)
 
             if (adresse != null) {
-                call.respond(adresse)
+                call.respond(adresseTilDto(adresse))
             } else {
                 call.respond(HttpStatusCode.NotFound)
             }
@@ -138,5 +138,41 @@ fun Route.sakRoute(
         }
 
         sakBrev(brevmalService, p1Service, brevredigeringFacade, dto2ApiService)
+    }
+}
+
+private fun adresseTilDto(adresse: KontaktAdresseResponseDto) = KontaktadresseDto(
+    adresseString = adresse.adresseString,
+    adresselinjer = adresse.adresselinjer,
+    type = when (adresse.type) {
+        KontaktAdresseResponseDto.Adressetype.MATRIKKELADRESSE -> KontaktadresseDto.Adressetype.MATRIKKELADRESSE
+        KontaktAdresseResponseDto.Adressetype.POSTADRESSE_I_FRITT_FORMAT -> KontaktadresseDto.Adressetype.POSTADRESSE_I_FRITT_FORMAT
+        KontaktAdresseResponseDto.Adressetype.POSTBOKSADRESSE -> KontaktadresseDto.Adressetype.POSTBOKSADRESSE
+        KontaktAdresseResponseDto.Adressetype.REGOPPSLAG_ADRESSE -> KontaktadresseDto.Adressetype.REGOPPSLAG_ADRESSE
+        KontaktAdresseResponseDto.Adressetype.UKJENT_BOSTED -> KontaktadresseDto.Adressetype.UKJENT_BOSTED
+        KontaktAdresseResponseDto.Adressetype.UTENLANDSK_ADRESSE -> KontaktadresseDto.Adressetype.UTENLANDSK_ADRESSE
+        KontaktAdresseResponseDto.Adressetype.UTENLANDSK_ADRESSE_I_FRITT_FORMAT -> KontaktadresseDto.Adressetype.UTENLANDSK_ADRESSE_I_FRITT_FORMAT
+        KontaktAdresseResponseDto.Adressetype.VEGADRESSE -> KontaktadresseDto.Adressetype.VEGADRESSE
+        KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE -> KontaktadresseDto.Adressetype.VERGE_PERSON_POSTADRESSE
+        KontaktAdresseResponseDto.Adressetype.VERGE_SAMHANDLER_POSTADRESSE -> KontaktadresseDto.Adressetype.VERGE_SAMHANDLER_POSTADRESSE
+    }
+)
+
+data class KontaktadresseDto(
+    val adresseString: String,
+    val adresselinjer: List<String>,
+    val type: Adressetype
+) {
+    enum class Adressetype {
+        MATRIKKELADRESSE,
+        POSTADRESSE_I_FRITT_FORMAT,
+        POSTBOKSADRESSE,
+        REGOPPSLAG_ADRESSE,
+        UKJENT_BOSTED,
+        UTENLANDSK_ADRESSE,
+        UTENLANDSK_ADRESSE_I_FRITT_FORMAT,
+        VEGADRESSE,
+        VERGE_PERSON_POSTADRESSE,
+        VERGE_SAMHANDLER_POSTADRESSE,
     }
 }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataService.kt
@@ -26,6 +26,7 @@ data class KontaktAdresseResponseDto(
     val adresseString: String,
     val adresselinjer: List<String>,
     val type: Adressetype,
+    val vergePid: Pid? = null,
 ){
     @Suppress("unused")
     enum class Adressetype {

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceTest.kt
@@ -19,6 +19,49 @@ private const val forventaDokumentId = "5678"
 
 class LegacyBrevServiceTest {
 
+    @Test
+    suspend fun `mottaker settes til vergePid ved VERGE_PERSON_POSTADRESSE`() {
+        val vergePid = Pid("12345678901")
+        var faktiskMottaker: String? = null
+
+        val penService = object : PenClientStub() {
+            override suspend fun bestillExstreamBrev(bestillExstreamBrevRequest: Pen.BestillExstreamBrevRequest) = Pen.BestillExstreamBrevResponse(forventaJournalpostId).also { faktiskMottaker = bestillExstreamBrevRequest.sakskontekst?.mottaker }
+            override suspend fun redigerExstreamBrev(journalpostId: JournalpostId) = Pen.RedigerDokumentResponse(EXPECTED_EXSTREAM_URL)
+        }
+
+        val pensjonPersonDataService = object : PensjonPersonDataServiceStub() {
+            override suspend fun hentKontaktadresse(pid: Pid) = KontaktAdresseResponseDto(
+                adresseString = "vergeadresse",
+                adresselinjer = listOf("linje1"),
+                type = KontaktAdresseResponseDto.Adressetype.VERGE_PERSON_POSTADRESSE,
+                vergePid = vergePid
+            )
+        }
+
+        val legacyBrevService = LegacyBrevServiceImpl(
+            brevmetadataService = brevmetadataService,
+            safService = safService,
+            penClient = penService,
+            navansattService = navansattService,
+            pensjonPersonDataService = pensjonPersonDataService
+        )
+
+        withPrincipal(principal) {
+            legacyBrevService.bestillOgRedigerExstreamBrev(
+                gjelderPid = Pid("9999"),
+                request = Api.BestillExstreamBrevRequest(
+                    brevkode = "exstream",
+                    spraak = SpraakKode.NB,
+                    vedtaksId = null,
+                    idTSSEkstern = null,
+                    brevtittel = null,
+                    enhetsId = principalSinNAVEnhet.id
+                ),
+                saksId = SaksId(3333L)
+            )
+        }
+        assertThat(faktiskMottaker).isEqualTo(vergePid.value)
+    }
     private val principalIdent = NavIdent("kulIdent1234")
     private val principal = MockPrincipal(principalIdent, "Kul saksbehandler")
     private val principalSinNAVEnhet = NAVAnsattEnhet(EnhetId("1111"), "Nav Ozzzlo")

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceTest.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.brev.skribenten.fagsystem.pesys
 
 import kotlinx.coroutines.runBlocking
+import no.nav.pensjon.brev.skribenten.Features
 import no.nav.pensjon.brev.skribenten.MockPrincipal
 import no.nav.pensjon.brev.skribenten.auth.withPrincipal
 import no.nav.pensjon.brev.skribenten.fagsystem.pesys.BrevdataDto.*
@@ -24,6 +25,7 @@ class LegacyBrevServiceTest {
         val vergePid = Pid("12345678901")
         var faktiskMottaker: String? = null
 
+        Features.override(Features.vergeForExstream, true)
         val penService = object : PenClientStub() {
             override suspend fun bestillExstreamBrev(bestillExstreamBrevRequest: Pen.BestillExstreamBrevRequest) = Pen.BestillExstreamBrevResponse(forventaJournalpostId).also { faktiskMottaker = bestillExstreamBrevRequest.sakskontekst?.mottaker }
             override suspend fun redigerExstreamBrev(journalpostId: JournalpostId) = Pen.RedigerDokumentResponse(EXPECTED_EXSTREAM_URL)

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/LegacyBrevServiceTest.kt
@@ -87,6 +87,7 @@ class LegacyBrevServiceTest {
         safService = safService,
         penClient = penService,
         navansattService = navansattService,
+        pensjonPersonDataService = PensjonPersonDataServiceStub()
     )
 
     @Test


### PR DESCRIPTION
Det er nokre avvegingar å ta her, som at vi no hentar inn kontaktadresse kun for å sjekke om brukar har verge, men 1) det er dette endepunktet vi allereie brukar frå pensjon-person, 2) framover skal vi nok bruke denne adressa uansett.