### PR TITLE
refactor(skribenten-backend): flytt getAlltidValgbareVedlegg til handler

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Dependencies.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Dependencies.kt
@@ -28,6 +28,7 @@ import no.nav.pensjon.brev.skribenten.brevredigering.application.usecases.SlettR
 import no.nav.pensjon.brev.skribenten.brevredigering.application.usecases.EndreValgteVedleggHandler
 import no.nav.pensjon.brev.skribenten.brevredigering.application.usecases.FrigiReservasjonHandler
 import no.nav.pensjon.brev.skribenten.brevredigering.application.usecases.TilbakestillBrevHandler
+import no.nav.pensjon.brev.skribenten.brevredigering.application.usecases.HentAlltidValgbareVedleggHandler
 import no.nav.pensjon.brev.skribenten.brevredigering.application.usecases.HentBrevAttesteringHandler
 import no.nav.pensjon.brev.skribenten.brevredigering.application.usecases.HentBrevHandler
 import no.nav.pensjon.brev.skribenten.brevredigering.application.usecases.OppdaterBrevHandler
@@ -123,6 +124,7 @@ fun Application.configureDependencies() {
         provide(EndreRedigertVedleggHandler::class)
         provide(EndreValgteVedleggHandler::class)
         provide(FrigiReservasjonHandler::class)
+        provide(HentAlltidValgbareVedleggHandler::class)
         provide(HentBrevAttesteringHandler::class)
         provide(HentBrevHandler::class)
         provide(HentEllerOpprettPdfHandler::class)

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevbaker/BrevbakerService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevbaker/BrevbakerService.kt
@@ -83,7 +83,7 @@ interface BrevbakerService {
 
     suspend fun getTemplates(): List<TemplateDescription.Redigerbar>?
     suspend fun getRedigerbarTemplate(brevkode: Brevkode.Redigerbart): TemplateDescription.Redigerbar?
-    suspend fun getAlltidValgbareVedlegg(brevId: BrevId): Set<AlltidValgbartVedleggBrevkode>
+    suspend fun getAlltidValgbareVedlegg(): Set<AlltidValgbartVedleggBrevkode>
 }
 
 class BrevbakerServiceHttp(config: OboClientConfig, authService: AuthService, val cache: Cache) : BrevbakerService, ServiceStatus, Closeable {
@@ -292,8 +292,8 @@ class BrevbakerServiceHttp(config: OboClientConfig, authService: AuthService, va
             }
         }
 
-    override suspend fun getAlltidValgbareVedlegg(brevId: BrevId): Set<AlltidValgbartVedleggBrevkode> =
-        cache.cached(Cacheomraade.ALLTID_VALGBARE_VEDLEGG, brevId) {
+    override suspend fun getAlltidValgbareVedlegg(): Set<AlltidValgbartVedleggBrevkode> =
+        cache.cached(Cacheomraade.ALLTID_VALGBARE_VEDLEGG, "alltidValgbareVedlegg") {
             val response = client.get("/letter/redigerbar/alltidValgbareVedlegg")
 
             if (response.status.isSuccess()) {
@@ -301,7 +301,7 @@ class BrevbakerServiceHttp(config: OboClientConfig, authService: AuthService, va
             } else {
                 throw BrevbakerServiceException(
                     response.bodyAsText().takeIf { it.isNotBlank() }
-                        ?: "Ukjent feil oppstod ved henting av alltid valgbare vedlegg for brev $brevId"
+                        ?: "Ukjent feil oppstod ved henting av alltid valgbare vedlegg for brev"
                 )
             }
         }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
@@ -1,15 +1,15 @@
 package no.nav.pensjon.brev.skribenten.brevredigering.application.usecases
 
-import no.nav.pensjon.brev.skribenten.brevbaker.BrevbakerService
 import no.nav.pensjon.brev.skribenten.brevredigering.domain.BrevredigeringEntity
 import no.nav.pensjon.brev.skribenten.common.Outcome
 import no.nav.pensjon.brev.skribenten.common.Outcome.Companion.success
+import no.nav.pensjon.brev.skribenten.fagsystem.BrevmalService
 import no.nav.pensjon.brev.skribenten.model.BrevId
 import no.nav.pensjon.brevbaker.api.model.LanguageCode
 import org.jetbrains.exposed.v1.jdbc.Database
 
 class HentAlltidValgbareVedleggHandler(
-    private val brevbakerService: BrevbakerService,
+    private val brevmalService: BrevmalService,
     database: Database,
 ) : TransactionHandler<HentAlltidValgbareVedleggHandler.Request, List<ValgbartVedlegg>, Nothing>(database) {
 
@@ -20,7 +20,7 @@ class HentAlltidValgbareVedleggHandler(
     override suspend fun execute(request: Request): Outcome<List<ValgbartVedlegg>, Nothing>? {
         val spraakIBrevet = BrevredigeringEntity.findById(request.brevId)?.spraak ?: return null
 
-        val vedlegg = brevbakerService.getAlltidValgbareVedlegg().map {
+        val vedlegg = brevmalService.getAlltidValgbareVedlegg().map {
             ValgbartVedlegg(
                 kode = it.kode,
                 visningstekst = it.visningstekst,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
@@ -11,22 +11,21 @@ import org.jetbrains.exposed.v1.jdbc.Database
 class HentAlltidValgbareVedleggHandler(
     private val brevbakerService: BrevbakerService,
     database: Database,
-) : PartlyTransactionHandler<HentAlltidValgbareVedleggHandler.Request, LanguageCode?, List<ValgbartVedlegg>, Nothing>(database) {
+) : TransactionHandler<HentAlltidValgbareVedleggHandler.Request, List<ValgbartVedlegg>, Nothing>(database) {
 
     data class Request(
         override val brevId: BrevId,
     ) : BrevredigeringRequest
 
-    override suspend fun execute(request: Request): Outcome<LanguageCode, Nothing>? =
-        BrevredigeringEntity.findById(request.brevId)?.spraak?.let { success(it) }
+    override suspend fun execute(request: Request): Outcome<List<ValgbartVedlegg>, Nothing>? {
+        val spraakIBrevet = BrevredigeringEntity.findById(request.brevId)?.spraak ?: return null
 
-    override suspend fun executeOutsideTransaction(request: Request, response: LanguageCode?): Outcome<List<ValgbartVedlegg>, Nothing> {
         val vedlegg = brevbakerService.getAlltidValgbareVedlegg(request.brevId).map {
             ValgbartVedlegg(
                 kode = it.kode,
                 visningstekst = it.visningstekst,
                 spraak = it.spraak,
-                tilgjengeligForSpraak = it.spraak.contains(response),
+                tilgjengeligForSpraak = it.spraak.contains(spraakIBrevet),
             )
         }.sortedBy { it.visningstekst }
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
@@ -1,0 +1,41 @@
+package no.nav.pensjon.brev.skribenten.brevredigering.application.usecases
+
+import no.nav.pensjon.brev.skribenten.brevbaker.BrevbakerService
+import no.nav.pensjon.brev.skribenten.brevredigering.domain.BrevredigeringEntity
+import no.nav.pensjon.brev.skribenten.common.Outcome
+import no.nav.pensjon.brev.skribenten.common.Outcome.Companion.success
+import no.nav.pensjon.brev.skribenten.model.BrevId
+import no.nav.pensjon.brevbaker.api.model.LanguageCode
+import org.jetbrains.exposed.v1.jdbc.Database
+
+class HentAlltidValgbareVedleggHandler(
+    private val brevbakerService: BrevbakerService,
+    database: Database,
+) : TransactionHandler<HentAlltidValgbareVedleggHandler.Request, List<ValgbartVedlegg>, Nothing>(database) {
+
+    data class Request(
+        override val brevId: BrevId,
+    ) : BrevredigeringRequest
+
+    override suspend fun execute(request: Request): Outcome<List<ValgbartVedlegg>, Nothing>? {
+        val spraakIBrevet = BrevredigeringEntity.findById(request.brevId)?.spraak ?: return null
+
+        val vedlegg = brevbakerService.getAlltidValgbareVedlegg(request.brevId).map {
+            ValgbartVedlegg(
+                kode = it.kode,
+                visningstekst = it.visningstekst,
+                spraak = it.spraak,
+                tilgjengeligForSpraak = it.spraak.contains(spraakIBrevet),
+            )
+        }.sortedBy { it.visningstekst }
+
+        return success(vedlegg)
+    }
+}
+
+data class ValgbartVedlegg(
+    val kode: String,
+    val visningstekst: String,
+    val spraak: Set<LanguageCode>,
+    val tilgjengeligForSpraak: Boolean,
+)

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
@@ -20,7 +20,7 @@ class HentAlltidValgbareVedleggHandler(
     override suspend fun execute(request: Request): Outcome<List<ValgbartVedlegg>, Nothing>? {
         val spraakIBrevet = BrevredigeringEntity.findById(request.brevId)?.spraak ?: return null
 
-        val vedlegg = brevbakerService.getAlltidValgbareVedlegg(request.brevId).map {
+        val vedlegg = brevbakerService.getAlltidValgbareVedlegg().map {
             ValgbartVedlegg(
                 kode = it.kode,
                 visningstekst = it.visningstekst,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandler.kt
@@ -11,21 +11,22 @@ import org.jetbrains.exposed.v1.jdbc.Database
 class HentAlltidValgbareVedleggHandler(
     private val brevbakerService: BrevbakerService,
     database: Database,
-) : TransactionHandler<HentAlltidValgbareVedleggHandler.Request, List<ValgbartVedlegg>, Nothing>(database) {
+) : PartlyTransactionHandler<HentAlltidValgbareVedleggHandler.Request, LanguageCode?, List<ValgbartVedlegg>, Nothing>(database) {
 
     data class Request(
         override val brevId: BrevId,
     ) : BrevredigeringRequest
 
-    override suspend fun execute(request: Request): Outcome<List<ValgbartVedlegg>, Nothing>? {
-        val spraakIBrevet = BrevredigeringEntity.findById(request.brevId)?.spraak ?: return null
+    override suspend fun execute(request: Request): Outcome<LanguageCode, Nothing>? =
+        BrevredigeringEntity.findById(request.brevId)?.spraak?.let { success(it) }
 
+    override suspend fun executeOutsideTransaction(request: Request, response: LanguageCode?): Outcome<List<ValgbartVedlegg>, Nothing> {
         val vedlegg = brevbakerService.getAlltidValgbareVedlegg(request.brevId).map {
             ValgbartVedlegg(
                 kode = it.kode,
                 visningstekst = it.visningstekst,
                 spraak = it.spraak,
-                tilgjengeligForSpraak = it.spraak.contains(spraakIBrevet),
+                tilgjengeligForSpraak = it.spraak.contains(response),
             )
         }.sortedBy { it.visningstekst }
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/UseCaseHandler.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/UseCaseHandler.kt
@@ -21,25 +21,6 @@ abstract class TransactionHandler<Request, Response, Error>(private val database
         }
 }
 
-abstract class PartlyTransactionHandler<Request, ResponseTransaction, Response, Error>(private val database: Database): UseCaseHandler<Request, Response, Error> {
-    abstract suspend fun execute(request: Request): Outcome<ResponseTransaction, Error>?
-    abstract suspend fun executeOutsideTransaction(request: Request, response: ResponseTransaction?): Outcome<Response, Error>?
-
-    suspend fun executeOutsideTransaction(request: Request, response: Outcome<ResponseTransaction, Error>?): Outcome<Response, Error>? = when (response) {
-        is Outcome.Success -> executeOutsideTransaction(request, response.value)
-        is Outcome.Failure -> response
-        null -> null
-    }
-
-    open fun transactionIsolation(): Int? = null
-    final override suspend fun invoke(request: Request): Outcome<Response, Error>? {
-        val transaction = isolatedTransaction(database = database, isolation = transactionIsolation()) {
-            execute(request)?.onError { rollback() }
-        }
-        return executeOutsideTransaction(request, transaction)
-    }
-}
-
 abstract class ReservertBrevHandler<Request : BrevredigeringRequest, Response>(
     private val database: Database,
     private val reserverBrev: ReserverBrevHandler,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/UseCaseHandler.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/UseCaseHandler.kt
@@ -21,6 +21,25 @@ abstract class TransactionHandler<Request, Response, Error>(private val database
         }
 }
 
+abstract class PartlyTransactionHandler<Request, ResponseTransaction, Response, Error>(private val database: Database): UseCaseHandler<Request, Response, Error> {
+    abstract suspend fun execute(request: Request): Outcome<ResponseTransaction, Error>?
+    abstract suspend fun executeOutsideTransaction(request: Request, response: ResponseTransaction?): Outcome<Response, Error>?
+
+    suspend fun executeOutsideTransaction(request: Request, response: Outcome<ResponseTransaction, Error>?): Outcome<Response, Error>? = when (response) {
+        is Outcome.Success -> executeOutsideTransaction(request, response.value)
+        is Outcome.Failure -> response
+        null -> null
+    }
+
+    open fun transactionIsolation(): Int? = null
+    final override suspend fun invoke(request: Request): Outcome<Response, Error>? {
+        val transaction = isolatedTransaction(database = database, isolation = transactionIsolation()) {
+            execute(request)?.onError { rollback() }
+        }
+        return executeOutsideTransaction(request, transaction)
+    }
+}
+
 abstract class ReservertBrevHandler<Request : BrevredigeringRequest, Response>(
     private val database: Database,
     private val reserverBrev: ReserverBrevHandler,

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/BrevmalService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/BrevmalService.kt
@@ -15,6 +15,7 @@ import no.nav.pensjon.brev.skribenten.fagsystem.pesys.PenClient
 import no.nav.pensjon.brev.skribenten.fagsystem.pesys.PenClient.KravStoettetAvDatabyggerResult
 import no.nav.pensjon.brev.skribenten.model.*
 import no.nav.pensjon.brev.skribenten.model.Sakstype
+import no.nav.pensjon.brevbaker.api.model.AlltidValgbartVedleggBrevkode
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.VedleggId
 import no.nav.pensjon.brevbaker.api.model.LanguageCode
 import no.nav.pensjon.brevbaker.api.model.LetterMarkup
@@ -87,6 +88,9 @@ class BrevmalService(
 
     suspend fun getModelSpecification(brevkode: Brevkode.Redigerbart): TemplateModelSpecification? =
         brevbakerService.getModelSpecification(brevkode)
+
+    suspend fun getAlltidValgbareVedlegg(): Set<AlltidValgbartVedleggBrevkode> =
+        brevbakerService.getAlltidValgbareVedlegg()
 
     suspend fun getTemplates(): List<TemplateDescription.Redigerbar>? =
         brevbakerService.getTemplates()

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/BrevmalService.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/fagsystem/BrevmalService.kt
@@ -7,7 +7,6 @@ import no.nav.pensjon.brev.api.model.TemplateDescription
 import no.nav.pensjon.brev.api.model.maler.Brevkode
 import no.nav.pensjon.brev.skribenten.brevbaker.BrevbakerService
 import no.nav.pensjon.brev.skribenten.brevredigering.domain.Brevredigering
-import no.nav.pensjon.brev.skribenten.brevredigering.domain.BrevredigeringEntity
 import no.nav.pensjon.brev.skribenten.common.GeneriskRedigerbarBrevdata
 import no.nav.pensjon.brev.skribenten.fagsystem.pesys.BrevdataDto
 import no.nav.pensjon.brev.skribenten.fagsystem.pesys.BrevdataResponse
@@ -22,17 +21,9 @@ import no.nav.pensjon.brevbaker.api.model.LetterMarkup
 import no.nav.pensjon.brevbaker.api.model.LetterMarkupWithDataUsage
 import no.nav.pensjon.brevbaker.api.model.RedigerbareVedleggTitler
 import no.nav.pensjon.brevbaker.api.model.TemplateModelSpecification
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.slf4j.LoggerFactory
 
 private val ekskluderteBrev = hashSetOf("PE_IY_05_301", "PE_BA_01_108", "PE_GP_01_010", "PE_AP_04_922", "PE_IY_03_169")
-
-data class ValgbartVedlegg(
-    val kode: String,
-    val visningstekst: String,
-    val spraak: Set<LanguageCode>,
-    val tilgjengeligForSpraak: Boolean,
-)
 
 class BrevmalService(
     private val brevbakerService: BrevbakerService,
@@ -96,20 +87,6 @@ class BrevmalService(
 
     suspend fun getModelSpecification(brevkode: Brevkode.Redigerbart): TemplateModelSpecification? =
         brevbakerService.getModelSpecification(brevkode)
-
-    suspend fun getAlltidValgbareVedlegg(brevId: BrevId): List<ValgbartVedlegg>? {
-        val spraakIBrevet = transaction {
-            BrevredigeringEntity.findById(brevId)?.spraak
-        } ?: return null
-        return brevbakerService.getAlltidValgbareVedlegg(brevId).map {
-            ValgbartVedlegg(
-                kode = it.kode,
-                visningstekst = it.visningstekst,
-                spraak = it.spraak,
-                tilgjengeligForSpraak = it.spraak.contains(spraakIBrevet),
-            )
-        }.sortedBy { it.visningstekst }
-    }
 
     suspend fun getTemplates(): List<TemplateDescription.Redigerbar>? =
         brevbakerService.getTemplates()

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/routes/SakBrev.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/routes/SakBrev.kt
@@ -10,7 +10,6 @@ import io.ktor.server.routing.*
 import no.nav.pensjon.brev.skribenten.auth.SakKey
 import no.nav.pensjon.brev.skribenten.brevredigering.application.HentBrevInfoService
 import no.nav.pensjon.brev.skribenten.brevredigering.application.usecases.*
-import no.nav.pensjon.brev.skribenten.fagsystem.BrevmalService
 import no.nav.pensjon.brev.skribenten.fagsystem.Fagsak
 import no.nav.pensjon.brev.skribenten.fagsystem.pesys.SpraakKode
 import no.nav.pensjon.brev.skribenten.model.Api
@@ -21,7 +20,6 @@ import no.nav.pensjon.brevbaker.api.model.LanguageCode
 context(app: Application)
 fun Route.sakBrev() =
     route("/brev") {
-        val brevmalService: BrevmalService by app.dependencies
         val dto2ApiService: Dto2ApiService by app.dependencies
         val hentBrevInfoService: HentBrevInfoService by app.dependencies
 
@@ -316,14 +314,15 @@ fun Route.sakBrev() =
                 }
             }
 
+            val hentAlltidValgbareVedlegg: HentAlltidValgbareVedleggHandler by app.dependencies
             get("/alltidValgbareVedlegg") {
                 val brevId = call.parameters.brevId()
-                val valgbareVedlegg = brevmalService.getAlltidValgbareVedlegg(brevId)
-                if (valgbareVedlegg != null) {
-                    call.respond(valgbareVedlegg)
-                } else {
-                    call.respond(HttpStatusCode.NotFound)
-                }
+
+                val result = hentAlltidValgbareVedlegg(
+                    HentAlltidValgbareVedleggHandler.Request(brevId = brevId)
+                )
+
+                respondOutcome(dto2ApiService, result) { respond(it) }
             }
         }
     }

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/BrevredigeringHandlerTestBase.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/BrevredigeringHandlerTestBase.kt
@@ -63,6 +63,7 @@ abstract class BrevredigeringHandlerTestBase {
         brevbakerService.redigerbareMaler[Testbrevkoder.INFORMASJONSBREV] = informasjonsbrev
         brevbakerService.redigerbareMaler[Testbrevkoder.VEDTAKSBREV] = vedtaksbrev
         brevbakerService.redigerbareMaler[Testbrevkoder.VARSELBREV] = varselbrevIVedtakskontekst
+        brevbakerService.alltidValgbareVedleggResultat = emptyList()
         stagePdf(stagetPDF)
 
         penService.pesysBrevdata = brevdataResponseData
@@ -532,6 +533,7 @@ abstract class BrevredigeringHandlerTestBase {
         lateinit var renderMarkupResultat: suspend ((f: BrevbakerFelles) -> LetterMarkup)
         lateinit var renderPdfResultat: LetterResponse
         var modelSpecificationResultat: TemplateModelSpecification? = null
+        var alltidValgbareVedleggResultat: List<AlltidValgbartVedleggBrevkode> = emptyList()
         override var redigerbareMaler: MutableMap<RedigerbarBrevkode, TemplateDescription.Redigerbar> = mutableMapOf()
         val renderMarkupKall = mutableListOf<Pair<Brevkode.Redigerbart, LanguageCode>>()
         val renderPdfKall = mutableListOf<LetterMarkup>()
@@ -563,7 +565,7 @@ abstract class BrevredigeringHandlerTestBase {
         }
 
         override suspend fun getRedigerbarTemplate(brevkode: Brevkode.Redigerbart) = redigerbareMaler[brevkode]
-        override suspend fun getAlltidValgbareVedlegg(brevId: BrevId) = notYetStubbed()
+        override suspend fun getAlltidValgbareVedlegg(brevId: BrevId) = alltidValgbareVedleggResultat
 
         override suspend fun hentRedigerbareVedleggTitler(
             brevkode: Brevkode.Redigerbart,

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/BrevredigeringHandlerTestBase.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/BrevredigeringHandlerTestBase.kt
@@ -63,7 +63,7 @@ abstract class BrevredigeringHandlerTestBase {
         brevbakerService.redigerbareMaler[Testbrevkoder.INFORMASJONSBREV] = informasjonsbrev
         brevbakerService.redigerbareMaler[Testbrevkoder.VEDTAKSBREV] = vedtaksbrev
         brevbakerService.redigerbareMaler[Testbrevkoder.VARSELBREV] = varselbrevIVedtakskontekst
-        brevbakerService.alltidValgbareVedleggResultat = emptyList()
+        brevbakerService.alltidValgbareVedleggResultat = emptySet()
         stagePdf(stagetPDF)
 
         penService.pesysBrevdata = brevdataResponseData
@@ -533,7 +533,7 @@ abstract class BrevredigeringHandlerTestBase {
         lateinit var renderMarkupResultat: suspend ((f: BrevbakerFelles) -> LetterMarkup)
         lateinit var renderPdfResultat: LetterResponse
         var modelSpecificationResultat: TemplateModelSpecification? = null
-        var alltidValgbareVedleggResultat: List<AlltidValgbartVedleggBrevkode> = emptyList()
+        var alltidValgbareVedleggResultat: Set<AlltidValgbartVedleggBrevkode> = emptySet()
         override var redigerbareMaler: MutableMap<RedigerbarBrevkode, TemplateDescription.Redigerbar> = mutableMapOf()
         val renderMarkupKall = mutableListOf<Pair<Brevkode.Redigerbart, LanguageCode>>()
         val renderPdfKall = mutableListOf<LetterMarkup>()

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/BrevredigeringHandlerTestBase.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/BrevredigeringHandlerTestBase.kt
@@ -565,7 +565,7 @@ abstract class BrevredigeringHandlerTestBase {
         }
 
         override suspend fun getRedigerbarTemplate(brevkode: Brevkode.Redigerbart) = redigerbareMaler[brevkode]
-        override suspend fun getAlltidValgbareVedlegg(brevId: BrevId) = alltidValgbareVedleggResultat
+        override suspend fun getAlltidValgbareVedlegg() = alltidValgbareVedleggResultat
 
         override suspend fun hentRedigerbareVedleggTitler(
             brevkode: Brevkode.Redigerbart,

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandlerTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandlerTest.kt
@@ -13,7 +13,7 @@ class HentAlltidValgbareVedleggHandlerTest : BrevredigeringHandlerTestBase() {
     @Test
     suspend fun `henter alltid valgbare vedlegg sortert med spraaktilgjengelighet`() {
         val brev = opprettBrev().resultOrFail()
-        brevbakerService.alltidValgbareVedleggResultat = listOf(
+        brevbakerService.alltidValgbareVedleggResultat = setOf(
             AlltidValgbartVedleggBrevkode("kode-2", "B vedlegg", setOf(LanguageCode.ENGLISH)),
             AlltidValgbartVedleggBrevkode("kode-1", "A vedlegg", setOf(LanguageCode.BOKMAL)),
             AlltidValgbartVedleggBrevkode("kode-3", "C vedlegg", setOf(LanguageCode.BOKMAL, LanguageCode.ENGLISH)),

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandlerTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandlerTest.kt
@@ -1,0 +1,30 @@
+package no.nav.pensjon.brev.skribenten.brevredigering.application.usecases
+
+import no.nav.pensjon.brev.skribenten.SharedPostgres
+import no.nav.pensjon.brev.skribenten.isSuccess
+import no.nav.pensjon.brevbaker.api.model.AlltidValgbartVedleggBrevkode
+import no.nav.pensjon.brevbaker.api.model.LanguageCode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class HentAlltidValgbareVedleggHandlerTest : BrevredigeringHandlerTestBase() {
+    private val handler by lazy { HentAlltidValgbareVedleggHandler(brevbakerService, SharedPostgres.database) }
+
+    @Test
+    suspend fun `henter alltid valgbare vedlegg sortert med spraaktilgjengelighet`() {
+        val brev = opprettBrev().resultOrFail()
+        brevbakerService.alltidValgbareVedleggResultat = listOf(
+            AlltidValgbartVedleggBrevkode("kode-2", "B vedlegg", setOf(LanguageCode.ENGLISH)),
+            AlltidValgbartVedleggBrevkode("kode-1", "A vedlegg", setOf(LanguageCode.BOKMAL)),
+            AlltidValgbartVedleggBrevkode("kode-3", "C vedlegg", setOf(LanguageCode.BOKMAL, LanguageCode.ENGLISH)),
+        )
+
+        assertThat(handler(HentAlltidValgbareVedleggHandler.Request(brev.info.id))).isSuccess {
+            assertThat(it).containsExactly(
+                ValgbartVedlegg("kode-1", "A vedlegg", setOf(LanguageCode.BOKMAL), false),
+                ValgbartVedlegg("kode-2", "B vedlegg", setOf(LanguageCode.ENGLISH), true),
+                ValgbartVedlegg("kode-3", "C vedlegg", setOf(LanguageCode.BOKMAL, LanguageCode.ENGLISH), true),
+            )
+        }
+    }
+}

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandlerTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/HentAlltidValgbareVedleggHandlerTest.kt
@@ -8,7 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class HentAlltidValgbareVedleggHandlerTest : BrevredigeringHandlerTestBase() {
-    private val handler by lazy { HentAlltidValgbareVedleggHandler(brevbakerService, SharedPostgres.database) }
+    private val handler by lazy { HentAlltidValgbareVedleggHandler(brevmalService, SharedPostgres.database) }
 
     @Test
     suspend fun `henter alltid valgbare vedlegg sortert med spraaktilgjengelighet`() {

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/FakeServices.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/FakeServices.kt
@@ -86,7 +86,7 @@ open class FakeBrevbakerService(
     override suspend fun getTemplates() = maler
 
     override suspend fun getRedigerbarTemplate(brevkode: Brevkode.Redigerbart) = redigerbareMaler[brevkode]
-    override suspend fun getAlltidValgbareVedlegg(brevId: BrevId): Set<AlltidValgbartVedleggBrevkode> = notYetStubbed()
+    override suspend fun getAlltidValgbareVedlegg(): Set<AlltidValgbartVedleggBrevkode> = notYetStubbed()
 
     override suspend fun getModelSpecification(brevkode: Brevkode.Redigerbart): TemplateModelSpecification? = notYetStubbed()
     override suspend fun renderMarkup(

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/FakeServices.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/services/FakeServices.kt
@@ -86,7 +86,7 @@ open class FakeBrevbakerService(
     override suspend fun getTemplates() = maler
 
     override suspend fun getRedigerbarTemplate(brevkode: Brevkode.Redigerbart) = redigerbareMaler[brevkode]
-    override suspend fun getAlltidValgbareVedlegg(brevId: BrevId) = notYetStubbed()
+    override suspend fun getAlltidValgbareVedlegg(brevId: BrevId): Set<AlltidValgbartVedleggBrevkode> = notYetStubbed()
 
     override suspend fun getModelSpecification(brevkode: Brevkode.Redigerbart): TemplateModelSpecification? = notYetStubbed()
     override suspend fun renderMarkup(

--- a/skribenten-web/frontend/src/types/skribenten-api.ts
+++ b/skribenten-web/frontend/src/types/skribenten-api.ts
@@ -2170,11 +2170,53 @@ export interface paths {
                         "application/json": components["schemas"]["ValgbartVedlegg"][];
                     };
                 };
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
                 404: {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BrevExceptionDto"];
+                    };
+                };
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BrevExceptionDto"];
+                    };
+                };
+                423: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
                 };
             };
         };


### PR DESCRIPTION
Konverterer BrevmalService.getAlltidValgbareVedlegg til HentAlltidValgbareVedleggHandler etter samme mønster som de andre brevredigering-handlerne (TransactionHandler). Ruten i SakBrev.kt bruker nå respondOutcome i stedet for manuell null-sjekk.