### PR TITLE
UFO-489

### DIFF
--- a/pensjon/api-model/gradle.properties
+++ b/pensjon/api-model/gradle.properties
@@ -1,1 +1,1 @@
-version=374
+version=375

--- a/pensjon/api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/legacy/redigerbar/InnvilgelseUfoeretrygd.kt
+++ b/pensjon/api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/legacy/redigerbar/InnvilgelseUfoeretrygd.kt
@@ -19,7 +19,7 @@ data class InnvilgelseUfoeretrygdDto(
         @DisplayText("Info om rett til barnetillegg")
         val barnetilleggInfo: Boolean,
         @DisplayText("Innvilget etter 12-2 3.ledd")
-        val innvilget_etter_12_2_tredjeledd: Boolean,
+        val innvilgetEtter12_2Tredjeledd: Boolean = false,
     ) : SaksbehandlerValgBrevdata
 
     data class PesysData(

--- a/pensjon/api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/legacy/redigerbar/InnvilgelseUfoeretrygd.kt
+++ b/pensjon/api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/legacy/redigerbar/InnvilgelseUfoeretrygd.kt
@@ -18,6 +18,8 @@ data class InnvilgelseUfoeretrygdDto(
     data class Saksbehandlervalg(
         @DisplayText("Info om rett til barnetillegg")
         val barnetilleggInfo: Boolean,
+        @DisplayText("Innvilget etter 12-2 3.ledd")
+        val innvilget_etter_12_2_tredjeledd: Boolean,
     ) : SaksbehandlerValgBrevdata
 
     data class PesysData(

--- a/pensjon/api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/legacy/redigerbar/InnvilgelseUfoeretrygdUtland.kt
+++ b/pensjon/api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/legacy/redigerbar/InnvilgelseUfoeretrygdUtland.kt
@@ -20,7 +20,9 @@ data class InnvilgelseUfoeretrygdUtlandDto(
         val barnetilleggInfo: Boolean,
         @DisplayText("Refusjon")
         val refusjon: Boolean,
-    ) : SaksbehandlerValgBrevdata
+        @DisplayText("Innvilget etter 12-2 3.ledd")
+        val innvilget_etter_12_2_tredjeledd: Boolean,
+        ) : SaksbehandlerValgBrevdata
 
     data class PesysData(
         val pe: PEgruppe10,

--- a/pensjon/api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/legacy/redigerbar/InnvilgelseUfoeretrygdUtland.kt
+++ b/pensjon/api-model/src/main/kotlin/no/nav/pensjon/brev/api/model/maler/legacy/redigerbar/InnvilgelseUfoeretrygdUtland.kt
@@ -21,7 +21,7 @@ data class InnvilgelseUfoeretrygdUtlandDto(
         @DisplayText("Refusjon")
         val refusjon: Boolean,
         @DisplayText("Innvilget etter 12-2 3.ledd")
-        val innvilget_etter_12_2_tredjeledd: Boolean,
+        val innvilgetEtter12_2Tredjeledd: Boolean = false,
         ) : SaksbehandlerValgBrevdata
 
     data class PesysData(

--- a/pensjon/maler/build.gradle.kts
+++ b/pensjon/maler/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-val apiModelVersion = 374
+val apiModelVersion = 375
 
 val apiModelJavaTarget: String by System.getProperties()
 

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Innvilgelse.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/ufoer/Innvilgelse.kt
@@ -410,6 +410,7 @@ object Innvilgelse {
         val pe: Expression<PEgruppe10>,
         val yrkesskadeResultat: Expression<String>,
         val ungUforResultat: Expression<String>,
+        val innvilgetEtter12_2_tredjeledd: Expression<Boolean>,
     ) : OutlinePhrase<LangBokmalNynorsk>() {
         override fun OutlineOnlyScope<LangBokmalNynorsk, Unit>.template() {
             showIf(((pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_vilkar_forutgaendemedlemskap_unntakfraforutgaendemedlemskap()))) {
@@ -460,9 +461,15 @@ object Innvilgelse {
             showIf(pe.vedtaksbrev_vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_vilkar_forutgaendemedlemskap_inngangunntak().equalTo("halv_minpen_ufp_ut")) {
                 paragraph {
                     text(
-                        bokmal { +"Du var medlem i folketrygden på uføretidspunktet og har tjent opp rett til minst halvparten av full minsteytelse for uføretrygd. Du oppfyller derfor vilkåret om medlemskap i folketrygden." },
-                        nynorsk { +"Du var medlem i folketrygda på uføretidspunktet og har tent opp rett til minst halvparten av full minsteyting for uføretrygd. Du oppfyller derfor vilkåret om medlemskap i folketrygda." },
+                        bokmal { +"Du var medlem i folketrygden på uføretidspunktet og har tjent opp rett til minst halvparten av full minsteytelse for uføretrygd. Du oppfyller derfor vilkåret om medlemskap i folketrygden. " },
+                        nynorsk { +"Du var medlem i folketrygda på uføretidspunktet og har tent opp rett til minst halvparten av full minsteyting for uføretrygd. Du oppfyller derfor vilkåret om medlemskap i folketrygda. " },
                     )
+                    showIf(innvilgetEtter12_2_tredjeledd) {
+                        text(
+                            bokmal { +"Uføretrygden din er innvilget etter unntaksregelen i § 12-2 tredje ledd. Denne regelen sier at du ikke får beregnet fremtidig trygdetid, jf. folketrygdloven § 12-2 fjerde ledd. " },
+                            nynorsk { +"Uføretrygda di er innvilga etter unntaksregelen i § 12-2 tredje ledd. Denne regelen seier at du ikkje får berekna framtidig trygdetid, jf. folketrygdlova § 12-2 fjerde ledd. " },
+                        )
+                    }
                 }
             }
         }

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/fraser/vedlegg/opplysningerbruktiberegningufoere/TBU039V_TBU044V_1.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/fraser/vedlegg/opplysningerbruktiberegningufoere/TBU039V_TBU044V_1.kt
@@ -22,31 +22,20 @@ data class TBU039V_TBU044V_1(
 
         paragraph {
             text(
-                bokmal { + "Vi fastsetter trygdetiden din ut fra faktisk trygdetid" },
-                nynorsk { + "Vi fastset trygdetida di ut frå faktisk trygdetid" },
+                bokmal { + "I utgangspunktet fasetter vi trygdetiden din ut fra faktisk og fremtidig trygdetid. Er ytelsen innvilget etter unntaksregelen § 12-2 tredje ledd, så får du ikke fremtidig trygdetid, jf. folketrygdloven § 12-2 fjerde ledd. " },
+                nynorsk { + "I utgangspunktet fasetter vi trygdetida di ut fra faktisk og framtidig trygdetid. Er ytelsen innvilga etter unntaksregelen § 12-2 tredje ledd, så får du ikkje framtidig trygdetid, jf. folketrygdlova § 12-2 fjerde ledd. " },
             )
 
-            //IF(FF_GetArrayElement_Integer(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_BeregningsVilkar_Trygdetid_FramtidigTTNorsk) <> 0 OR FF_GetArrayElement_Integer(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_BeregningsVilkar_Trygdetid_FramtidigTTEOS) <> 0) THEN      INCLUDE ENDIF
-            showIf((pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_trygdetid_framtidigttnorsk().notEqualTo(0) or pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_trygdetid_framtidigtteos().notEqualTo(0))) {
-                text(
-                    bokmal { + " og framtidig trygdetid" },
-                    nynorsk { + " og framtidig trygdetid" },
-                )
-            }
             text(
-                bokmal { + ". Den faktiske trygdetiden din er perioder du har vært medlem av folketrygden fra fylte 16 år og fram til uføretidspunktet. " },
-                nynorsk { + ". Den faktiske trygdetida di er periodar du har vore medlem av folketrygda frå fylte 16 år og fram til uføretidspunktet. " },
+                bokmal { + "Den faktiske trygdetiden din er perioder du har vært medlem av folketrygden fra fylte 16 år og fram til uføretidspunktet. " },
+                nynorsk { + "Den faktiske trygdetida di er periodar du har vore medlem av folketrygda frå fylte 16 år og fram til uføretidspunktet. " },
             )
 
-            //IF(FF_GetArrayElement_Integer(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_BeregningsVilkar_Trygdetid_FramtidigTTNorsk) <> 0 OR FF_GetArrayElement_Integer(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_BeregningsVilkar_Trygdetid_FramtidigTTEOS) <> 0) THEN      INCLUDE ENDIF
-            showIf((pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_trygdetid_framtidigttnorsk().notEqualTo(0) or pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_trygdetid_framtidigtteos().notEqualTo(0))) {
-                text(
-                    bokmal { + "Den framtidige trygdetiden er perioden fra uføretidspunktet ditt og fram til og med det året du fyller 66 år." },
-                    nynorsk { + "Den framtidige trygdetida er perioden frå uføretidspunktet ditt og fram til og med det året du fyller 66 år." },
-                )
-            }
+            text(
+                bokmal { + "Den framtidige trygdetiden er perioden fra uføretidspunktet ditt og fram til og med det året du fyller 66 år." },
+                nynorsk { + "Den framtidige trygdetida er perioden frå uføretidspunktet ditt og fram til og med det året du fyller 66 år." },
+            )
         }
-        //[TBU039V-TBU044V_1]
 
         paragraph {
             text(
@@ -70,8 +59,6 @@ data class TBU039V_TBU044V_1(
 
         //IF(FF_GetArrayElement_Boolean(PE_Grunnlag_Persongrunnlagsliste_BrukerFlyktning) = true) THEN      INCLUDE ENDIF
         showIf(pe.grunnlag_persongrunnlagsliste_brukerflyktning()) {
-            //[TBU039V-TBU044V_1]
-
             paragraph {
                 text(
                     bokmal { + "Trygdetiden din er fastsatt til 40 år, fordi du er innvilget flyktningstatus fra Utlendingsdirektoratet. Du beholder uføretrygden beregnet med 40 års trygdetid så lenge du er bosatt i Norge." },
@@ -82,8 +69,6 @@ data class TBU039V_TBU044V_1(
 
         //IF(((FF_GetArrayElement_Integer(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_BeregningsVilkar_Trygdetid_FaTTNorge)+ FF_GetArrayElement_Integer(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_BeregningsVilkar_Trygdetid_FramtidigTTNorsk))/12) < 40 AND FF_GetArrayElement_Boolean(PE_Grunnlag_Persongrunnlagsliste_BrukerFlyktning) = false  AND FF_GetArrayElement_String(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_Vilkar_YrkesskadeResultat) = "oppfylt" AND PE_Vedtaksdata_BeregningsData_BeregningUfore_Uforetrygdberegning_Uforegrad <> PE_Vedtaksdata_BeregningsData_BeregningUfore_Uforetrygdberegning_Yrkesskadegrad  ) THEN      INCLUDE ENDIF
         // manuellt konvertert logikk
-
-        //[TBU039V-TBU044V_1]
         showIf(
             pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_anvendttrygdetid().lessThan(40)
                     and not(pe.grunnlag_persongrunnlagsliste_brukerflyktning())
@@ -117,8 +102,6 @@ data class TBU039V_TBU044V_1(
         // manuellt konvertert logikk
         //IF(FF_GetArrayElement_Boolean(PE_Grunnlag_Persongrunnlagsliste_BrukerFlyktning) <> true AND FF_GetArrayElement_String(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_Vilkar_YrkesskadeResultat) = "oppfylt" AND PE_Vedtaksdata_BeregningsData_BeregningUfore_Uforetrygdberegning_Uforegrad = PE_Vedtaksdata_BeregningsData_BeregningUfore_Uforetrygdberegning_Yrkesskadegrad) THEN      INCLUDE ENDIF
         showIf((pe.grunnlag_persongrunnlagsliste_brukerflyktning().notEqualTo(true) and pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_vilkar_yrkesskaderesultat().equalTo("oppfylt") and pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_uforegrad().equalTo(pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_yrkesskadegrad()))) {
-            //[TBU039V-TBU044V_1]
-
             paragraph {
                 text(
                     bokmal { + "Trygdetiden din er fastsatt til 40 år, fordi du er innvilget uføretrygd etter særbestemmelser for yrkesskade eller yrkessykdom." },
@@ -129,7 +112,6 @@ data class TBU039V_TBU044V_1(
 
         // manuellt konvertert logikk
         //IF(  (FF_GetArrayElement_Integer(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_BeregningsVilkar_Trygdetid_FaTTNorge) +  FF_GetArrayElement_Integer(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_BeregningsVilkar_Trygdetid_FramtidigTTNorsk)) / 12 < 40 AND FF_GetArrayElement_Boolean(PE_Grunnlag_Persongrunnlagsliste_BrukerFlyktning) <> true AND FF_GetArrayElement_String(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_Vilkar_YrkesskadeResultat) = ""   ) THEN      INCLUDE ENDIF
-        //[TBU039V-TBU044V_1]
 
         showIf(
             pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_anvendttrygdetid().lessThan(40)

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/fraser/vedlegg/opplysningerbruktiberegningufoere/TBU039V_TBU044V_1.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/fraser/vedlegg/opplysningerbruktiberegningufoere/TBU039V_TBU044V_1.kt
@@ -22,8 +22,8 @@ data class TBU039V_TBU044V_1(
 
         paragraph {
             text(
-                bokmal { + "I utgangspunktet fasetter vi trygdetiden din ut fra faktisk og fremtidig trygdetid. Er ytelsen innvilget etter unntaksregelen § 12-2 tredje ledd, så får du ikke fremtidig trygdetid, jf. folketrygdloven § 12-2 fjerde ledd. " },
-                nynorsk { + "I utgangspunktet fasetter vi trygdetida di ut fra faktisk og framtidig trygdetid. Er ytelsen innvilga etter unntaksregelen § 12-2 tredje ledd, så får du ikkje framtidig trygdetid, jf. folketrygdlova § 12-2 fjerde ledd. " },
+                bokmal { + "I utgangspunktet fastsetter vi trygdetiden din ut fra faktisk og fremtidig trygdetid. Er ytelsen innvilget etter unntaksregelen § 12-2 tredje ledd, så får du ikke fremtidig trygdetid, jf. folketrygdloven § 12-2 fjerde ledd. " },
+                nynorsk { + "I utgangspunktet fastsetter vi trygdetida di ut fra faktisk og framtidig trygdetid. Er ytelsen innvilga etter unntaksregelen § 12-2 tredje ledd, så får du ikkje framtidig trygdetid, jf. folketrygdlova § 12-2 fjerde ledd. " },
             )
 
             text(

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygd.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygd.kt
@@ -12,6 +12,7 @@ import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretr
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.PesysDataSelectors.oifuVedVirkningstidspunkt
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.PesysDataSelectors.pe
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.barnetilleggInfo
+import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.innvilget_etter_12_2_tredjeledd
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.pesysData
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.saksbehandlerValg
 import no.nav.pensjon.brev.maler.FeatureToggles
@@ -194,6 +195,7 @@ object InnvilgelseUforetrygd : RedigerbarTemplate<InnvilgelseUfoeretrygdDto> {
                 pe = pe,
                 yrkesskadeResultat = yrkesskadeResultat,
                 ungUforResultat = ungUforResultat,
+                innvilgetEtter12_2_tredjeledd = saksbehandlerValg.innvilget_etter_12_2_tredjeledd,
             ))
 
             includePhrase(Innvilgelse.YrkesskadeEllerYrkessykdom(

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygd.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygd.kt
@@ -12,7 +12,7 @@ import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretr
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.PesysDataSelectors.oifuVedVirkningstidspunkt
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.PesysDataSelectors.pe
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.barnetilleggInfo
-import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.innvilget_etter_12_2_tredjeledd
+import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.innvilgetEtter12_2Tredjeledd
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.pesysData
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.saksbehandlerValg
 import no.nav.pensjon.brev.maler.FeatureToggles
@@ -195,7 +195,7 @@ object InnvilgelseUforetrygd : RedigerbarTemplate<InnvilgelseUfoeretrygdDto> {
                 pe = pe,
                 yrkesskadeResultat = yrkesskadeResultat,
                 ungUforResultat = ungUforResultat,
-                innvilgetEtter12_2_tredjeledd = saksbehandlerValg.innvilget_etter_12_2_tredjeledd,
+                innvilgetEtter12_2_tredjeledd = saksbehandlerValg.innvilgetEtter12_2Tredjeledd,
             ))
 
             includePhrase(Innvilgelse.YrkesskadeEllerYrkessykdom(

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdMellombehandling.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdMellombehandling.kt
@@ -13,6 +13,7 @@ import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretr
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.PesysDataSelectors.pe
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.PesysDataSelectors.sisteTrygdetidsgrunnlag
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.barnetilleggInfo
+import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.innvilget_etter_12_2_tredjeledd
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.TrygdetidsgrunnlagSelectors.fom
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.TrygdetidsgrunnlagSelectors.tom
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.pesysData
@@ -237,6 +238,7 @@ object InnvilgelseUforetrygdMellombehandling : RedigerbarTemplate<InnvilgelseUfo
                 pe = pe,
                 yrkesskadeResultat = yrkesskadeResultat,
                 ungUforResultat = ungUforResultat,
+                innvilgetEtter12_2_tredjeledd = saksbehandlerValg.innvilget_etter_12_2_tredjeledd,
             ))
 
             includePhrase(Innvilgelse.YrkesskadeEllerYrkessykdom(

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdMellombehandling.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdMellombehandling.kt
@@ -13,7 +13,7 @@ import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretr
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.PesysDataSelectors.pe
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.PesysDataSelectors.sisteTrygdetidsgrunnlag
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.barnetilleggInfo
-import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.innvilget_etter_12_2_tredjeledd
+import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.SaksbehandlervalgSelectors.innvilgetEtter12_2Tredjeledd
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.TrygdetidsgrunnlagSelectors.fom
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.TrygdetidsgrunnlagSelectors.tom
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdDtoSelectors.pesysData
@@ -238,7 +238,7 @@ object InnvilgelseUforetrygdMellombehandling : RedigerbarTemplate<InnvilgelseUfo
                 pe = pe,
                 yrkesskadeResultat = yrkesskadeResultat,
                 ungUforResultat = ungUforResultat,
-                innvilgetEtter12_2_tredjeledd = saksbehandlerValg.innvilget_etter_12_2_tredjeledd,
+                innvilgetEtter12_2_tredjeledd = saksbehandlerValg.innvilgetEtter12_2Tredjeledd,
             ))
 
             includePhrase(Innvilgelse.YrkesskadeEllerYrkessykdom(

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdUtland.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdUtland.kt
@@ -12,7 +12,7 @@ import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretr
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.PesysDataSelectors.oifuVedVirkningstidspunkt
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.PesysDataSelectors.pe
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.SaksbehandlervalgSelectors.barnetilleggInfo
-import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.SaksbehandlervalgSelectors.innvilget_etter_12_2_tredjeledd
+import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.SaksbehandlervalgSelectors.innvilgetEtter12_2Tredjeledd
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.SaksbehandlervalgSelectors.refusjon
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.pesysData
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.saksbehandlerValg
@@ -186,7 +186,7 @@ object InnvilgelseUforetrygdUtland : RedigerbarTemplate<InnvilgelseUfoeretrygdUt
                     pe = pe,
                     yrkesskadeResultat = yrkesskadeResultat,
                     ungUforResultat = ungUforResultat,
-                    innvilgetEtter12_2_tredjeledd = saksbehandlerValg.innvilget_etter_12_2_tredjeledd
+                    innvilgetEtter12_2_tredjeledd = saksbehandlerValg.innvilgetEtter12_2Tredjeledd
                 )
             )
 

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdUtland.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdUtland.kt
@@ -12,6 +12,7 @@ import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretr
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.PesysDataSelectors.oifuVedVirkningstidspunkt
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.PesysDataSelectors.pe
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.SaksbehandlervalgSelectors.barnetilleggInfo
+import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.SaksbehandlervalgSelectors.innvilget_etter_12_2_tredjeledd
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.SaksbehandlervalgSelectors.refusjon
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.pesysData
 import no.nav.pensjon.brev.api.model.maler.legacy.redigerbar.InnvilgelseUfoeretrygdUtlandDtoSelectors.saksbehandlerValg
@@ -21,6 +22,7 @@ import no.nav.pensjon.brev.maler.fraser.common.Constants.NAV_URL
 import no.nav.pensjon.brev.maler.fraser.common.Constants.UFOERETRYGD_URL
 import no.nav.pensjon.brev.maler.fraser.common.Felles
 import no.nav.pensjon.brev.maler.fraser.ufoer.Innvilgelse
+import no.nav.pensjon.brev.maler.fraser.ufoer.Innvilgelse.UnntaksregelMedlemskap
 import no.nav.pensjon.brev.maler.fraser.ufoer.Ufoeretrygd
 import no.nav.pensjon.brev.maler.legacy.*
 import no.nav.pensjon.brev.maler.legacy.vedlegg.vedleggOpplysningerBruktIBeregningUTLegacy
@@ -179,11 +181,14 @@ object InnvilgelseUforetrygdUtland : RedigerbarTemplate<InnvilgelseUfoeretrygdUt
                 vedleggOpplysningerBruktIBeregningUT = vedleggOpplysningerBruktIBeregningUTLegacy,
             ))
 
-            includePhrase(Innvilgelse.UnntaksregelMedlemskap(
-                pe = pe,
-                yrkesskadeResultat = yrkesskadeResultat,
-                ungUforResultat = ungUforResultat,
-            ))
+            includePhrase(
+                UnntaksregelMedlemskap(
+                    pe = pe,
+                    yrkesskadeResultat = yrkesskadeResultat,
+                    ungUforResultat = ungUforResultat,
+                    innvilgetEtter12_2_tredjeledd = saksbehandlerValg.innvilget_etter_12_2_tredjeledd
+                )
+            )
 
             showIf(oppfyltvedsammenlegging){
                 title1 {

--- a/pensjon/maler/src/test/kotlin/no/nav/pensjon/brev/fixtures/redigerbar/InnvilgelseUfoeretrygdTestdata.kt
+++ b/pensjon/maler/src/test/kotlin/no/nav/pensjon/brev/fixtures/redigerbar/InnvilgelseUfoeretrygdTestdata.kt
@@ -14,7 +14,7 @@ import java.time.Month
 
 fun createInnvilgelseUfoeretrygdDto() =
     InnvilgelseUfoeretrygdDto(
-        saksbehandlerValg = InnvilgelseUfoeretrygdDto.Saksbehandlervalg(barnetilleggInfo = true),
+        saksbehandlerValg = InnvilgelseUfoeretrygdDto.Saksbehandlervalg(barnetilleggInfo = true, innvilget_etter_12_2_tredjeledd = true),
         pesysData = InnvilgelseUfoeretrygdDto.PesysData(
             pe = createPEgruppe10(),
             oifuVedVirkningstidspunkt = Kroner(10000),
@@ -62,7 +62,7 @@ fun createInnvilgelseUfoeretrygdDto() =
 
 fun createInnvilgelseUfoeretrygdUtlandDto() =
     InnvilgelseUfoeretrygdUtlandDto(
-        saksbehandlerValg = InnvilgelseUfoeretrygdUtlandDto.Saksbehandlervalg(refusjon = true, barnetilleggInfo = true),
+        saksbehandlerValg = InnvilgelseUfoeretrygdUtlandDto.Saksbehandlervalg(refusjon = true, barnetilleggInfo = true, innvilget_etter_12_2_tredjeledd = true),
         pesysData = InnvilgelseUfoeretrygdUtlandDto.PesysData(
             pe = createPEgruppe10(),
             oifuVedVirkningstidspunkt = Kroner(10000),

--- a/pensjon/maler/src/test/kotlin/no/nav/pensjon/brev/fixtures/redigerbar/InnvilgelseUfoeretrygdTestdata.kt
+++ b/pensjon/maler/src/test/kotlin/no/nav/pensjon/brev/fixtures/redigerbar/InnvilgelseUfoeretrygdTestdata.kt
@@ -14,7 +14,7 @@ import java.time.Month
 
 fun createInnvilgelseUfoeretrygdDto() =
     InnvilgelseUfoeretrygdDto(
-        saksbehandlerValg = InnvilgelseUfoeretrygdDto.Saksbehandlervalg(barnetilleggInfo = true, innvilget_etter_12_2_tredjeledd = true),
+        saksbehandlerValg = InnvilgelseUfoeretrygdDto.Saksbehandlervalg(barnetilleggInfo = true, innvilgetEtter12_2Tredjeledd = true),
         pesysData = InnvilgelseUfoeretrygdDto.PesysData(
             pe = createPEgruppe10(),
             oifuVedVirkningstidspunkt = Kroner(10000),
@@ -62,7 +62,7 @@ fun createInnvilgelseUfoeretrygdDto() =
 
 fun createInnvilgelseUfoeretrygdUtlandDto() =
     InnvilgelseUfoeretrygdUtlandDto(
-        saksbehandlerValg = InnvilgelseUfoeretrygdUtlandDto.Saksbehandlervalg(refusjon = true, barnetilleggInfo = true, innvilget_etter_12_2_tredjeledd = true),
+        saksbehandlerValg = InnvilgelseUfoeretrygdUtlandDto.Saksbehandlervalg(refusjon = true, barnetilleggInfo = true, innvilgetEtter12_2Tredjeledd = true),
         pesysData = InnvilgelseUfoeretrygdUtlandDto.PesysData(
             pe = createPEgruppe10(),
             oifuVedVirkningstidspunkt = Kroner(10000),


### PR DESCRIPTION
Lagt til saksbehandlervalg for 12.2 3.ledd, og skrevet om vedlegg så den er uavhengig av om 12.2 3.ledd er benyttet eller ei.

Dette er en midlertidig fiks inntil vi får endret psak og pen-regler slik at bruken av 12-2 3.ledd blir brukt riktig, og at vi dermed kan benytte logikk på dette i brev og vedlegg.