### PR TITLE
Skrur ned tida frå oppstart til vi sjekkar live- og readiness

### DIFF
--- a/skribenten-backend/.nais/nais.yaml
+++ b/skribenten-backend/.nais/nais.yaml
@@ -15,13 +15,13 @@ spec:
   liveness:
     path: "/isAlive"
     port: 8080
-    initialDelay: 20
-    timeout: 60
+    initialDelay: 10
+    timeout: 15
   readiness:
     path: "/isReady"
     port: 8080
-    initialDelay: 20
-    timeout: 60
+    initialDelay: 10
+    timeout: 15
   replicas:
     min: 2
     max: 10


### PR DESCRIPTION
I dev ser det ut som det er ca 6 sekund frå første logginnslag til `Application started`, feks 
`{"@timestamp":"2026-06-16T10:04:39.751768974Z","@version":"1","message":"Application started in 5.585 seconds.","logger_name":"io.ktor.server.Application","thread_name":"main","level":"INFO","level_value":20000}`

Skrur også ned timeout som var veldig høg. Er sikkert veldig høg enno også, men vil ikkje endre altfor drastisk i eitt.