### PR TITLE
Bruker standard executor-service-strategi.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ allprojects {
         systemProperties["junit.jupiter.execution.parallel.enabled"] = true
         systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
         systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
+        systemProperties["junit.jupiter.execution.parallel.config.executor-service"] = "FORK_JOIN_POOL"
         systemProperties["junit.jupiter.execution.parallel.config.strategy"] = "dynamic"
         maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
         forkEvery = 100
@@ -80,6 +81,7 @@ subprojects {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             timeout = 15.minutes.toJavaDuration()
             systemProperties["junit.jupiter.execution.parallel.config.dynamic.factor"] = 0.5
+            systemProperties["junit.jupiter.execution.parallel.config.executor-service"] = "FORK_JOIN_POOL"
             forkEvery = 0 // for å dele test-container uten å spinne opp ny.
             useJUnitPlatform {
                 includeTags = setOf("integration-test")


### PR DESCRIPTION
Den nye WORKER_THREAD_POOL er experimental, så vil ikkje bytta dit enno med mindre vi har konkrete grunnar til det, og det trur eg ikkje vi har. Roar derfor ned meldingane ved å seie eksplisitt at vi bruker dagens standard FORK_JOIN_POOL

Ref melding i bygget:     (1) [INFO] Parallel test execution is enabled but the default ForkJoinPool-based executor service will be used. Please give the new implementation based on a regular thread pool a try by setting the 'junit.jupiter.execution.parallel.config.executor-service' configuration parameter to 'WORKER_THREAD_POOL' and report any issues to the JUnit team. Alternatively, set the configuration parameter to 'FORK_JOIN_POOL' to hide this message and keep using the original implementation.ı