### PR TITLE
Testar å skru ned shutdown-tida i skribenten igjen

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
@@ -77,8 +77,8 @@ private fun run() {
                 host = "0.0.0.0"
                 port = skribentenConfig.getInt("port")
             })
-            shutdownGracePeriod = 25.seconds.inWholeMilliseconds
-            shutdownTimeout = 29.seconds.inWholeMilliseconds
+            shutdownGracePeriod = 5.seconds.inWholeMilliseconds
+            shutdownTimeout = 10.seconds.inWholeMilliseconds
         },
     ) {
         skribentenApp(skribentenConfig)


### PR DESCRIPTION
Feilen som gjorde at vi auka det er fiksa upstream, så vi treng ikkje omgå det lenger