### PR TITLE
UFO-479

### DIFF
--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Innvilgelse.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Innvilgelse.kt
@@ -1,7 +1,9 @@
 package no.nav.pensjon.brev.maler.fraser.ufoer
 
 import no.nav.pensjon.brev.api.model.maler.legacy.pegruppe10.PEgruppe10
+import no.nav.pensjon.brev.api.model.maler.legacy.pegruppe10.PEgruppe10Selectors.personsak
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.BarnetilleggUTDto
+import no.nav.pensjon.brev.api.model.maler.legacy.personsak.PersonSakSelectors.foedselsdato
 import no.nav.pensjon.brev.maler.fraser.common.Constants.NAV_URL
 import no.nav.pensjon.brev.maler.fraser.common.Constants.UFOERE_SOK_URL
 import no.nav.pensjon.brev.maler.fraser.common.Felles
@@ -1563,6 +1565,14 @@ object Innvilgelse {
         val uforetidspunkt: Expression<LocalDate>,
     ) : OutlinePhrase<LangBokmalNynorsk>() {
         override fun OutlineOnlyScope<LangBokmalNynorsk, Unit>.template() {
+            val foedselsdato = pe.personsak.foedselsdato
+            val erMndEtterFoedsel =
+                (uforetidspunkt.month equalTo (foedselsdato.month + 1) and (uforetidspunkt.year equalTo foedselsdato.year))
+                    .or(
+                        (foedselsdato.month equalTo 12) and (uforetidspunkt.month equalTo 1) and (uforetidspunkt.year equalTo (foedselsdato.year + 1))
+                    )
+            val visUforetidspunkt = ifElse(erMndEtterFoedsel, foedselsdato.formatMonthYear(), uforetidspunkt.formatMonthYear())
+
             title1 {
                 text(
                     bokmal { +"Dette er uføretidspunktet ditt" },
@@ -1573,22 +1583,22 @@ object Innvilgelse {
             showIf(pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunktbegrunnelse().equalTo("stdbegr_12_7_1_1")) {
                 paragraph {
                     text(
-                        bokmal { +"Du ble ufør i " + uforetidspunkt.formatMonthYear() + ". Da ble inntektsevnen din varig nedsatt med minst halvparten." },
-                        nynorsk { +"Du blei ufør i " + uforetidspunkt.formatMonthYear() + ". Då blei inntektsevna di varig sett ned med minst halvparten." },
+                        bokmal { +"Du ble ufør i " + visUforetidspunkt + ". Da ble inntektsevnen din varig nedsatt med minst halvparten." },
+                        nynorsk { +"Du blei ufør i " + visUforetidspunkt + ". Då blei inntektsevna di varig sett ned med minst halvparten." },
                     )
                 }
             }.orShowIf(pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunktbegrunnelse().equalTo("stdbegr_12_7_1_2")) {
                 paragraph {
                     text(
-                        bokmal { +"Du ble ufør i " + uforetidspunkt.formatMonthYear() + ". Da ble inntektsevnen din varig nedsatt med minst 40 prosent." },
-                        nynorsk { +"Du blei ufør i " + uforetidspunkt.formatMonthYear() + ". Då blei inntektsevna di varig sett ned med minst 40 prosent." },
+                        bokmal { +"Du ble ufør i " + visUforetidspunkt + ". Da ble inntektsevnen din varig nedsatt med minst 40 prosent." },
+                        nynorsk { +"Du blei ufør i " + visUforetidspunkt + ". Då blei inntektsevna di varig sett ned med minst 40 prosent." },
                     )
                 }
             }.orShowIf(pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunktbegrunnelse().equalTo("stdbegr_12_7_1_3")) {
                 paragraph {
                     text(
-                        bokmal { +"Du ble ufør i " + uforetidspunkt.formatMonthYear() + ". Da ble inntektsevnen din varig nedsatt med minst 30 prosent." },
-                        nynorsk { +"Du blei ufør i " + uforetidspunkt.formatMonthYear() + ". Då blei inntektsevna di varig sett ned med minst 30 prosent." },
+                        bokmal { +"Du ble ufør i " + visUforetidspunkt + ". Da ble inntektsevnen din varig nedsatt med minst 30 prosent." },
+                        nynorsk { +"Du blei ufør i " + visUforetidspunkt + ". Då blei inntektsevna di varig sett ned med minst 30 prosent." },
                     )
                 }
             }

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/fraser/vedlegg/opplysningerbruktiberegningufoere/TBU010V.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/fraser/vedlegg/opplysningerbruktiberegningufoere/TBU010V.kt
@@ -1,6 +1,8 @@
 package no.nav.pensjon.brev.maler.legacy.fraser.vedlegg.opplysningerbruktiberegningufoere
 
 import no.nav.pensjon.brev.api.model.maler.legacy.pegruppe10.PEgruppe10
+import no.nav.pensjon.brev.api.model.maler.legacy.pegruppe10.PEgruppe10Selectors.personsak
+import no.nav.pensjon.brev.api.model.maler.legacy.personsak.PersonSakSelectors.foedselsdato
 import no.nav.pensjon.brev.maler.fraser.common.BroekText
 import no.nav.pensjon.brev.maler.fraser.common.Ja
 import no.nav.pensjon.brev.maler.legacy.*
@@ -32,6 +34,14 @@ data class TBU010V(val pe: Expression<PEgruppe10>) : OutlinePhrase<LangBokmalNyn
                 ifNotNull(pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_uforetidspunkt()){ uforetidspunkt ->
                     //[TBU010V]
 
+                    val foedselsdato = pe.personsak.foedselsdato
+                    val erMndEtterFoedsel =
+                        (uforetidspunkt.month equalTo (foedselsdato.month + 1) and (uforetidspunkt.year equalTo foedselsdato.year))
+                            .or(
+                                (foedselsdato.month equalTo 12) and (uforetidspunkt.month equalTo 1) and (uforetidspunkt.year equalTo (foedselsdato.year + 1))
+                            )
+                    val visUforetidspunkt = ifElse(erMndEtterFoedsel, foedselsdato.formatMonthYear(), uforetidspunkt.formatMonthYear())
+
                     row {
                         cell {
                             text(
@@ -41,8 +51,8 @@ data class TBU010V(val pe: Expression<PEgruppe10>) : OutlinePhrase<LangBokmalNyn
                         }
                         cell {
                             text(
-                                bokmal { + uforetidspunkt.format() },
-                                nynorsk { + uforetidspunkt.format() },
+                                bokmal { + visUforetidspunkt },
+                                nynorsk { + visUforetidspunkt },
                             )
                         }
 


### PR DESCRIPTION
Juster uføretidspunkt til fødselsmåned i vedtak og vedlegg

Når uføretidspunkt er satt til måneden etter fødsel (pga. PESYS-begrensning), vises nå fødselsmåneden i stedet i vedtakstekst og vedlegg-tabell. Gjelder også ved årsskifte (des→jan).

Endret filer:
- TBU010V.kt: Legacy vedlegg-tabell viser fødselsmåned ved match
- Innvilgelse.kt: Vedtakstekst (Uforetidspunkt-frase) viser fødselsmåned ved match