### PR TITLE
Timeout for integrasjonstestkøyring.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,8 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintCheckTask
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
 
 plugins {
     kotlin("jvm") version libs.versions.kotlinVersion apply false
@@ -76,6 +78,7 @@ subprojects {
             outputs.doNotCacheIf("Output of this task is not cached") { true }
             outputs.upToDateWhen { false }
             group = LifecycleBasePlugin.VERIFICATION_GROUP
+            timeout = 15.minutes.toJavaDuration()
             systemProperties["junit.jupiter.execution.parallel.config.dynamic.factor"] = 0.5
             forkEvery = 0 // for å dele test-container uten å spinne opp ny.
             useJUnitPlatform {


### PR DESCRIPTION
Per no kan integrasjonstestbygget vårt stå og gå tilsynelatande evig. Viss det er noko som heng, så er det betre å stoppe og heller feile bygget.

15 minutt-grensa er litt vilkårleg sett, men det verkar usannsynleg at vi skal komme opp i så lang køyretid utan at noko er feil