### PR TITLE
fix: remove stylelint aksel/no-class-override warnings

### DIFF
--- a/skribenten-web/frontend/src/components/endreMottaker/UtfyllingAvManuellAdresseForm.tsx
+++ b/skribenten-web/frontend/src/components/endreMottaker/UtfyllingAvManuellAdresseForm.tsx
@@ -148,15 +148,6 @@ const UtfyllingAvManuellAdresseForm = (properties: {
                     css={css`
                       align-self: flex-start;
                       width: 60%;
-
-                      /*
-                        siden input feltet er nederts på modalen, vil det å åpne den tvinge en scroll på modalen
-                        vi setter den derfor til å åpne oppover
-                      */
-                      .aksel-combobox__list {
-                        bottom: 100%;
-                        top: auto;
-                      }
                     `}
                     data-testid="land-combobox"
                     error={fieldState.error?.message}

--- a/skribenten-web/frontend/src/components/select/SamhandlerSelect.tsx
+++ b/skribenten-web/frontend/src/components/select/SamhandlerSelect.tsx
@@ -1,4 +1,3 @@
-import { css } from "@emotion/react";
 import { UNSAFE_Combobox } from "@navikt/ds-react";
 import { type FieldError } from "react-hook-form";
 
@@ -19,12 +18,6 @@ export const SamhandlerTypeSelect = ({
 
   return (
     <UNSAFE_Combobox
-      //begrenser høyden så en ikke faller utenfor modalen og forårsaker scrolling
-      css={css`
-        .aksel-combobox__list {
-          max-height: 200px;
-        }
-      `}
       description={description}
       error={error?.message}
       label="Samhandlertype"


### PR DESCRIPTION
- Remove .aksel-combobox__list class override from UtfyllingAvManuellAdresseForm
  - Rely on UNSAFE_Combobox's built-in floating positioning with fallbackPlacements=['top']
  - Keep only layout styling (align-self, width) which doesn't affect design system internals

- Remove .aksel-combobox__list override from SamhandlerSelect
  - Remove empty css prop and unused @emotion/react import
  - Let UNSAFE_Combobox handle dropdown sizing with its built-in max-height logic

This resolves both aksel/no-class-override stylelint warnings. The combobox now uses its native floating positioning and auto-flipping behavior without styling internal design system classes.