### PR TITLE
Viss brevet ikkje fins, returner som 404 not found

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/BrevmalService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/BrevmalService.kt
@@ -97,10 +97,10 @@ class BrevmalService(
     suspend fun getModelSpecification(brevkode: Brevkode.Redigerbart): TemplateModelSpecification? =
         brevbakerService.getModelSpecification(brevkode)
 
-    suspend fun getAlltidValgbareVedlegg(brevId: BrevId): List<ValgbartVedlegg> {
+    suspend fun getAlltidValgbareVedlegg(brevId: BrevId): List<ValgbartVedlegg>? {
         val spraakIBrevet = transaction {
-            BrevredigeringEntity.findById(brevId)?.spraak ?: throw IllegalStateException("Finner ikke brev med id $brevId")
-        }
+            BrevredigeringEntity.findById(brevId)?.spraak
+        } ?: return null
         return brevbakerService.getAlltidValgbareVedlegg(brevId).map {
             ValgbartVedlegg(
                 kode = it.kode,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/routes/SakBrev.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/routes/SakBrev.kt
@@ -298,7 +298,12 @@ fun Route.sakBrev(
 
             get("/alltidValgbareVedlegg") {
                 val brevId = call.parameters.brevId()
-                call.respond(brevmalService.getAlltidValgbareVedlegg(brevId))
+                val valgbareVedlegg = brevmalService.getAlltidValgbareVedlegg(brevId)
+                if (valgbareVedlegg != null) {
+                    call.respond(valgbareVedlegg)
+                } else {
+                    call.respond(HttpStatusCode.NotFound)
+                }
             }
         }
     }

--- a/skribenten-web/frontend/src/types/skribenten-api.ts
+++ b/skribenten-web/frontend/src/types/skribenten-api.ts
@@ -2114,6 +2114,12 @@ export interface paths {
                         "application/json": components["schemas"]["ValgbartVedlegg"][];
                     };
                 };
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
         };
         put?: never;


### PR DESCRIPTION
Gir meining, hindrar unødvendig feilmelding i loggane og er konsistens med korleis vi elles gjer det