### PR TITLE
Avbrytar typst-kall når klienten koplar frå

### DIFF
--- a/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/typst/TypstCompileService.kt
+++ b/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/typst/TypstCompileService.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.brev.pdfbygger.typst
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runInterruptible
@@ -8,6 +9,8 @@ import no.nav.brev.brevbaker.PDFCompilationOutput
 import no.nav.pensjon.brev.pdfbygger.PDFCompilationResponse
 import org.slf4j.LoggerFactory
 import java.io.IOException
+import java.io.InterruptedIOException
+import java.nio.channels.ClosedByInterruptException
 import java.nio.file.Path
 
 
@@ -82,6 +85,9 @@ open class TypstCompileService(
                     Execution.Failure.Compilation(error = stderrContent)
                 }
             } catch (e: IOException) {
+                if (e is InterruptedIOException || e is ClosedByInterruptException) {
+                    throw CancellationException("Typst compile process was cancelled", e)
+                }
                 Execution.Failure.Execution(e)
             } finally {
                 process?.destroyForcibly()

--- a/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/typst/TypstCompileService.kt
+++ b/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/typst/TypstCompileService.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.brev.pdfbygger.typst
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import no.nav.brev.brevbaker.PDFCompilationOutput
 import no.nav.pensjon.brev.pdfbygger.PDFCompilationResponse
@@ -64,13 +65,13 @@ open class TypstCompileService(
                     .directory(templateDir.toFile())
                     .start()
 
-                process.outputStream.writer(Charsets.UTF_8).use { writeLetter(TypstFileWriter(it)) }
+                runInterruptible { process.outputStream.writer(Charsets.UTF_8).use { writeLetter(TypstFileWriter(it)) } }
 
-                val stdoutDeferred = async(Dispatchers.IO) { process.inputStream.readAllBytes() }
-                val stderrContent = String(process.errorStream.readAllBytes(), Charsets.UTF_8)
+                val stdoutDeferred = async(Dispatchers.IO) { runInterruptible { process.inputStream.readAllBytes() } }
+                val stderrContent = runInterruptible { String(process.errorStream.readAllBytes(), Charsets.UTF_8) }
                 val pdfBytes = stdoutDeferred.await()
 
-                val exitCode = process.waitFor()
+                val exitCode = runInterruptible { process.waitFor() }
 
                 if (exitCode == 0) {
                     if (stderrContent.isNotBlank()) {


### PR DESCRIPTION
Fleire av kalla mot process handterte ikkje at kallet/coroutinen vart kansellert, så når det skjedde, fekk vi unødig feil og feilmelding.