### PR TITLE
Skribenten/sikkerhetsfiks js yaml

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -17,13 +17,13 @@
       }
     },
     "node_modules/@antora/asciidoc-loader": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-3.1.14.tgz",
-      "integrity": "sha512-4xxisnoBFrlLNY6f3xZtyyfgm+tBLsqesTcEStfc8jtXUMYJ4b2DWIzo1vULmxvZ7yY5+Q7YqEvS5o6kIWAG0A==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-3.1.15.tgz",
+      "integrity": "sha512-MVspbcMPmBgxZms0EjmyC9nlCAWBJfHYSwQCXRZn6T7OujRrLvJFPgz+EROz9XOqh4v76BeqgEuLsUJIZjH3cw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/logger": "3.1.14",
+        "@antora/logger": "3.1.15",
         "@antora/user-require-helper": "~3.0",
         "@asciidoctor/core": "~2.2"
       },
@@ -32,14 +32,14 @@
       }
     },
     "node_modules/@antora/cli": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/cli/-/cli-3.1.14.tgz",
-      "integrity": "sha512-I6WcygMU2bFInjdURJjkYjo7K5M8B3lBB53v9OO0IcY0LhEY8Wa7IlZ7wVinf5qEjHvaYzRGTZVl6RsJtVt7Sw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/cli/-/cli-3.1.15.tgz",
+      "integrity": "sha512-76vLhkyzyFd49WJHsC04oPAZlK4qWbJaeZdS/pLUUVBqgaxeSeNqpTZ0pXo7f+5laGRO19fXyk1eDWGus9h8jA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/logger": "3.1.14",
-        "@antora/playbook-builder": "3.1.14",
+        "@antora/logger": "3.1.15",
+        "@antora/playbook-builder": "3.1.15",
         "@antora/user-require-helper": "~3.0",
         "commander": "~11.1"
       },
@@ -51,14 +51,14 @@
       }
     },
     "node_modules/@antora/content-aggregator": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-3.1.14.tgz",
-      "integrity": "sha512-FVuBgnrGPiktYqK1WHbGF8O8l4m5KHlkxoJumrbacgFo8SKuiRFEo31zalxrCUsv8QM3UBEgX+LdHrve/9CGLg==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-3.1.15.tgz",
+      "integrity": "sha512-w84rJRKx+C4dsSbOHmjg78oM2T6xP9JRDsxpXjTmlh9T4zlNELCB6AD5s6Gztt3S6wlTiCNFLZw0v/HEVtuhzQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@antora/expand-path-helper": "~3.0",
-        "@antora/logger": "3.1.14",
+        "@antora/logger": "3.1.15",
         "@antora/user-require-helper": "~3.0",
         "braces": "~3.0",
         "cache-directory": "~2.0",
@@ -78,14 +78,14 @@
       }
     },
     "node_modules/@antora/content-classifier": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-3.1.14.tgz",
-      "integrity": "sha512-y8Fk+KU1lqD3aawOu3ZFK92YfOZ1k3YBJhLI9QIFM6Ck4STPnf7AwYbhfOtjODlwer5/OhFmfhjUB2hn7onGnA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-3.1.15.tgz",
+      "integrity": "sha512-m7INbqJcXBZU04HdBMqfL/NvezC3aaJGHHa0KfzeEKICg5FT22cVsEp6mYTgJVT4HqRy7JPCn9UeZvoa9x+MzQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.14",
-        "@antora/logger": "3.1.14",
+        "@antora/asciidoc-loader": "3.1.15",
+        "@antora/logger": "3.1.15",
         "mime-types": "~2.1",
         "vinyl": "~3.0"
       },
@@ -94,13 +94,13 @@
       }
     },
     "node_modules/@antora/document-converter": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/document-converter/-/document-converter-3.1.14.tgz",
-      "integrity": "sha512-f6wFnL+489DI0ZDgoxYWzbxxWqPviRiJ56OHS1NixEfvJ7OpRBDPEbX1xnsIeiyFBgqX4+nY92MsCWKTa+Gf3w==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/document-converter/-/document-converter-3.1.15.tgz",
+      "integrity": "sha512-7YZsc/iIJVTxvHKy0/eqPTuRIJupBd7Pq49gWvCxiDBR9Zj4esqMZIU3HaIbkBgqJLlQv5TLBeTjiQ1Qpe1hNw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.14"
+        "@antora/asciidoc-loader": "3.1.15"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -117,25 +117,25 @@
       }
     },
     "node_modules/@antora/file-publisher": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/file-publisher/-/file-publisher-3.1.14.tgz",
-      "integrity": "sha512-fTaAnkyKSOlsxQM1TBFCAmiERA6Q67XleDCD2bMPVgfcENmo0Xfx59KwCHaA92IcRSmMftydlXHPaFxNh0UVsg==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/file-publisher/-/file-publisher-3.1.15.tgz",
+      "integrity": "sha512-UfLYeyD6Na9YXespr3Xjy6OPIAGG6GTbdW3SNn8KxHl3hGeF/AtM3NaR+AJgyOmTb2r9lHzfODXeZevqX+vMww==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@antora/expand-path-helper": "~3.0",
         "@antora/user-require-helper": "~3.0",
         "vinyl": "~3.0",
-        "yazl": "~2.5"
+        "yazl": "~3.3"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/logger": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/logger/-/logger-3.1.14.tgz",
-      "integrity": "sha512-kVEeGqZbXR903hPIm+BlN97fLdQ3LoUzE/BOPZ6vRp9m9Mmbnm67Kg7fSYkfTMLB0S2UWpAPFg22RdsU5ZoAzA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/logger/-/logger-3.1.15.tgz",
+      "integrity": "sha512-txA2Nv0QQ+hIt6arc3Rrh1BiUJNlucsyNF7ZA7LgtN+rzxyjcqQPpbQ2F3tU2lOV/LOQCEvMbmz9Dj0tY8oBuA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -166,26 +166,26 @@
       }
     },
     "node_modules/@antora/navigation-builder": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-3.1.14.tgz",
-      "integrity": "sha512-/637YLGD7oUHGSfEfszXkk4ASfIhDAg5Xs9035J1dV07XYRlGqmtUb15rtapbcECpcQFjCyM5jFQYSNNvLrGcQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-3.1.15.tgz",
+      "integrity": "sha512-XRs4pfNd88GCG9lDAJ1J+2vwvre7OzNRSgRmZhEhtgv0A13NEZq37X4YuaH46F2kj2BqiZT8UOuxqAqarLaxmg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.14"
+        "@antora/asciidoc-loader": "3.1.15"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/page-composer": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/page-composer/-/page-composer-3.1.14.tgz",
-      "integrity": "sha512-RfA+67TxCqUPrQbZdrfjgLpHh8MR2z2du7cyF3HGX4N6DpqEBvz81NHHl3rA3fj6BQZPQbGm2OYAMU6wzJ6Pog==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/page-composer/-/page-composer-3.1.15.tgz",
+      "integrity": "sha512-koKlhWilA0E0QdCCOeLLzCFLNViBVjNe3aIlmJnMCwAK0p85wyhVfyolNqbNejAvdCZ87YhUQJ52Q4ikCgkQQg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/logger": "3.1.14",
+        "@antora/logger": "3.1.15",
         "handlebars": "~4.7",
         "require-from-string": "~2.0"
       },
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@antora/playbook-builder": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-3.1.14.tgz",
-      "integrity": "sha512-Ss2r7In00u/n9Da+JOxEqIE8NeRosf+f+agzH3Te09JV/mpgZKxEOE5V/VuP+TNNq4ww1eu5aOS8DiU2PYwj4Q==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-3.1.15.tgz",
+      "integrity": "sha512-L2bE9FS0Th/d37DeDjz/dg9YXrkHM1xI0WQB3eiW3K/6d0Mc7eJhbmDMT0K8S+hgdaO0AT4kqDWzvx2866ZobA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@antora/redirect-producer": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-3.1.14.tgz",
-      "integrity": "sha512-5koAwRk1cZrvE/qfOWKXqb3jtxrZbWA5EYHYGFEoato5By3cbC42blH4Bre9/48pjyS6znFpbZhYUBpT7PRhZA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-3.1.15.tgz",
+      "integrity": "sha512-mV0KnRiTr9oi0hPm7okT/Bw8kkz+PWYxp9AVSGqzhkoQgr3crxhgyS0NFCoViHwjaj4NfQrf++yxbhr6Igd7Dw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -223,25 +223,25 @@
       }
     },
     "node_modules/@antora/site-generator": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/site-generator/-/site-generator-3.1.14.tgz",
-      "integrity": "sha512-hQIUVtM9+xwleYWc4fIRZmiKl2p+ItOJuUm2+Hkdh07BZsySxkMOxxCyZsvTn9rc+4R94CYqDQCYElwFwdB2WA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/site-generator/-/site-generator-3.1.15.tgz",
+      "integrity": "sha512-Z9YiRTqw3ssnLQxSHI3VZHEPLytQXt8cWC5C/o9vS+Fc560TSNs1UO4quPFIkg+bFUpxXtcAxqbp650aA4/N1g==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.14",
-        "@antora/content-aggregator": "3.1.14",
-        "@antora/content-classifier": "3.1.14",
-        "@antora/document-converter": "3.1.14",
-        "@antora/file-publisher": "3.1.14",
-        "@antora/logger": "3.1.14",
-        "@antora/navigation-builder": "3.1.14",
-        "@antora/page-composer": "3.1.14",
-        "@antora/playbook-builder": "3.1.14",
-        "@antora/redirect-producer": "3.1.14",
-        "@antora/site-mapper": "3.1.14",
-        "@antora/site-publisher": "3.1.14",
-        "@antora/ui-loader": "3.1.14",
+        "@antora/asciidoc-loader": "3.1.15",
+        "@antora/content-aggregator": "3.1.15",
+        "@antora/content-classifier": "3.1.15",
+        "@antora/document-converter": "3.1.15",
+        "@antora/file-publisher": "3.1.15",
+        "@antora/logger": "3.1.15",
+        "@antora/navigation-builder": "3.1.15",
+        "@antora/page-composer": "3.1.15",
+        "@antora/playbook-builder": "3.1.15",
+        "@antora/redirect-producer": "3.1.15",
+        "@antora/site-mapper": "3.1.15",
+        "@antora/site-publisher": "3.1.15",
+        "@antora/ui-loader": "3.1.15",
         "@antora/user-require-helper": "~3.0"
       },
       "engines": {
@@ -249,13 +249,13 @@
       }
     },
     "node_modules/@antora/site-mapper": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-3.1.14.tgz",
-      "integrity": "sha512-3qbETtwadl+fWREjzrBUxPUorMcMiZ+hdkB1El9z7it9KzKh0Yp7Je0+2uTxGX+Lov9uik48dZJ9e/mr5PeaRQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-3.1.15.tgz",
+      "integrity": "sha512-dV5zGeL1uMQ83sfkBWKg8vjaJQXz1Zh3ZSNQZYa64HnT4M7oSuQUzwDZdS0j6ZtTiYcNGulRi1ucz3uIoc9tqw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/content-classifier": "3.1.14",
+        "@antora/content-classifier": "3.1.15",
         "vinyl": "~3.0"
       },
       "engines": {
@@ -263,22 +263,22 @@
       }
     },
     "node_modules/@antora/site-publisher": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-3.1.14.tgz",
-      "integrity": "sha512-8apyEmgepUc7ms9CTEIPwN3tGtWwLqR6fbLMLs7hibqmOSR880Ut/4GRGb97sqcGQXSHdIyWK2oJKzRl1Akb6Q==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-3.1.15.tgz",
+      "integrity": "sha512-pBuNxgA+H+WB5F4gA/gim5wKx/884QwlqOl0CpOY+6Fqn7h2ooHA7Tv6O47Tra1nZzNbIe3CQRoA5pnrX6zyRw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/file-publisher": "3.1.14"
+        "@antora/file-publisher": "3.1.15"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/ui-loader": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-3.1.14.tgz",
-      "integrity": "sha512-LVvTdKQOB44CmJ1JQDu8sJf6rrLZMxPAWWackdg2JtGyGHHpd80/MBcv4BSFk7//cJQ13Oqm/7JCbhD51KAFjg==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-3.1.15.tgz",
+      "integrity": "sha512-zYjF5ID7t6mUEJuMyeNW/AYu1U0026wZj58H0siGuaT5YhVoxZrfvZYWV5iCMntpKduMqkwZW/l+D4MIqjhFYQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -292,7 +292,7 @@
         "should-proxy": "~1.0",
         "simple-get": "~4.0",
         "vinyl": "~3.0",
-        "yauzl": "~3.1"
+        "yauzl": "~3.3"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -543,9 +543,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -567,9 +567,9 @@
       }
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -679,13 +679,13 @@
       }
     },
     "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/cache-directory": {
@@ -702,15 +702,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -1179,9 +1179,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1728,10 +1728,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2163,9 +2173,9 @@
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2221,9 +2231,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2683,9 +2693,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2762,9 +2772,9 @@
       }
     },
     "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2772,9 +2782,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2950,14 +2960,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -3005,13 +3015,12 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.1.3.tgz",
-      "integrity": "sha512-JCCdmlJJWv7L0q/KylOekyRaUrdEoUxWkWVcgorosTROCFWiS9p2NNPE9Yb91ak7b1N5SxAZEliWpspbZccivw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.2.tgz",
+      "integrity": "sha512-Md9ankxxN23wncAN8s7+Tn3Co52zLUPMtnrLAbVCnfG5d2tKBFfmygYSgXlqFgXObtzIgqkx7aNgDBpso9+4qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
         "pend": "~1.2.0"
       },
       "engines": {
@@ -3019,13 +3028,13 @@
       }
     },
     "node_modules/yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3"
+        "buffer-crc32": "^1.0.0"
       }
     }
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,15 @@
     "asciidoctor-kroki": "0.18.1"
   },
   "overrides": {
+    "@antora/content-aggregator": {
+      "js-yaml": ">=4.2.0"
+    },
+    "@antora/playbook-builder": {
+      "js-yaml": ">=4.2.0"
+    },
+    "@antora/ui-loader": {
+      "js-yaml": ">=4.2.0"
+    },
     "glob": {
       "minimatch": "10.2.4"
     }

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,13 +18,13 @@
   },
   "overrides": {
     "@antora/content-aggregator": {
-      "js-yaml": ">=4.2.0"
+      "js-yaml": "^4.2.0"
     },
     "@antora/playbook-builder": {
-      "js-yaml": ">=4.2.0"
+      "js-yaml": "^4.2.0"
     },
     "@antora/ui-loader": {
-      "js-yaml": ">=4.2.0"
+      "js-yaml": "^4.2.0"
     },
     "glob": {
       "minimatch": "10.2.4"

--- a/skribenten-web/frontend/package-lock.json
+++ b/skribenten-web/frontend/package-lock.json
@@ -30,7 +30,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "@navikt/aksel-stylelint": "8.11.0",
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "1.60.0",
         "@tanstack/react-query-devtools": "5.100.14",
         "@tanstack/react-router-devtools": "1.167.0",
         "@tanstack/router-vite-plugin": "1.167.11",
@@ -3969,10 +3969,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/skribenten-web/frontend/package.json
+++ b/skribenten-web/frontend/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
     "@navikt/aksel-stylelint": "8.11.0",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "1.60.0",
     "@tanstack/react-query-devtools": "5.100.14",
     "@tanstack/react-router-devtools": "1.167.0",
     "@tanstack/router-vite-plugin": "1.167.11",
@@ -67,7 +67,8 @@
   },
   "overrides": {
     "openapi-typescript": {
-      "typescript": "$typescript"
+      "typescript": "$typescript",
+      "js-yaml": ">=4.2.0"
     }
   }
 }

--- a/skribenten-web/frontend/package.json
+++ b/skribenten-web/frontend/package.json
@@ -67,7 +67,9 @@
   },
   "overrides": {
     "openapi-typescript": {
-      "typescript": "$typescript",
+      "typescript": "$typescript"
+    },
+    "@redocly/openapi-core": {
       "js-yaml": "^4.2.0"
     }
   }

--- a/skribenten-web/frontend/package.json
+++ b/skribenten-web/frontend/package.json
@@ -68,7 +68,7 @@
   "overrides": {
     "openapi-typescript": {
       "typescript": "$typescript",
-      "js-yaml": ">=4.2.0"
+      "js-yaml": "^4.2.0"
     }
   }
 }


### PR DESCRIPTION
Må legge på overstyring på følgende avhengigheter for å få oppdatert sub-avhengighet:
- `@antora/content-aggregator`
- `@antora/playbook-builder`
- `@antora/ui-loader`
- `openapi-typescript`

For å ta i bruk sikret versjon av:
- `js-yaml@4.2.0`

Ref
https://github.com/navikt/pensjonsbrev/security/dependabot/325
https://github.com/navikt/pensjonsbrev/security/dependabot/326 