### PR TITLE
Det er vårt team som skal sjå på dependabot-endringar

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -30,6 +30,7 @@ jobs:
               'stainawarjar',
               'sanderhaNav',
               'dependabot',
+              'dependabot[bot]',
             ].map(user => user.toLowerCase());
             const author = context.payload.pull_request.user.login.toLowerCase();
             if (teamMembers.includes(author)) {

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -29,6 +29,7 @@ jobs:
               'mussie009',
               'stainawarjar',
               'sanderhaNav',
+              'dependabot',
             ].map(user => user.toLowerCase());
             const author = context.payload.pull_request.user.login.toLowerCase();
             if (teamMembers.includes(author)) {


### PR DESCRIPTION
Så da er det fint å få dei opp i lista over PRs merka som våre