### PR TITLE
Loggar Axios-feilmeldingar som info

### DIFF
--- a/skribenten-web/bff/src/internalRoutes.ts
+++ b/skribenten-web/bff/src/internalRoutes.ts
@@ -23,22 +23,6 @@ export const internalRoutes = (server: Express) => {
     });
   });
 
-  function findLogLevel(status: number | undefined): string {
-    switch (status) {
-      case undefined:
-        return "ERROR";
-      case 401:
-      case 403:
-      case 404:
-      case 504:
-        return "WARN";
-      case 422:
-        return "INFO";
-      default:
-        return "ERROR";
-    }
-  }
-
   server.post("/bff/api/logg", bodyParser.json(), cookieParser(), (request, response) => {
     if (request.cookies["use-local-vite-server"] === "true") {
       response.status(200).end();
@@ -49,7 +33,7 @@ export const internalRoutes = (server: Express) => {
 
     console.error(
       JSON.stringify({
-        level: findLogLevel(body.status),
+        level: body.level ?? "ERROR",
         statusCode: body.status,
         timestamp: body.jsonContent.timestamp,
         message: `Feil fra frontend: ${body.message}: ${body.jsonContent.url}`,

--- a/skribenten-web/frontend/src/api/bff-endpoints.ts
+++ b/skribenten-web/frontend/src/api/bff-endpoints.ts
@@ -38,6 +38,7 @@ export type Feilmelding = {
   message: unknown;
   stack: unknown;
   requestId?: string;
+  level: string;
   status: number | undefined;
   jsonContent: unknown;
 };

--- a/skribenten-web/frontend/src/utils/logger.tsx
+++ b/skribenten-web/frontend/src/utils/logger.tsx
@@ -22,7 +22,7 @@ export const logError = async (error: unknown, status: number | undefined) => {
       type: "error",
       message: "Error som ikke var av type error",
       status: status,
-      level: findLogLevel(error, undefined),
+      level: findLogLevel(error, status),
       stack: "",
       jsonContent: JSON.stringify(error),
     };

--- a/skribenten-web/frontend/src/utils/logger.tsx
+++ b/skribenten-web/frontend/src/utils/logger.tsx
@@ -8,6 +8,7 @@ export const logError = async (error: unknown, status: number | undefined) => {
       type: "error",
       message: error.message,
       stack: error.stack,
+      level: findLogLevel(error, status),
       status: status,
       requestId: error instanceof AxiosError ? error.response?.headers["x-request-id"] : undefined,
       jsonContent: {
@@ -21,9 +22,29 @@ export const logError = async (error: unknown, status: number | undefined) => {
       type: "error",
       message: "Error som ikke var av type error",
       status: status,
+      level: findLogLevel(error, undefined),
       stack: "",
       jsonContent: JSON.stringify(error),
     };
     return loggFeil(data);
+  }
+
+  function findLogLevel(error: unknown, status: number | undefined): string {
+    if (error instanceof AxiosError) {
+      return "INFO";
+    }
+    switch (status) {
+      case undefined:
+        return "ERROR";
+      case 401:
+      case 403:
+      case 404:
+      case 504:
+        return "WARN";
+      case 422:
+        return "INFO";
+      default:
+        return "ERROR";
+    }
   }
 };


### PR DESCRIPTION
Erfaringa er at det er feilmeldingar som uansett blir logga i backend viss dei skal loggast

Flyttar med det samme ansvaret for å avgjera log level over til frontend, som er den som har mest informasjon og lettast kan seie det


Testa lokalt, fungerte som forventa.