### PR TITLE
Lukkar alle tilkoplingar når applikasjonen stoppar

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Routing.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Routing.kt
@@ -1,7 +1,6 @@
 package no.nav.pensjon.brev.skribenten
 
 import com.typesafe.config.Config
-import io.ktor.client.HttpClient
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.plugins.swagger.*
@@ -26,29 +25,29 @@ import no.nav.pensjon.brev.skribenten.routes.*
 import no.nav.pensjon.brev.skribenten.routes.samhandler.samhandlerRoute
 import no.nav.pensjon.brev.skribenten.services.*
 
-
 fun Application.configureRouting(
     authConfig: JwtConfig,
     skribentenConfig: Config,
     cache: Cache
 ) {
-    val closeOnShutdown: (HttpClient) -> Unit = { client -> monitor.subscribe(ApplicationStopping) { client.close() } }
-    val authService = AzureADService(authConfig, cache = cache, closeOnShutdown = closeOnShutdown)
+    val services = mutableListOf<SkribentenService>()
+
+    val authService = services.register(AzureADService(authConfig, cache = cache))
     val servicesConfig = skribentenConfig.getConfig("services")
     initDatabase(servicesConfig).also { db -> monitor.subscribe(ApplicationStopping) { db.close() } }
-    val safService = SafServiceHttp(servicesConfig.getConfig("saf"), authService, closeOnShutdown)
-    val penClient = PentHttpClient(servicesConfig.getConfig("pen"), authService, closeOnShutdown)
-    val skjermingService = SkjermingServiceHttp(servicesConfig.getConfig("skjerming"), authService, cache, closeOnShutdown)
-    val pensjonPersonDataService = PensjonPersonDataServiceImpl(servicesConfig.getConfig("pensjon_persondata"), authService, cache, closeOnShutdown)
-    val pensjonRepresentasjonService = PensjonRepresentasjonService(servicesConfig.getConfig("pensjonRepresentasjon"), authService, cache, closeOnShutdown)
-    val pdlService = PdlServiceHttp(servicesConfig.getConfig("pdl"), authService, closeOnShutdown)
-    val krrService = KrrService(servicesConfig.getConfig("krr"), authService, closeOnShutdown = closeOnShutdown)
-    val brevbakerService = BrevbakerServiceHttp(servicesConfig.getConfig("brevbaker"), authService, cache, closeOnShutdown)
-    val brevmetadataService = BrevmetadataServiceHttp(servicesConfig.getConfig("brevmetadata"), closeOnShutdown)
-    val samhandlerService = SamhandlerServiceHttp(servicesConfig.getConfig("samhandlerProxy"), authService, cache, closeOnShutdown)
-    val navansattService = NavansattServiceHttp(servicesConfig.getConfig("navansatt"), authService, cache, closeOnShutdown)
+    val safService = services.register(SafServiceHttp(servicesConfig.getConfig("saf"), authService))
+    val penClient = services.register(PentHttpClient(servicesConfig.getConfig("pen"), authService))
+    val skjermingService = services.register(SkjermingServiceHttp(servicesConfig.getConfig("skjerming"), authService, cache))
+    val pensjonPersonDataService = services.register(PensjonPersonDataServiceImpl(servicesConfig.getConfig("pensjon_persondata"), authService, cache))
+    val pensjonRepresentasjonService = services.register(PensjonRepresentasjonService(servicesConfig.getConfig("pensjonRepresentasjon"), authService, cache))
+    val pdlService = services.register(PdlServiceHttp(servicesConfig.getConfig("pdl"), authService))
+    val krrService = services.register(KrrService(servicesConfig.getConfig("krr"), authService))
+    val brevbakerService = services.register(BrevbakerServiceHttp(servicesConfig.getConfig("brevbaker"), authService, cache))
+    val brevmetadataService = services.register(BrevmetadataServiceHttp(servicesConfig.getConfig("brevmetadata")))
+    val samhandlerService = services.register(SamhandlerServiceHttp(servicesConfig.getConfig("samhandlerProxy"), authService, cache))
+    val navansattService = services.register(NavansattServiceHttp(servicesConfig.getConfig("navansatt"), authService, cache))
     val legacyBrevService = LegacyBrevServiceImpl(brevmetadataService, safService, penClient, navansattService, pensjonPersonDataService)
-    val norg2Service = Norg2ServiceHttp(servicesConfig.getConfig("norg2"), cache, closeOnShutdown)
+    val norg2Service = services.register(Norg2ServiceHttp(servicesConfig.getConfig("norg2"), cache))
     val p1Service = P1ServiceImpl(penClient)
 
     val brevService = BrevService(penClient, legacyBrevService)
@@ -62,6 +61,9 @@ fun Application.configureRouting(
     val externalAPIService = ExternalAPIService(servicesConfig.getConfig("externalApi"), brevredigeringFacade, brevmalService, brevredigeringFacade)
 
     Features.initUnleash(servicesConfig.getConfig("unleash"))
+    monitor.subscribe(ApplicationStopping) {
+        services.forEach { it.close() }
+    }
 
     routing {
         healthRoute()
@@ -110,4 +112,9 @@ fun Application.configureRouting(
 
         externalAPI(authConfig, externalAPIService, pdlService, fagsakService)
     }
+}
+
+private fun <T : SkribentenService> MutableList<SkribentenService>.register(service: T): T {
+    this += service
+    return service
 }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Routing.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Routing.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.brev.skribenten
 
 import com.typesafe.config.Config
+import io.ktor.client.HttpClient
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.plugins.swagger.*
@@ -25,27 +26,29 @@ import no.nav.pensjon.brev.skribenten.routes.*
 import no.nav.pensjon.brev.skribenten.routes.samhandler.samhandlerRoute
 import no.nav.pensjon.brev.skribenten.services.*
 
+
 fun Application.configureRouting(
     authConfig: JwtConfig,
     skribentenConfig: Config,
     cache: Cache
 ) {
-    val authService = AzureADService(authConfig, cache = cache)
+    val closeOnShutdown: (HttpClient) -> Unit = { client -> monitor.subscribe(ApplicationStopping) { client.close() } }
+    val authService = AzureADService(authConfig, cache = cache, closeOnShutdown = closeOnShutdown)
     val servicesConfig = skribentenConfig.getConfig("services")
     initDatabase(servicesConfig).also { db -> monitor.subscribe(ApplicationStopping) { db.close() } }
-    val safService = SafServiceHttp(servicesConfig.getConfig("saf"), authService)
-    val penClient = PentHttpClient(servicesConfig.getConfig("pen"), authService)
-    val skjermingService = SkjermingServiceHttp(servicesConfig.getConfig("skjerming"), authService, cache)
-    val pensjonPersonDataService = PensjonPersonDataServiceImpl(servicesConfig.getConfig("pensjon_persondata"), authService, cache = cache)
-    val pensjonRepresentasjonService = PensjonRepresentasjonService(servicesConfig.getConfig("pensjonRepresentasjon"), authService, cache)
-    val pdlService = PdlServiceHttp(servicesConfig.getConfig("pdl"), authService)
-    val krrService = KrrService(servicesConfig.getConfig("krr"), authService)
-    val brevbakerService = BrevbakerServiceHttp(servicesConfig.getConfig("brevbaker"), authService, cache)
-    val brevmetadataService = BrevmetadataServiceHttp(servicesConfig.getConfig("brevmetadata"))
-    val samhandlerService = SamhandlerServiceHttp(servicesConfig.getConfig("samhandlerProxy"), authService, cache)
-    val navansattService = NavansattServiceHttp(servicesConfig.getConfig("navansatt"), authService, cache)
+    val safService = SafServiceHttp(servicesConfig.getConfig("saf"), authService, closeOnShutdown)
+    val penClient = PentHttpClient(servicesConfig.getConfig("pen"), authService, closeOnShutdown)
+    val skjermingService = SkjermingServiceHttp(servicesConfig.getConfig("skjerming"), authService, cache, closeOnShutdown)
+    val pensjonPersonDataService = PensjonPersonDataServiceImpl(servicesConfig.getConfig("pensjon_persondata"), authService, cache, closeOnShutdown)
+    val pensjonRepresentasjonService = PensjonRepresentasjonService(servicesConfig.getConfig("pensjonRepresentasjon"), authService, cache, closeOnShutdown)
+    val pdlService = PdlServiceHttp(servicesConfig.getConfig("pdl"), authService, closeOnShutdown)
+    val krrService = KrrService(servicesConfig.getConfig("krr"), authService, closeOnShutdown = closeOnShutdown)
+    val brevbakerService = BrevbakerServiceHttp(servicesConfig.getConfig("brevbaker"), authService, cache, closeOnShutdown)
+    val brevmetadataService = BrevmetadataServiceHttp(servicesConfig.getConfig("brevmetadata"), closeOnShutdown)
+    val samhandlerService = SamhandlerServiceHttp(servicesConfig.getConfig("samhandlerProxy"), authService, cache, closeOnShutdown)
+    val navansattService = NavansattServiceHttp(servicesConfig.getConfig("navansatt"), authService, cache, closeOnShutdown)
     val legacyBrevService = LegacyBrevServiceImpl(brevmetadataService, safService, penClient, navansattService, pensjonPersonDataService)
-    val norg2Service = Norg2ServiceHttp(servicesConfig.getConfig("norg2"), cache)
+    val norg2Service = Norg2ServiceHttp(servicesConfig.getConfig("norg2"), cache, closeOnShutdown)
     val p1Service = P1ServiceImpl(penClient)
 
     val brevService = BrevService(penClient, legacyBrevService)

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
@@ -24,7 +24,6 @@ import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import no.nav.pensjon.brev.skribenten.Metrics.configureMetrics

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
@@ -23,6 +23,8 @@ import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import no.nav.pensjon.brev.skribenten.Metrics.configureMetrics
@@ -186,20 +188,22 @@ fun Application.skribentenApp(skribentenConfig: Config) {
     configureRouting(azureADConfig, skribentenConfig, cache)
     configureMetrics()
 
+    val delayedJobs = mutableListOf<Job>()
     monitor.subscribe(ServerReady) {
-        launch {
+        delayedJobs.add(launch {
             delay(5.minutes)
-            oneShotJobs(skribentenConfig) {
+            oneShotJobs(skribentenConfig, { client -> monitor.subscribe(ApplicationStopping) { client.cancel() }}) {
                 job("leggPaaSpraakForValgbareVedlegg") {
                     updateBrevredigeringJson()
                 }
                 // Sett opp evt. jobber her
             }
-        }
+        })
     }
 
     monitor.subscribe(ApplicationStopPreparing) {
         Features.shutdown()
+        delayedJobs.forEach { it.cancel() }
     }
 }
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
@@ -192,7 +192,7 @@ fun Application.skribentenApp(skribentenConfig: Config) {
     monitor.subscribe(ServerReady) {
         delayedJobs.add(launch {
             delay(5.minutes)
-            oneShotJobs(skribentenConfig, { client -> monitor.subscribe(ApplicationStopping) { client.cancel() }}) {
+            oneShotJobs(skribentenConfig, { client -> monitor.subscribe(ApplicationStopping) { client.close() }}) {
                 job("leggPaaSpraakForValgbareVedlegg") {
                     updateBrevredigeringJson()
                 }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADService.kt
@@ -47,7 +47,7 @@ interface AuthService {
     suspend fun getOnBehalfOfToken(principal: UserPrincipal, scope: String): TokenResponse.OnBehalfOfToken
 }
 
-class AzureADService(private val jwtConfig: JwtConfig, engine: HttpClientEngine = CIO.create(), private val cache: Cache) : AuthService {
+class AzureADService(private val jwtConfig: JwtConfig, engine: HttpClientEngine = CIO.create(), private val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : AuthService {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     private val client = HttpClient(engine) {
@@ -57,7 +57,7 @@ class AzureADService(private val jwtConfig: JwtConfig, engine: HttpClientEngine 
             }
         }
         installRetry(logger, maxRetries = 2)
-    }
+    }.also { closeOnShutdown(it) }
 
     override suspend fun getOnBehalfOfToken(principal: UserPrincipal, scope: String) =
         cache.cached(Cacheomraade.AD, Pair(principal.navIdent, scope), { it.expiresIn.seconds.minus(5.minutes) }) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADService.kt
@@ -16,6 +16,7 @@ import io.ktor.serialization.jackson.*
 import no.nav.pensjon.brev.skribenten.common.Cache
 import no.nav.pensjon.brev.skribenten.common.Cacheomraade
 import no.nav.pensjon.brev.skribenten.common.cached
+import no.nav.pensjon.brev.skribenten.services.SkribentenService
 import no.nav.pensjon.brev.skribenten.services.installRetry
 import org.slf4j.LoggerFactory
 import kotlin.time.Duration.Companion.minutes
@@ -47,7 +48,7 @@ interface AuthService {
     suspend fun getOnBehalfOfToken(principal: UserPrincipal, scope: String): TokenResponse.OnBehalfOfToken
 }
 
-class AzureADService(private val jwtConfig: JwtConfig, engine: HttpClientEngine = CIO.create(), private val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : AuthService {
+class AzureADService(private val jwtConfig: JwtConfig, engine: HttpClientEngine = CIO.create(), private val cache: Cache) : AuthService, SkribentenService {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     private val client = HttpClient(engine) {
@@ -57,7 +58,9 @@ class AzureADService(private val jwtConfig: JwtConfig, engine: HttpClientEngine 
             }
         }
         installRetry(logger, maxRetries = 2)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     override suspend fun getOnBehalfOfToken(principal: UserPrincipal, scope: String) =
         cache.cached(Cacheomraade.AD, Pair(principal.navIdent, scope), { it.expiresIn.seconds.minus(5.minutes) }) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevbaker/BrevbakerService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevbaker/BrevbakerService.kt
@@ -59,7 +59,7 @@ interface BrevbakerService {
     suspend fun getAlltidValgbareVedlegg(brevId: BrevId): Set<AlltidValgbartVedleggKode>
 }
 
-class BrevbakerServiceHttp(config: Config, authService: AuthService, val cache: Cache) : BrevbakerService, ServiceStatus {
+class BrevbakerServiceHttp(config: Config, authService: AuthService, val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : BrevbakerService, ServiceStatus {
     private val logger = LoggerFactory.getLogger(BrevbakerServiceHttp::class.java)!!
 
     private val brevbakerUrl = config.getString("url")
@@ -84,7 +84,7 @@ class BrevbakerServiceHttp(config: Config, authService: AuthService, val cache: 
             }
         }
         callIdAndOnBehalfOfClient(scope, authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     /**
      * Get model specification for a template.

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevbaker/BrevbakerService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevbaker/BrevbakerService.kt
@@ -59,7 +59,7 @@ interface BrevbakerService {
     suspend fun getAlltidValgbareVedlegg(brevId: BrevId): Set<AlltidValgbartVedleggKode>
 }
 
-class BrevbakerServiceHttp(config: Config, authService: AuthService, val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : BrevbakerService, ServiceStatus {
+class BrevbakerServiceHttp(config: Config, authService: AuthService, val cache: Cache) : BrevbakerService, ServiceStatus, SkribentenService {
     private val logger = LoggerFactory.getLogger(BrevbakerServiceHttp::class.java)!!
 
     private val brevbakerUrl = config.getString("url")
@@ -84,7 +84,9 @@ class BrevbakerServiceHttp(config: Config, authService: AuthService, val cache: 
             }
         }
         callIdAndOnBehalfOfClient(scope, authService)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     /**
      * Get model specification for a template.

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/common/OneShotJob.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/common/OneShotJob.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.brev.skribenten.common
 
 import com.typesafe.config.Config
+import io.ktor.client.HttpClient
 import no.nav.pensjon.brev.skribenten.db.BrevredigeringTable
 import no.nav.pensjon.brev.skribenten.db.Hash
 import no.nav.pensjon.brev.skribenten.db.OneShotJobTable
@@ -72,8 +73,8 @@ private val logger = LoggerFactory.getLogger("OneShotJob")
  * @param skribentenConfig The configuration for Skribenten, including leader service settings.
  * @param block The block of one-shot job definitions to execute.
  */
-suspend fun oneShotJobs(skribentenConfig: Config, block: OneShotJobConfig.() -> Unit) =
-    oneShotJobs(NaisLeaderService(skribentenConfig.getConfig("services.leader")), block)
+suspend fun oneShotJobs(skribentenConfig: Config, closeOnShutdown: (HttpClient) -> Unit, block: OneShotJobConfig.() -> Unit) =
+    oneShotJobs(NaisLeaderService(skribentenConfig.getConfig("services.leader"), closeOnShutdown = closeOnShutdown), block)
 
 /**
  * Executes one-shot jobs if this instance is the leader in a leader election setup.

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/BrevmetadataService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/BrevmetadataService.kt
@@ -14,6 +14,7 @@ import io.ktor.serialization.jackson.*
 import no.nav.pensjon.brev.api.model.TemplateDescription.ISakstype
 import no.nav.pensjon.brev.skribenten.context.CallIdFromContext
 import no.nav.pensjon.brev.skribenten.services.ServiceStatus
+import no.nav.pensjon.brev.skribenten.services.SkribentenService
 import no.nav.pensjon.brev.skribenten.services.ping
 import org.slf4j.LoggerFactory
 
@@ -24,10 +25,7 @@ interface BrevmetadataService {
     suspend fun getMal(brevkode: String): BrevdataDto
 }
 
-class BrevmetadataServiceHttp(
-    config: Config,
-    closeOnShutdown: (HttpClient) -> Unit,
-) : BrevmetadataService, ServiceStatus {
+class BrevmetadataServiceHttp(config: Config) : BrevmetadataService, ServiceStatus, SkribentenService {
     private val brevmetadataUrl = config.getString("url")
     private val logger = LoggerFactory.getLogger(BrevmetadataService::class.java)
     private val httpClient = HttpClient(CIO) {
@@ -40,7 +38,9 @@ class BrevmetadataServiceHttp(
             }
         }
         install(CallIdFromContext)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = httpClient.close()
 
     override suspend fun getAllBrev(): List<BrevdataDto> {
         val httpResponse = httpClient.get("/api/brevdata/allBrev")

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/BrevmetadataService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/BrevmetadataService.kt
@@ -26,6 +26,7 @@ interface BrevmetadataService {
 
 class BrevmetadataServiceHttp(
     config: Config,
+    closeOnShutdown: (HttpClient) -> Unit,
 ) : BrevmetadataService, ServiceStatus {
     private val brevmetadataUrl = config.getString("url")
     private val logger = LoggerFactory.getLogger(BrevmetadataService::class.java)
@@ -39,7 +40,7 @@ class BrevmetadataServiceHttp(
             }
         }
         install(CallIdFromContext)
-    }
+    }.also { closeOnShutdown(it) }
 
     override suspend fun getAllBrev(): List<BrevdataDto> {
         val httpResponse = httpClient.get("/api/brevdata/allBrev")

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/PenClient.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/PenClient.kt
@@ -50,7 +50,7 @@ class PenServiceException(message: String) : ServiceException(message)
 class PenDataException(val feil: BrevExceptionDto) : ServiceException("${feil.tittel}: ${feil.melding}", status = HttpStatusCode.UnprocessableEntity)
 class PenFeilIDatabyggerException(message: String) : ServiceException(message)
 
-class PentHttpClient(config: Config, authService: AuthService, closeOnShutdown: (HttpClient) -> Unit) : PenClient, ServiceStatus {
+class PentHttpClient(config: Config, authService: AuthService) : PenClient, ServiceStatus, SkribentenService {
     private val penUrl = config.getString("url")
     private val penScope = config.getString("scope")
 
@@ -67,7 +67,9 @@ class PentHttpClient(config: Config, authService: AuthService, closeOnShutdown: 
             }
         }
         callIdAndOnBehalfOfClient(penScope, authService)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     private suspend inline fun <reified T> HttpResponse.bodyOrThrow(): T? =
         when {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/PenClient.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/pesys/PenClient.kt
@@ -50,7 +50,7 @@ class PenServiceException(message: String) : ServiceException(message)
 class PenDataException(val feil: BrevExceptionDto) : ServiceException("${feil.tittel}: ${feil.melding}", status = HttpStatusCode.UnprocessableEntity)
 class PenFeilIDatabyggerException(message: String) : ServiceException(message)
 
-class PentHttpClient(config: Config, authService: AuthService) : PenClient, ServiceStatus {
+class PentHttpClient(config: Config, authService: AuthService, closeOnShutdown: (HttpClient) -> Unit) : PenClient, ServiceStatus {
     private val penUrl = config.getString("url")
     private val penScope = config.getString("scope")
 
@@ -67,7 +67,7 @@ class PentHttpClient(config: Config, authService: AuthService) : PenClient, Serv
             }
         }
         callIdAndOnBehalfOfClient(penScope, authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     private suspend inline fun <reified T> HttpResponse.bodyOrThrow(): T? =
         when {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
@@ -18,7 +18,7 @@ import no.nav.pensjon.brev.skribenten.fagsystem.pesys.SpraakKode
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Pid
 import org.slf4j.LoggerFactory
 
-class KrrService(config: Config, authService: AuthService, engine: HttpClientEngine = CIO.create()) : ServiceStatus {
+class KrrService(config: Config, authService: AuthService, engine: HttpClientEngine = CIO.create(), closeOnShutdown: (HttpClient) -> Unit) : ServiceStatus {
     private val logger = LoggerFactory.getLogger(this::class.java)
     private val client = HttpClient(engine) {
         defaultRequest {
@@ -30,7 +30,7 @@ class KrrService(config: Config, authService: AuthService, engine: HttpClientEng
             }
         }
         callIdAndOnBehalfOfClient(config.getString("scope"), authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     @Suppress("EnumEntryName")
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/KrrService.kt
@@ -18,7 +18,7 @@ import no.nav.pensjon.brev.skribenten.fagsystem.pesys.SpraakKode
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Pid
 import org.slf4j.LoggerFactory
 
-class KrrService(config: Config, authService: AuthService, engine: HttpClientEngine = CIO.create(), closeOnShutdown: (HttpClient) -> Unit) : ServiceStatus {
+class KrrService(config: Config, authService: AuthService, engine: HttpClientEngine = CIO.create()) : ServiceStatus, SkribentenService {
     private val logger = LoggerFactory.getLogger(this::class.java)
     private val client = HttpClient(engine) {
         defaultRequest {
@@ -30,7 +30,9 @@ class KrrService(config: Config, authService: AuthService, engine: HttpClientEng
             }
         }
         callIdAndOnBehalfOfClient(config.getString("scope"), authService)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     @Suppress("EnumEntryName")
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/LeaderService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/LeaderService.kt
@@ -23,10 +23,12 @@ interface LeaderService {
 class NaisLeaderService(
     private val url: String?,
     clientEngine: HttpClientEngine = CIO.create(),
+    closeOnShutdown: (HttpClient) -> Unit = {}
 ) : LeaderService {
-    constructor(config: Config, clientEngine: HttpClientEngine = CIO.create()) : this(
+    constructor(config: Config, clientEngine: HttpClientEngine = CIO.create(), closeOnShutdown: (HttpClient) -> Unit) : this(
         url = config.tryGetString("url"),
-        clientEngine = clientEngine
+        clientEngine = clientEngine,
+        closeOnShutdown = closeOnShutdown
     )
 
     private val client = HttpClient(clientEngine) {
@@ -35,7 +37,7 @@ class NaisLeaderService(
                 configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             }
         }
-    }
+    }.also { closeOnShutdown(it) }
     private val thisInstanceName by lazy { thisInstanceName() }
 
     override val isLeaderElectionEnabled: Boolean

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/NavansattService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/NavansattService.kt
@@ -28,7 +28,7 @@ interface NavansattService {
 
 class NavansattServiceException(message: String) : ServiceException(message)
 
-class NavansattServiceHttp(config: Config, authService: AuthService, private val cache: Cache) : NavansattService, ServiceStatus {
+class NavansattServiceHttp(config: Config, authService: AuthService, private val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : NavansattService, ServiceStatus {
     private val logger = LoggerFactory.getLogger(NavansattServiceHttp::class.java)
 
     private val navansattUrl = config.getString("url")
@@ -46,7 +46,7 @@ class NavansattServiceHttp(config: Config, authService: AuthService, private val
         }
         installRetry(logger)
         callIdAndOnBehalfOfClient(navansattScope, authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     override suspend fun hentNavAnsattEnhetListe(ansattId: NavIdent): List<NAVAnsattEnhet> {
         return cache.cached(Cacheomraade.NAVANSATTENHET, ansattId.id) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/NavansattService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/NavansattService.kt
@@ -28,7 +28,7 @@ interface NavansattService {
 
 class NavansattServiceException(message: String) : ServiceException(message)
 
-class NavansattServiceHttp(config: Config, authService: AuthService, private val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : NavansattService, ServiceStatus {
+class NavansattServiceHttp(config: Config, authService: AuthService, private val cache: Cache) : NavansattService, ServiceStatus, SkribentenService {
     private val logger = LoggerFactory.getLogger(NavansattServiceHttp::class.java)
 
     private val navansattUrl = config.getString("url")
@@ -46,7 +46,9 @@ class NavansattServiceHttp(config: Config, authService: AuthService, private val
         }
         installRetry(logger)
         callIdAndOnBehalfOfClient(navansattScope, authService)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     override suspend fun hentNavAnsattEnhetListe(ansattId: NavIdent): List<NAVAnsattEnhet> {
         return cache.cached(Cacheomraade.NAVANSATTENHET, ansattId.id) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/Norg2Service.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/Norg2Service.kt
@@ -22,7 +22,7 @@ interface Norg2Service {
 }
 
 // docs: https://confluence.adeo.no/display/FEL/NORG2+-+Teknisk+beskrivelse - trykk på droppdown
-class Norg2ServiceHttp(val config: Config, val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : Norg2Service {
+class Norg2ServiceHttp(val config: Config, val cache: Cache) : Norg2Service, SkribentenService {
     private val logger = LoggerFactory.getLogger(Norg2ServiceHttp::class.java)
     private val norgUrl = config.getString("url")
 
@@ -36,7 +36,9 @@ class Norg2ServiceHttp(val config: Config, val cache: Cache, closeOnShutdown: (H
             }
         }
         install(CallIdFromContext)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     override suspend fun getEnhet(enhetId: EnhetId): NavEnhet =
         cache.cached(Cacheomraade.NORG, enhetId) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/Norg2Service.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/Norg2Service.kt
@@ -22,7 +22,7 @@ interface Norg2Service {
 }
 
 // docs: https://confluence.adeo.no/display/FEL/NORG2+-+Teknisk+beskrivelse - trykk på droppdown
-class Norg2ServiceHttp(val config: Config, val cache: Cache) : Norg2Service {
+class Norg2ServiceHttp(val config: Config, val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : Norg2Service {
     private val logger = LoggerFactory.getLogger(Norg2ServiceHttp::class.java)
     private val norgUrl = config.getString("url")
 
@@ -36,7 +36,7 @@ class Norg2ServiceHttp(val config: Config, val cache: Cache) : Norg2Service {
             }
         }
         install(CallIdFromContext)
-    }
+    }.also { closeOnShutdown(it) }
 
     override suspend fun getEnhet(enhetId: EnhetId): NavEnhet =
         cache.cached(Cacheomraade.NORG, enhetId) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PdlService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PdlService.kt
@@ -38,7 +38,7 @@ interface PdlService {
 
 class PdlServiceException(message: String, status: HttpStatusCode = HttpStatusCode.InternalServerError) : ServiceException(message, status = status)
 
-class PdlServiceHttp(config: Config, authService: AuthService) : PdlService, ServiceStatus {
+class PdlServiceHttp(config: Config, authService: AuthService, closeOnShutdown: (HttpClient) -> Unit) : PdlService, ServiceStatus {
     private val pdlUrl = config.getString("url")
     private val pdlScope = config.getString("scope")
 
@@ -51,7 +51,7 @@ class PdlServiceHttp(config: Config, authService: AuthService) : PdlService, Ser
             jackson { registerModule(JavaTimeModule()) }
         }
         callIdAndOnBehalfOfClient(pdlScope, authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     private data class PDLQuery<T : Any>(
         val query: String,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PdlService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PdlService.kt
@@ -38,7 +38,7 @@ interface PdlService {
 
 class PdlServiceException(message: String, status: HttpStatusCode = HttpStatusCode.InternalServerError) : ServiceException(message, status = status)
 
-class PdlServiceHttp(config: Config, authService: AuthService, closeOnShutdown: (HttpClient) -> Unit) : PdlService, ServiceStatus {
+class PdlServiceHttp(config: Config, authService: AuthService) : PdlService, ServiceStatus, SkribentenService {
     private val pdlUrl = config.getString("url")
     private val pdlScope = config.getString("scope")
 
@@ -51,7 +51,9 @@ class PdlServiceHttp(config: Config, authService: AuthService, closeOnShutdown: 
             jackson { registerModule(JavaTimeModule()) }
         }
         callIdAndOnBehalfOfClient(pdlScope, authService)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     private data class PDLQuery<T : Any>(
         val query: String,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataService.kt
@@ -51,8 +51,9 @@ interface PensjonPersonDataService {
 class PensjonPersonDataServiceImpl(
     config: Config,
     authService: AuthService,
-    clientEngine: HttpClientEngine = CIO.create(),
     private val cache: Cache,
+    closeOnShutdown: (HttpClient) -> Unit,
+    clientEngine: HttpClientEngine = CIO.create(),
 ): ServiceStatus, PensjonPersonDataService {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val pensjonPersondataURL = config.getString("url")
@@ -68,7 +69,7 @@ class PensjonPersonDataServiceImpl(
             }
         }
         callIdAndOnBehalfOfClient(scope, authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     override suspend fun hentKontaktadresse(pid: Pid): KontaktAdresseResponseDto? = cache.cached(
         Cacheomraade.PENSJON_PERSONDATA,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataService.kt
@@ -52,9 +52,8 @@ class PensjonPersonDataServiceImpl(
     config: Config,
     authService: AuthService,
     private val cache: Cache,
-    closeOnShutdown: (HttpClient) -> Unit,
     clientEngine: HttpClientEngine = CIO.create(),
-): ServiceStatus, PensjonPersonDataService {
+): ServiceStatus, PensjonPersonDataService, SkribentenService {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val pensjonPersondataURL = config.getString("url")
     private val scope = config.getString("scope")
@@ -69,7 +68,9 @@ class PensjonPersonDataServiceImpl(
             }
         }
         callIdAndOnBehalfOfClient(scope, authService)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     override suspend fun hentKontaktadresse(pid: Pid): KontaktAdresseResponseDto? = cache.cached(
         Cacheomraade.PENSJON_PERSONDATA,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonRepresentasjonService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonRepresentasjonService.kt
@@ -23,8 +23,7 @@ class PensjonRepresentasjonService(
     config: Config,
     authService: AuthService,
     private val cache: Cache,
-    closeOnShutdown: (HttpClient) -> Unit,
-) {
+) : SkribentenService {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val pensjonPersondataURL = config.getString("url")
     private val scope = config.getString("scope")
@@ -38,7 +37,9 @@ class PensjonRepresentasjonService(
         }
         install(ContentNegotiation) { jackson() }
         callIdAndOnBehalfOfClient(scope, authService)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     data class HasRepresentantRequest(
         val representertPid: Pid,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonRepresentasjonService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonRepresentasjonService.kt
@@ -23,6 +23,7 @@ class PensjonRepresentasjonService(
     config: Config,
     authService: AuthService,
     private val cache: Cache,
+    closeOnShutdown: (HttpClient) -> Unit,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val pensjonPersondataURL = config.getString("url")
@@ -37,7 +38,7 @@ class PensjonRepresentasjonService(
         }
         install(ContentNegotiation) { jackson() }
         callIdAndOnBehalfOfClient(scope, authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     data class HasRepresentantRequest(
         val representertPid: Pid,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SafService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SafService.kt
@@ -52,7 +52,7 @@ interface SafService {
 
 class SafServiceException(message: String) : ServiceException(message)
 
-class SafServiceHttp(config: Config, authService: AuthService, closeOnShutdown: (HttpClient) -> Unit) : SafService, ServiceStatus {
+class SafServiceHttp(config: Config, authService: AuthService) : SafService, ServiceStatus, SkribentenService {
     private val safUrl = config.getString("url")
     private val safRestUrl = config.getString("rest_url")
     private val safScope = config.getString("scope")
@@ -67,7 +67,7 @@ class SafServiceHttp(config: Config, authService: AuthService, closeOnShutdown: 
             jackson()
         }
         callIdAndOnBehalfOfClient(safScope, authService)
-    }.also { closeOnShutdown(it) }
+    }
 
     data class HentJournalStatusResponse(val data: HentJournalpostData?, val errors: JsonNode?)
     data class HentJournalpostData(val journalpost: JournalPost)
@@ -110,6 +110,8 @@ class SafServiceHttp(config: Config, authService: AuthService, closeOnShutdown: 
             throw SafServiceException("Feil ved henting av journalpoststatus fra SAF for journalpostId $journalpostId: $body")
         }
     }
+
+    override fun close() = client.close()
 
     override suspend fun waitForJournalpostStatusUnderArbeid(journalpostId: JournalpostId): JournalpostLoadingResult =
         withTimeoutOrNull(TIMEOUT.seconds) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SafService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SafService.kt
@@ -52,7 +52,7 @@ interface SafService {
 
 class SafServiceException(message: String) : ServiceException(message)
 
-class SafServiceHttp(config: Config, authService: AuthService) : SafService, ServiceStatus {
+class SafServiceHttp(config: Config, authService: AuthService, closeOnShutdown: (HttpClient) -> Unit) : SafService, ServiceStatus {
     private val safUrl = config.getString("url")
     private val safRestUrl = config.getString("rest_url")
     private val safScope = config.getString("scope")
@@ -67,7 +67,7 @@ class SafServiceHttp(config: Config, authService: AuthService) : SafService, Ser
             jackson()
         }
         callIdAndOnBehalfOfClient(safScope, authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     data class HentJournalStatusResponse(val data: HentJournalpostData?, val errors: JsonNode?)
     data class HentJournalpostData(val journalpost: JournalPost)

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SamhandlerService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SamhandlerService.kt
@@ -30,7 +30,7 @@ interface SamhandlerService {
     suspend fun hentSamhandlerAdresse(idTSSEkstern: String): HentSamhandlerAdresseResponseDto
 }
 
-class SamhandlerServiceHttp(configSamhandlerProxy: Config, authService: AuthService, private val cache: Cache) : SamhandlerService, ServiceStatus {
+class SamhandlerServiceHttp(configSamhandlerProxy: Config, authService: AuthService, private val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : SamhandlerService, ServiceStatus {
     private val samhandlerProxyUrl = configSamhandlerProxy.getString("url")
     private val samhandlerProxyScope = configSamhandlerProxy.getString("scope")
 
@@ -44,7 +44,7 @@ class SamhandlerServiceHttp(configSamhandlerProxy: Config, authService: AuthServ
             }
         }
         callIdAndOnBehalfOfClient(samhandlerProxyScope, authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     private val logger = LoggerFactory.getLogger(SamhandlerServiceHttp::class.java)
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SamhandlerService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SamhandlerService.kt
@@ -30,7 +30,7 @@ interface SamhandlerService {
     suspend fun hentSamhandlerAdresse(idTSSEkstern: String): HentSamhandlerAdresseResponseDto
 }
 
-class SamhandlerServiceHttp(configSamhandlerProxy: Config, authService: AuthService, private val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : SamhandlerService, ServiceStatus {
+class SamhandlerServiceHttp(configSamhandlerProxy: Config, authService: AuthService, private val cache: Cache) : SamhandlerService, ServiceStatus, SkribentenService {
     private val samhandlerProxyUrl = configSamhandlerProxy.getString("url")
     private val samhandlerProxyScope = configSamhandlerProxy.getString("scope")
 
@@ -44,7 +44,9 @@ class SamhandlerServiceHttp(configSamhandlerProxy: Config, authService: AuthServ
             }
         }
         callIdAndOnBehalfOfClient(samhandlerProxyScope, authService)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = samhandlerProxyClient.close()
 
     private val logger = LoggerFactory.getLogger(SamhandlerServiceHttp::class.java)
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SkjermingService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SkjermingService.kt
@@ -24,7 +24,7 @@ interface SkjermingService {
 
 private val logger = LoggerFactory.getLogger(SkjermingService::class.java)
 
-class SkjermingServiceHttp(config: Config, authService: AuthService, private val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : SkjermingService {
+class SkjermingServiceHttp(config: Config, authService: AuthService, private val cache: Cache) : SkjermingService, SkribentenService {
     private val url = config.getString("url")
     private val scope = config.getString("scope")
 
@@ -33,7 +33,9 @@ class SkjermingServiceHttp(config: Config, authService: AuthService, private val
         installRetry(logger)
         install(ContentNegotiation) { jackson() }
         callIdAndOnBehalfOfClient(scope, authService)
-    }.also { closeOnShutdown(it) }
+    }
+
+    override fun close() = client.close()
 
     override suspend fun hentSkjerming(pid: Pid): Boolean? =
         cache.cached(Cacheomraade.SKJERMING, pid, ttl = { 5.minutes }) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SkjermingService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SkjermingService.kt
@@ -24,7 +24,7 @@ interface SkjermingService {
 
 private val logger = LoggerFactory.getLogger(SkjermingService::class.java)
 
-class SkjermingServiceHttp(config: Config, authService: AuthService, private val cache: Cache) : SkjermingService {
+class SkjermingServiceHttp(config: Config, authService: AuthService, private val cache: Cache, closeOnShutdown: (HttpClient) -> Unit) : SkjermingService {
     private val url = config.getString("url")
     private val scope = config.getString("scope")
 
@@ -33,7 +33,7 @@ class SkjermingServiceHttp(config: Config, authService: AuthService, private val
         installRetry(logger)
         install(ContentNegotiation) { jackson() }
         callIdAndOnBehalfOfClient(scope, authService)
-    }
+    }.also { closeOnShutdown(it) }
 
     override suspend fun hentSkjerming(pid: Pid): Boolean? =
         cache.cached(Cacheomraade.SKJERMING, pid, ttl = { 5.minutes }) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SkribentenService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/services/SkribentenService.kt
@@ -1,0 +1,3 @@
+package no.nav.pensjon.brev.skribenten.services
+
+interface SkribentenService : AutoCloseable

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADServiceTest.kt
@@ -92,5 +92,6 @@ class AzureADServiceTest {
             jwtConfig = jwtConfig,
             engine = MockEngine.invoke(handler),
             cache = InMemoryCache(),
+            closeOnShutdown = {},
         )
 }

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADServiceTest.kt
@@ -91,6 +91,6 @@ class AzureADServiceTest {
         AzureADService(
             jwtConfig = jwtConfig,
             engine = MockEngine.invoke(handler),
-            cache = InMemoryCache()
+            cache = InMemoryCache(),
         )
 }

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/auth/AzureADServiceTest.kt
@@ -92,6 +92,5 @@ class AzureADServiceTest {
             jwtConfig = jwtConfig,
             engine = MockEngine.invoke(handler),
             cache = InMemoryCache(),
-            closeOnShutdown = {},
         )
 }

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/db/OneShotJobTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/db/OneShotJobTest.kt
@@ -38,7 +38,7 @@ class OneShotJobTest {
         val name = jobName("test-job")
 
         runBlocking {
-            oneShotJobs(config) {
+            oneShotJobs(config, {}) {
                 job(name) {
                     isExecuted = true
                 }
@@ -60,7 +60,7 @@ class OneShotJobTest {
         val name = jobName("no-duplicate-execution")
         fun aJob() {
             runBlocking {
-                oneShotJobs(config) {
+                oneShotJobs(config, {}) {
                     job(name) {
                         executionCount++
                     }
@@ -80,7 +80,7 @@ class OneShotJobTest {
         val name = jobName("failing-job")
 
         fun failingJob() = runBlocking {
-            oneShotJobs(config) {
+            oneShotJobs(config, {}) {
                 job(name) {
                     isExecuted = true
                     throw RuntimeException("Simulated failure")

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
@@ -24,7 +24,6 @@ class KrrServiceTest {
                 config = config,
                 authService = FakeAuthService,
                 engine = engine,
-                closeOnShutdown = {},
             )
 
             val preferredLocale = service.getPreferredLocale(Pid("12345"))
@@ -45,7 +44,6 @@ class KrrServiceTest {
                 config = config,
                 authService = FakeAuthService,
                 engine = engine,
-                closeOnShutdown = {},
             )
 
             val preferredLocale = service.getPreferredLocale(Pid("12345"))
@@ -66,7 +64,6 @@ class KrrServiceTest {
                 config = config,
                 authService = FakeAuthService,
                 engine = engine,
-                closeOnShutdown = {},
             )
 
             val preferredLocale = service.getPreferredLocale(Pid("12345"))

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
@@ -23,7 +23,7 @@ class KrrServiceTest {
             val service = KrrService(
                 config = config,
                 authService = FakeAuthService,
-                engine = engine,
+                engine = engine,,
             )
 
             val preferredLocale = service.getPreferredLocale(Pid("12345"))
@@ -43,7 +43,7 @@ class KrrServiceTest {
             val service = KrrService(
                 config = config,
                 authService = FakeAuthService,
-                engine = engine,
+                engine = engine,,
             )
 
             val preferredLocale = service.getPreferredLocale(Pid("12345"))
@@ -63,7 +63,7 @@ class KrrServiceTest {
             val service = KrrService(
                 config = config,
                 authService = FakeAuthService,
-                engine = engine
+                engine = engine,
             )
 
             val preferredLocale = service.getPreferredLocale(Pid("12345"))

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/KrrServiceTest.kt
@@ -23,7 +23,8 @@ class KrrServiceTest {
             val service = KrrService(
                 config = config,
                 authService = FakeAuthService,
-                engine = engine,,
+                engine = engine,
+                closeOnShutdown = {},
             )
 
             val preferredLocale = service.getPreferredLocale(Pid("12345"))
@@ -43,7 +44,8 @@ class KrrServiceTest {
             val service = KrrService(
                 config = config,
                 authService = FakeAuthService,
-                engine = engine,,
+                engine = engine,
+                closeOnShutdown = {},
             )
 
             val preferredLocale = service.getPreferredLocale(Pid("12345"))
@@ -64,6 +66,7 @@ class KrrServiceTest {
                 config = config,
                 authService = FakeAuthService,
                 engine = engine,
+                closeOnShutdown = {},
             )
 
             val preferredLocale = service.getPreferredLocale(Pid("12345"))

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataServiceTest.kt
@@ -28,8 +28,9 @@ class PensjonPersonDataServiceTest {
     private fun pensjonPersonDataService(engine: MockEngine) = PensjonPersonDataServiceImpl(
         ConfigFactory.parseMap(mapOf("url" to "http://localhost", "scope" to "fri tilgang")),
         FakeAuthService,
+        InMemoryCache(),
+        {},
         engine,
-        InMemoryCache()
     )
 
 }

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataServiceTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/PensjonPersonDataServiceTest.kt
@@ -29,7 +29,6 @@ class PensjonPersonDataServiceTest {
         ConfigFactory.parseMap(mapOf("url" to "http://localhost", "scope" to "fri tilgang")),
         FakeAuthService,
         InMemoryCache(),
-        {},
         engine,
     )
 


### PR DESCRIPTION
Det inkluderer alle http-klientar og også å sørge for at oneshotjobs stoppar ordentleg

Med dette får vi avslutta applikasjonen meir kontrollert, og vi bør også sleppe unna litt logg-støy rundt dette