### PR TITLE
Fiks håndering av generert nullable editedListType

### DIFF
--- a/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/common.ts
+++ b/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/common.ts
@@ -812,7 +812,7 @@ export function newItem({
 export function newItemList(args: {
   id?: Nullable<number>;
   listType?: ListType;
-  editedListType?: ListType;
+  editedListType?: ListType | null;
   items: Item[];
   deletedItems?: number[];
 }): ItemList {
@@ -821,7 +821,7 @@ export function newItemList(args: {
     parentId: null,
     type: "ITEM_LIST",
     listType: args.listType ?? ListType.PUNKTLISTE,
-    editedListType: args.editedListType,
+    editedListType: args.editedListType ?? undefined,
     items: args.items,
     deletedItems: args.deletedItems ?? [],
   };

--- a/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/toggleListType.ts
+++ b/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/toggleListType.ts
@@ -134,7 +134,7 @@ const mergeListWithAdjacentBlocks = (
   let blockIndex = initialBlockIndex;
 
   const currentBlock = blocks[blockIndex];
-  if (!currentBlock || currentBlock.type !== "PARAGRAPH") return;
+  if (currentBlock?.type !== "PARAGRAPH") return;
 
   const currentList = currentBlock.content[contentIndex];
   if (!isItemList(currentList) || effectiveListType(currentList) !== listType) return;

--- a/skribenten-web/frontend/src/types/skribenten-api.ts
+++ b/skribenten-web/frontend/src/types/skribenten-api.ts
@@ -3287,7 +3287,7 @@ export interface components {
         /** EditParagraphContentItemList */
         EditParagraphContentItemList: {
             deletedItems: number[];
-            editedListType?: components["schemas"]["Listetype"];
+            editedListType?: components["schemas"]["Listetype"] | null;
             id?: number | null;
             items: components["schemas"]["EditParagraphContentItemListItem"][];
             listType: components["schemas"]["Listetype"];


### PR DESCRIPTION
Fikk problemer med feilende deploy av skribenten-backend https://github.com/navikt/pensjonsbrev/actions/runs/29244153280 ved merge av PR #2910 (usikker på hvordan det glapp gjennom helt til deploy).

Legger til riktig håndtering av typen i frontend.