### PR TITLE
UFO-482

### DIFF
--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Innvilgelse.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Innvilgelse.kt
@@ -618,6 +618,12 @@ object Innvilgelse {
                             nynorsk { +"Du har fått innvilga uføretrygd frå " + virkningsdato.format() + ". Dette kallar vi verknadstidspunktet. Fram til dette kjem du til å få arbeidsavklaringspengar." },
                         )
                     }
+                    paragraph {
+                        text(
+                            bokmal { +"Du må huske å sende meldekort ut inneværende måned." },
+                            nynorsk { +"Du må hugse å sende meldekort ut inneverande månad." },
+                        )
+                    }
                 }
             }
 


### PR DESCRIPTION
Legger til setningen 'Du må huske å sende meldekort ut inneværende måned' i Virkningstidspunkt-frasen når virkningbegrunnelse er stdbegr_22_12_1_1 (uføretrygd settes i gang måneden etter at AAP opphører).

Gjelder automatisk for alle Innvilgelse UT-varianter (nasjonal, utland, mellombehandling, Norge etter utland) da de deler samme frase.