### PR TITLE
refactor: eliminate unsafe casts in Brevkode typing

### DIFF
--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/api/AutobrevTemplateResource.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/api/AutobrevTemplateResource.kt
@@ -5,29 +5,32 @@ import no.nav.brev.brevbaker.PDFByggerService
 import no.nav.pensjon.brev.api.model.BestillBrevRequest
 import no.nav.pensjon.brev.api.model.LetterResponse
 import no.nav.pensjon.brev.api.model.maler.AutobrevData
+import no.nav.pensjon.brev.api.model.maler.AutomatiskBrevkode
 import no.nav.pensjon.brev.api.model.maler.Brevkode
 import no.nav.pensjon.brev.pdfvedlegg.PDFVedleggAppenderImpl
 import no.nav.pensjon.brev.template.BrevTemplate
 import no.nav.pensjon.brevbaker.api.model.LetterMarkup
 
-class AutobrevTemplateResource<Kode : Brevkode<Kode>, out T : BrevTemplate<AutobrevData, Kode>>(
+class AutobrevTemplateResource<out T : BrevTemplate<AutobrevData, Brevkode.Automatisk>>(
     override val name: String,
     templates: Set<T>,
     pdfByggerService: PDFByggerService,
-    ) : TemplateResource<Kode, T, BestillBrevRequest<Kode>>, TemplateLibrary<Kode, T> by TemplateLibraryImpl(templates) {
+    ) : TemplateResource<Brevkode.Automatisk, T, BestillBrevRequest<Brevkode.Automatisk>>, TemplateLibrary<Brevkode.Automatisk, T> by TemplateLibraryImpl(templates) {
     private val brevbaker = Brevbaker(pdfByggerService, PDFVedleggAppenderImpl)
-    private val letterFactory: LetterFactory<Kode> = LetterFactory(emptySet())
+    private val letterFactory: LetterFactory<Brevkode.Automatisk> = LetterFactory(emptySet())
 
-    override suspend fun renderPDF(brevbestilling: BestillBrevRequest<Kode>): LetterResponse =
+    override fun kodeOf(key: String): Brevkode.Automatisk = AutomatiskBrevkode(key)
+
+    override suspend fun renderPDF(brevbestilling: BestillBrevRequest<Brevkode.Automatisk>): LetterResponse =
         brevbaker.renderPDF(createLetter(brevbestilling))
 
-    override fun renderHTML(brevbestilling: BestillBrevRequest<Kode>): LetterResponse =
+    override fun renderHTML(brevbestilling: BestillBrevRequest<Brevkode.Automatisk>): LetterResponse =
         brevbaker.renderHTML(createLetter(brevbestilling))
 
-    override fun renderLetterMarkup(brevbestilling: BestillBrevRequest<Kode>): LetterMarkup =
+    override fun renderLetterMarkup(brevbestilling: BestillBrevRequest<Brevkode.Automatisk>): LetterMarkup =
         brevbaker.renderLetterMarkup(createLetter(brevbestilling))
 
-    private fun createLetter(brevbestilling: BestillBrevRequest<Kode>) =
+    private fun createLetter(brevbestilling: BestillBrevRequest<Brevkode.Automatisk>) =
         letterFactory.createLetter(brevbestilling, getTemplate(brevbestilling.kode))
 
 }

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/api/RedigerbarTemplateResource.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/api/RedigerbarTemplateResource.kt
@@ -7,36 +7,39 @@ import no.nav.pensjon.brev.api.model.BestillRedigertBrevRequest
 import no.nav.pensjon.brev.api.model.LetterResponse
 import no.nav.pensjon.brev.api.model.maler.BrevbakerBrevdata
 import no.nav.pensjon.brev.api.model.maler.Brevkode
+import no.nav.pensjon.brev.api.model.maler.RedigerbarBrevkode
 import no.nav.pensjon.brev.pdfvedlegg.PDFVedleggAppenderImpl
 import no.nav.pensjon.brev.template.BrevTemplate
 import no.nav.pensjon.brev.template.AlltidValgbartVedlegg
 import no.nav.pensjon.brevbaker.api.model.LetterMarkup
 import no.nav.pensjon.brevbaker.api.model.LetterMarkupWithDataUsage
 
-class RedigerbarTemplateResource<Kode : Brevkode<Kode>, out T : BrevTemplate<BrevbakerBrevdata, Kode>>(
+class RedigerbarTemplateResource<out T : BrevTemplate<BrevbakerBrevdata, Brevkode.Redigerbart>>(
     override val name: String,
     templates: Set<T>,
     pdfByggerService: PDFByggerService,
     val alltidValgbareVedlegg: Set<AlltidValgbartVedlegg<*>>,
-) : TemplateResource<Kode, T, BestillRedigertBrevRequest<Kode>>, TemplateLibrary<Kode, T> by TemplateLibraryImpl(templates) {
+) : TemplateResource<Brevkode.Redigerbart, T, BestillRedigertBrevRequest<Brevkode.Redigerbart>>, TemplateLibrary<Brevkode.Redigerbart, T> by TemplateLibraryImpl(templates) {
     private val brevbaker = Brevbaker(pdfByggerService, PDFVedleggAppenderImpl)
-    private val letterFactory: LetterFactory<Kode> = LetterFactory(alltidValgbareVedlegg)
+    private val letterFactory: LetterFactory<Brevkode.Redigerbart> = LetterFactory(alltidValgbareVedlegg)
 
-    override fun renderLetterMarkup(brevbestilling: BestillBrevRequest<Kode>): LetterMarkup =
+    override fun kodeOf(key: String): Brevkode.Redigerbart = RedigerbarBrevkode(key)
+
+    override fun renderLetterMarkup(brevbestilling: BestillBrevRequest<Brevkode.Redigerbart>): LetterMarkup =
         brevbaker.renderLetterMarkup(createLetter(brevbestilling))
 
-    fun renderLetterMarkupWithDataUsage(brevbestilling: BestillBrevRequest<Kode>): LetterMarkupWithDataUsage =
+    fun renderLetterMarkupWithDataUsage(brevbestilling: BestillBrevRequest<Brevkode.Redigerbart>): LetterMarkupWithDataUsage =
         brevbaker.renderLetterMarkupWithDataUsage(createLetter(brevbestilling))
 
-    override suspend fun renderPDF(brevbestilling: BestillRedigertBrevRequest<Kode>): LetterResponse =
+    override suspend fun renderPDF(brevbestilling: BestillRedigertBrevRequest<Brevkode.Redigerbart>): LetterResponse =
         brevbaker.renderRedigertBrevPDF(createLetter(brevbestilling), brevbestilling.letterMarkup)
 
-    override fun renderHTML(brevbestilling: BestillRedigertBrevRequest<Kode>): LetterResponse =
+    override fun renderHTML(brevbestilling: BestillRedigertBrevRequest<Brevkode.Redigerbart>): LetterResponse =
         brevbaker.renderRedigertBrevHTML(createLetter(brevbestilling), brevbestilling.letterMarkup)
 
-    private fun createLetter(brevbestilling: BestillBrevRequest<Kode>) =
+    private fun createLetter(brevbestilling: BestillBrevRequest<Brevkode.Redigerbart>) =
         letterFactory.createLetter(brevbestilling, getTemplate(brevbestilling.kode))
 
-    private fun createLetter(brevbestilling: BestillRedigertBrevRequest<Kode>) =
+    private fun createLetter(brevbestilling: BestillRedigertBrevRequest<Brevkode.Redigerbart>) =
         letterFactory.createLetter(brevbestilling, getTemplate(brevbestilling.kode))
 }

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/api/TemplateResource.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/api/TemplateResource.kt
@@ -15,6 +15,8 @@ interface TemplateResource<Kode : Brevkode<Kode>, out T : BrevTemplate<Brevbaker
 
     val name: String
 
+    fun kodeOf(key: String): Kode
+
     suspend fun renderPDF(brevbestilling: Request): LetterResponse
 
     fun renderHTML(brevbestilling: Request): LetterResponse

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/routing/AutobrevRoutes.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/routing/AutobrevRoutes.kt
@@ -18,7 +18,7 @@ fun <T : Brevkode<T>> RoutingContext.installBrevkodeInCallContext(kode: Brevkode
 fun ApplicationCall.useBrevkodeFromCallContext(): String? = attributes.getOrNull(BREV_KODE)
 
 fun Route.autobrevRoutes(
-    autobrev: AutobrevTemplateResource<Brevkode.Automatisk, AutobrevTemplate<*>>,
+    autobrev: AutobrevTemplateResource<AutobrevTemplate<*>>,
 ) {
     route("/${autobrev.name}") {
         post<BestillBrevRequest<Brevkode.Automatisk>>("/pdf") { brevbestilling ->

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/routing/RedigerbarRoutes.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/routing/RedigerbarRoutes.kt
@@ -11,7 +11,7 @@ import no.nav.pensjon.brev.template.RedigerbarTemplate
 
 
 fun Route.redigerbarRoutes(
-    redigerbareBrev: RedigerbarTemplateResource<Brevkode.Redigerbart, RedigerbarTemplate<*>>,
+    redigerbareBrev: RedigerbarTemplateResource<RedigerbarTemplate<*>>,
 ) {
     route("/${redigerbareBrev.name}") {
         post<BestillBrevRequest<Brevkode.Redigerbart>>("/markup") { brevbestilling ->

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/routing/TemplateRoutes.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/routing/TemplateRoutes.kt
@@ -1,15 +1,12 @@
 package no.nav.pensjon.brev.routing
 
 import io.ktor.http.*
-import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
 import no.nav.pensjon.brev.api.TemplateResource
-import no.nav.pensjon.brev.api.model.maler.AutomatiskBrevkode
 import no.nav.pensjon.brev.api.model.maler.BrevbakerBrevdata
 import no.nav.pensjon.brev.api.model.maler.Brevkode
-import no.nav.pensjon.brev.api.model.maler.RedigerbarBrevkode
 import no.nav.pensjon.brev.api.toLanguage
 import no.nav.pensjon.brev.template.BrevTemplate
 import no.nav.pensjon.brev.template.LetterTemplate
@@ -17,7 +14,7 @@ import no.nav.pensjon.brev.template.TemplateModelSpecificationFactory
 import no.nav.pensjon.brev.template.render.TemplateDocumentationRenderer
 import no.nav.pensjon.brevbaker.api.model.LanguageCode
 
-inline fun <reified Kode : Brevkode<Kode>, T : BrevTemplate<BrevbakerBrevdata, Kode>> Route.templateRoutes(resource: TemplateResource<Kode, T, *>) =
+fun <Kode : Brevkode<Kode>, T : BrevTemplate<BrevbakerBrevdata, Kode>> Route.templateRoutes(resource: TemplateResource<Kode, T, *>) =
     route("/${resource.name}") {
 
         get {
@@ -30,7 +27,7 @@ inline fun <reified Kode : Brevkode<Kode>, T : BrevTemplate<BrevbakerBrevdata, K
 
         route("/{kode}") {
             get {
-                val template = call.kode(resource)
+                val template = resource.kodeOf(call.parameters.getOrFail("kode"))
                     .let { resource.getTemplate(it) }
                     ?.description()
 
@@ -44,7 +41,7 @@ inline fun <reified Kode : Brevkode<Kode>, T : BrevTemplate<BrevbakerBrevdata, K
             get("/doc/{language}") {
                 val language = call.parameters.getOrFail<LanguageCode>("language").toLanguage()
 
-                val template = call.kode(resource)
+                val template = resource.kodeOf(call.parameters.getOrFail("kode"))
                     .let { resource.getTemplate(it)?.template }
                     ?.takeIf { it.language.supports(language) }
 
@@ -56,7 +53,7 @@ inline fun <reified Kode : Brevkode<Kode>, T : BrevTemplate<BrevbakerBrevdata, K
             }
 
             get("/modelSpecification") {
-                val template = call.kode(resource)
+                val template = resource.kodeOf(call.parameters.getOrFail("kode"))
                     .let { resource.getTemplate(it)?.template }
 
                 if (template != null) {
@@ -69,12 +66,3 @@ inline fun <reified Kode : Brevkode<Kode>, T : BrevTemplate<BrevbakerBrevdata, K
     }
 
 fun LetterTemplate<*, *>.modelSpecification() = TemplateModelSpecificationFactory(this.letterDataType).build()
-
-// TODO: Med riktig typing burde heile denne metoden vera unødvendig
-fun <Kode: Brevkode<Kode>> ApplicationCall.kode(resource: TemplateResource<Kode,*,*>): Kode = parameters.getOrFail<String>("kode").let {
-    if (resource.name == "autobrev") {
-        AutomatiskBrevkode(it)
-    } else {
-        RedigerbarBrevkode(it)
-    } as Kode
-}


### PR DESCRIPTION
Add kodeOf(key) to TemplateResource interface, removing the need for the string-based runtime type check and unchecked cast in the old ApplicationCall.kode() extension function.

- TemplateResource now declares kodeOf(key: String): Kode
- AutobrevTemplateResource/RedigerbarTemplateResource implement it with their concrete Brevkode types (removing the redundant Kode type parameter)
- TemplateRoutes uses resource.kodeOf() directly
- Removed inline/reified from templateRoutes (no longer needed)