### PR TITLE
Ny ktlint-regel: hindre ikke-deterministiske verdier i Expression-literaler (stableHashCode)

### DIFF
--- a/brevbaker/dsl/api/dsl.api
+++ b/brevbaker/dsl/api/dsl.api
@@ -1019,6 +1019,13 @@ public final class no/nav/pensjon/brev/template/UnaryOperation$IsEmpty : no/nav/
 	public fun stableHashCode ()I
 }
 
+public final class no/nav/pensjon/brev/template/UnaryOperation$LocalDateNow : no/nav/pensjon/brev/template/UnaryOperation, no/nav/pensjon/brev/template/StableHash {
+	public static final field INSTANCE Lno/nav/pensjon/brev/template/UnaryOperation$LocalDateNow;
+	public synthetic fun apply (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun apply (Lkotlin/Unit;)Ljava/time/LocalDate;
+	public fun stableHashCode ()I
+}
+
 public final class no/nav/pensjon/brev/template/UnaryOperation$MapCollection : no/nav/pensjon/brev/template/UnaryOperation {
 	public synthetic fun apply (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun apply (Ljava/util/Collection;)Ljava/util/Collection;
@@ -1471,6 +1478,7 @@ public final class no/nav/pensjon/brev/template/dsl/expression/DateKt {
 	public static final fun getDay (Lno/nav/pensjon/brev/template/Expression;)Lno/nav/pensjon/brev/template/Expression;
 	public static final fun getFirstDayOfYear (Lno/nav/pensjon/brev/template/Expression;)Lno/nav/pensjon/brev/template/Expression;
 	public static final fun getLastDayOfYear (Lno/nav/pensjon/brev/template/Expression;)Lno/nav/pensjon/brev/template/Expression;
+	public static final fun getLocalDateNow ()Lno/nav/pensjon/brev/template/Expression;
 	public static final fun getMonth (Lno/nav/pensjon/brev/template/Expression;)Lno/nav/pensjon/brev/template/Expression;
 	public static final fun getYear (Lno/nav/pensjon/brev/template/Expression;)Lno/nav/pensjon/brev/template/Expression;
 }

--- a/brevbaker/dsl/src/main/kotlin/no/nav/pensjon/brev/template/Operations.kt
+++ b/brevbaker/dsl/src/main/kotlin/no/nav/pensjon/brev/template/Operations.kt
@@ -6,6 +6,7 @@ import no.nav.pensjon.brev.api.model.FeatureToggle
 import no.nav.pensjon.brev.api.model.FeatureToggleSingleton
 import no.nav.pensjon.brev.template.expression.ExpressionMapper
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Kroner
+import java.time.LocalDate
 import java.util.Objects
 import kotlin.math.absoluteValue
 
@@ -50,6 +51,10 @@ sealed class UnaryOperation<In, out Out> : Operation() {
     @BrevbakerDSLInternal
     object Fritekst : UnaryOperation<String, String>(), StableHash by StableHash.of("UnaryOperation.Fritekst") {
         override fun apply(input: String): String = input
+    }
+
+    object LocalDateNow : UnaryOperation<Unit, LocalDate>(), StableHash by StableHash.of("UnaryOperation.LocalDateNow") {
+        override fun apply(input: Unit): LocalDate = LocalDate.now()
     }
 
     @BrevbakerDSLInternal

--- a/brevbaker/dsl/src/main/kotlin/no/nav/pensjon/brev/template/dsl/expression/Date.kt
+++ b/brevbaker/dsl/src/main/kotlin/no/nav/pensjon/brev/template/dsl/expression/Date.kt
@@ -56,6 +56,7 @@ private object LocalDateSelectors {
 
 }
 
+val localDateNow: Expression<LocalDate> = UnaryOperation.LocalDateNow(Unit.expr())
 
 val Expression<LocalDate>.year: Expression<Int>
     get() = select(LocalDateSelectors.yearSelector)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
@@ -49,8 +50,19 @@ allprojects {
 
 subprojects {
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    // Version of the ktlint engine itself; declared once in gradle/libs.versions.toml so that both this
+    // KtlintExtension config and the :ktlint-rules module's dependencies stay in sync.
+    val ktlintEngineVersion =
+        rootProject.extensions
+            .getByType<VersionCatalogsExtension>()
+            .named("libs")
+            .findVersion("ktlintEngineVersion")
+            .get()
+            .requiredVersion
+
     configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
-        version.set("1.8.0")
+        version.set(ktlintEngineVersion)
         outputToConsole.set(true)
         reporters {
             reporter(ReporterType.JSON)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,13 @@ subprojects {
             }
         }
     }
+    // Custom rules (e.g. requiring compile-time constant arguments to `ifNull`), see :ktlint-rules.
+    // Excluded from the module itself to avoid a self-dependency.
+    if (path != ":ktlint-rules") {
+        dependencies {
+            "ktlintRuleset"(project(":ktlint-rules"))
+        }
+    }
 
     tasks {
         register<Test>("integrationTest") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,10 +18,12 @@ jupiterVersion = "6.1.1"
 kotlinxHtmlVersion = "0.12.0"
 kotlinxCoroutinesVersion = "1.11.0"
 ktlintVersion = "14.2.0"
+ktlintEngineVersion = "1.8.0"
 log4j2Version = "2.26.1"
 micrometerVersion = "1.17.0"
 pdfboxVersion = "3.0.7"
 postgresqlVersion = "42.7.12"
+slf4jVersion = "2.0.18"
 testcontainersCoreVersion = "2.0.5"
 testcontainersPostgresqlVersion = "2.0.5"
 unleashVersion = "12.2.2"
@@ -56,6 +58,12 @@ pdfbox = { module = "org.apache.pdfbox:pdfbox", version.ref = "pdfboxVersion" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresqlVersion" }
 unleash = { module = "io.getunleash:unleash-client-java", version.ref = "unleashVersion" }
 valkey = { module = "io.valkey:valkey-java", version.ref = "valkeyVersion" }
+
+# Ktlint (custom rules, see :ktlint-rules)
+ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlintEngineVersion" }
+ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlintEngineVersion" }
+ktlint-test = { module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlintEngineVersion" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4jVersion" }
 
 # Ktor
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktorVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ log4j2Version = "2.26.1"
 micrometerVersion = "1.17.0"
 pdfboxVersion = "3.0.7"
 postgresqlVersion = "42.7.12"
-slf4jVersion = "2.0.18"
 testcontainersCoreVersion = "2.0.5"
 testcontainersPostgresqlVersion = "2.0.5"
 unleashVersion = "12.2.2"
@@ -63,7 +62,6 @@ valkey = { module = "io.valkey:valkey-java", version.ref = "valkeyVersion" }
 ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlintEngineVersion" }
 ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlintEngineVersion" }
 ktlint-test = { module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlintEngineVersion" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4jVersion" }
 
 # Ktor
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktorVersion" }

--- a/ktlint-rules/build.gradle.kts
+++ b/ktlint-rules/build.gradle.kts
@@ -2,9 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 val javaTarget: String by System.getProperties()
 
-// Version of the ktlint engine itself, must match `version.set(...)` in the root build.gradle.kts KtlintExtension config.
-val ktlintEngineVersion = "1.8.0"
-
 plugins {
     kotlin("jvm")
 }
@@ -16,12 +13,12 @@ kotlin {
 }
 
 dependencies {
-    implementation("com.pinterest.ktlint:ktlint-cli-ruleset-core:$ktlintEngineVersion")
-    implementation("com.pinterest.ktlint:ktlint-rule-engine-core:$ktlintEngineVersion")
+    implementation(libs.ktlint.cli.ruleset.core)
+    implementation(libs.ktlint.rule.engine.core)
 
     testImplementation(libs.bundles.junit)
-    testImplementation("com.pinterest.ktlint:ktlint-test:$ktlintEngineVersion")
-    testRuntimeOnly("org.slf4j:slf4j-simple:2.0.18")
+    testImplementation(libs.ktlint.test)
+    testRuntimeOnly(libs.slf4j.simple)
 }
 
 tasks {

--- a/ktlint-rules/build.gradle.kts
+++ b/ktlint-rules/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
     testImplementation(libs.bundles.junit)
     testImplementation(libs.ktlint.test)
-    testRuntimeOnly(libs.slf4j.simple)
+    testImplementation(libs.log4j.slf4j2.impl)
 }
 
 tasks {

--- a/ktlint-rules/build.gradle.kts
+++ b/ktlint-rules/build.gradle.kts
@@ -1,0 +1,31 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+val javaTarget: String by System.getProperties()
+
+// Version of the ktlint engine itself, must match `version.set(...)` in the root build.gradle.kts KtlintExtension config.
+val ktlintEngineVersion = "1.8.0"
+
+plugins {
+    kotlin("jvm")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(javaTarget))
+    }
+}
+
+dependencies {
+    implementation("com.pinterest.ktlint:ktlint-cli-ruleset-core:$ktlintEngineVersion")
+    implementation("com.pinterest.ktlint:ktlint-rule-engine-core:$ktlintEngineVersion")
+
+    testImplementation(libs.bundles.junit)
+    testImplementation("com.pinterest.ktlint:ktlint-test:$ktlintEngineVersion")
+    testRuntimeOnly("org.slf4j:slf4j-simple:2.0.18")
+}
+
+tasks {
+    test {
+        useJUnitPlatform()
+    }
+}

--- a/ktlint-rules/src/main/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRule.kt
+++ b/ktlint-rules/src/main/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRule.kt
@@ -1,0 +1,188 @@
+package no.nav.pensjon.brev.ktlint
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT_QUALIFIED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_DIRECTIVE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.rule.engine.core.api.KtlintKotlinCompiler
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+
+/**
+ * Flags DSL calls that can bake a non-deterministic value (e.g. `LocalDate.now()`) into the `Expression` tree:
+ *
+ * - `Expression<T?>.ifNull(then)` - the `then` fallback.
+ * - `ifElse(condition, ifTrue, ifFalse)` - all three arguments, including `condition`.
+ *
+ * Background: `stableHashCode` is computed over the whole `Expression` tree (including its `condition`/branch
+ * sub-expressions), which brevbaker relies on to detect whether a rendered letter's content changed. A fallback,
+ * branch, or condition such as `.ifNull(LocalDate.now())` or `ifElse(date.equalTo(LocalDate.now()), a, b)` makes that
+ * hash change every day even though nothing about the letter template itself changed. These arguments must evaluate
+ * to the same value on every evaluation - i.e. effectively a compile-time constant (literal, enum constant, or a
+ * constructor/function call built purely from such constants).
+ *
+ * If you actually need "today's date" inside a template, use `no.nav.pensjon.brev.template.dsl.expression.localDateNow`
+ * instead of `LocalDate.now()`: it is a dedicated `Expression<LocalDate>` (`UnaryOperation.LocalDateNow`) whose
+ * `stableHashCode` is a fixed constant - the current date is only resolved when the expression is evaluated, not
+ * baked into the tree, so it doesn't destabilize the hash. When the whole argument is exactly `LocalDate.now()` (or
+ * `LocalDate.now().expr()`), this rule can auto-correct it to `localDateNow`.
+ *
+ * Note this is a syntactic (AST-only) check, not full compile-time constant evaluation: it does not verify that
+ * `val`/`var` references used as arguments are themselves constant. It specifically targets calls to known volatile/
+ * non-deterministic functions (clock/random sources), which is the failure mode this rule was introduced to prevent.
+ */
+class NoNonDeterministicExpressionLiteralRule :
+    Rule(
+        ruleId = RuleId("$PENSJONSBREV_RULE_SET_ID:no-nondeterministic-expression-literal"),
+        about =
+            About(
+                maintainer = "pensjonsbrev",
+                repositoryUrl = "https://github.com/navikt/pensjonsbrev",
+                issueTrackerUrl = "https://github.com/navikt/pensjonsbrev/issues",
+            ),
+    ),
+    RuleAutocorrectApproveHandler {
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        if (node.elementType != CALL_EXPRESSION) return
+        val calleeName = node.findChildByType(REFERENCE_EXPRESSION)?.text ?: return
+        val valueArgumentList = node.findChildByType(VALUE_ARGUMENT_LIST) ?: return
+        val valueArguments = valueArgumentList.getChildren(null).filter { it.elementType == VALUE_ARGUMENT }
+
+        val argumentsToCheck =
+            when (calleeName) {
+                // `<receiver>.ifNull(then)`, not some unrelated local function also named `ifNull`.
+                "ifNull" -> {
+                    if (node.treeParent?.elementType != DOT_QUALIFIED_EXPRESSION) return
+                    valueArguments
+                }
+                // `ifElse(condition, ifTrue, ifFalse)`: check every argument, `condition` included, since it is
+                // also part of the `Expression` tree that `stableHashCode` is computed over.
+                "ifElse" -> valueArguments
+                else -> return
+            }
+
+        for (argument in argumentsToCheck) {
+            val offendingCallName = findNonDeterministicCall(argument) ?: continue
+            val valueExpression = argument.valueExpression()
+
+            if (offendingCallName == "now" && valueExpression?.text in LOCAL_DATE_NOW_REPLACEABLE_TEXTS) {
+                emit(
+                    valueExpression!!.startOffset,
+                    "$calleeName(...) argument calls 'LocalDate.now()', which changes stableHashCode every day even " +
+                        "though the template didn't change. Use " +
+                        "'no.nav.pensjon.brev.template.dsl.expression.localDateNow' instead: it resolves the date " +
+                        "when the expression is evaluated, instead of baking it into the expression tree.",
+                    true,
+                ).ifAutocorrectAllowed {
+                    createLocalDateNowNode()?.let { replacement ->
+                        valueExpression.treeParent.replaceChild(valueExpression, replacement)
+                        replacement.addImportIfMissing(LOCAL_DATE_NOW_IMPORT)
+                    }
+                }
+            } else {
+                emit(
+                    argument.startOffset,
+                    "$calleeName(...) argument must be a compile-time constant, but calls non-deterministic " +
+                        "'$offendingCallName()'. This makes stableHashCode change over time even though the " +
+                        "template didn't change. Use a fixed literal/constant value instead.",
+                    false,
+                )
+            }
+        }
+    }
+
+    /** The actual expression content of a value argument, e.g. skipping the `then =` part of a named argument. */
+    private fun ASTNode.valueExpression(): ASTNode? =
+        getChildren(null).lastOrNull { it.elementType != WHITE_SPACE }
+
+    private fun createLocalDateNowNode(): ASTNode? =
+        KtlintKotlinCompiler
+            .createASTNodeFromText("localDateNow")
+            ?.findChildByType(REFERENCE_EXPRESSION)
+
+    /** Adds `import [importPath]` to this node's file, unless it is already imported (e.g. via this exact import). */
+    private fun ASTNode.addImportIfMissing(importPath: String) {
+        val fileNode = generateSequence(this) { it.treeParent }.last()
+        val importList = fileNode.findChildByType(IMPORT_LIST) ?: return
+        val importText = "import $importPath"
+        val alreadyImported =
+            importList
+                .getChildren(null)
+                .any { it.elementType == IMPORT_DIRECTIVE && it.text.trim() == importText }
+        if (alreadyImported) return
+
+        val newImportDirective =
+            KtlintKotlinCompiler
+                .createPsiFileFromText("Import.kt", "$importText\n")
+                .node
+                .findChildByType(IMPORT_LIST)
+                ?.findChildByType(IMPORT_DIRECTIVE)
+                ?: return
+
+        if (importList.getChildren(null).any { it.elementType == IMPORT_DIRECTIVE }) {
+            importList.addChild(PsiWhiteSpaceImpl("\n"), null)
+        }
+        importList.addChild(newImportDirective, null)
+
+        // The whitespace separating the import list from the rest of the file is a sibling of the import list
+        // itself (not a child), and only exists once there is something to separate.
+        val nextSibling = importList.treeNext
+        if (nextSibling == null || nextSibling.elementType != WHITE_SPACE || !nextSibling.text.contains("\n")) {
+            fileNode.addChild(PsiWhiteSpaceImpl("\n"), nextSibling)
+        }
+    }
+
+    private fun findNonDeterministicCall(node: ASTNode): String? {
+        if (node.elementType == CALL_EXPRESSION) {
+            val calleeName = node.findChildByType(REFERENCE_EXPRESSION)?.text
+            if (calleeName != null && calleeName in NON_DETERMINISTIC_CALL_NAMES) {
+                return calleeName
+            }
+        }
+        for (child in node.getChildren(null)) {
+            findNonDeterministicCall(child)?.let { return it }
+        }
+        return null
+    }
+
+    private companion object {
+        // Names of functions that return a different value on every call, commonly used (accidentally) as ifNull
+        // fallbacks or ifElse branches: java.time `now()`/`today()`-style factories, and clock/random sources.
+        val NON_DETERMINISTIC_CALL_NAMES: Set<String> =
+            setOf(
+                "now",
+                "today",
+                "currentTimeMillis",
+                "nanoTime",
+                "randomUUID",
+                "nextInt",
+                "nextLong",
+                "nextDouble",
+                "nextFloat",
+                "nextBoolean",
+                "nextBytes",
+            )
+
+        // Textual shapes of an argument that are safely & unambiguously auto-correctable to `localDateNow`.
+        val LOCAL_DATE_NOW_REPLACEABLE_TEXTS: Set<String> =
+            setOf(
+                "LocalDate.now()",
+                "LocalDate.now().expr()",
+            )
+
+        const val LOCAL_DATE_NOW_IMPORT = "no.nav.pensjon.brev.template.dsl.expression.localDateNow"
+    }
+}

--- a/ktlint-rules/src/main/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRule.kt
+++ b/ktlint-rules/src/main/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRule.kt
@@ -118,10 +118,14 @@ class NoNonDeterministicExpressionLiteralRule :
         val fileNode = generateSequence(this) { it.treeParent }.last()
         val importList = fileNode.findChildByType(IMPORT_LIST) ?: return
         val importText = "import $importPath"
+        val wildcardImportText = "import ${importPath.substringBeforeLast('.')}.*"
         val alreadyImported =
             importList
                 .getChildren(null)
-                .any { it.elementType == IMPORT_DIRECTIVE && it.text.trim() == importText }
+                .any {
+                    it.elementType == IMPORT_DIRECTIVE &&
+                        (it.text.trim() == importText || it.text.trim() == wildcardImportText)
+                }
         if (alreadyImported) return
 
         val newImportDirective =

--- a/ktlint-rules/src/main/kotlin/no/nav/pensjon/brev/ktlint/PensjonsbrevRuleSetProvider.kt
+++ b/ktlint-rules/src/main/kotlin/no/nav/pensjon/brev/ktlint/PensjonsbrevRuleSetProvider.kt
@@ -1,0 +1,18 @@
+package no.nav.pensjon.brev.ktlint
+
+import com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
+
+internal const val PENSJONSBREV_RULE_SET_ID = "pensjonsbrev"
+
+/**
+ * Registers custom ktlint rules for this repository. Discovered by ktlint via
+ * `META-INF/services/com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3`.
+ */
+class PensjonsbrevRuleSetProvider : RuleSetProviderV3(RuleSetId(PENSJONSBREV_RULE_SET_ID)) {
+    override fun getRuleProviders(): Set<RuleProvider> =
+        setOf(
+            RuleProvider { NoNonDeterministicExpressionLiteralRule() },
+        )
+}

--- a/ktlint-rules/src/main/resources/META-INF/services/com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
+++ b/ktlint-rules/src/main/resources/META-INF/services/com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
@@ -1,0 +1,1 @@
+no.nav.pensjon.brev.ktlint.PensjonsbrevRuleSetProvider

--- a/ktlint-rules/src/test/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRuleTest.kt
+++ b/ktlint-rules/src/test/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRuleTest.kt
@@ -1,0 +1,230 @@
+package no.nav.pensjon.brev.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import org.junit.jupiter.api.Test
+
+class NoNonDeterministicExpressionLiteralRuleTest {
+    private val ruleAssertThat = assertThatRule { NoNonDeterministicExpressionLiteralRule() }
+
+    @Test
+    fun `flags LocalDate now as ifNull fallback with a specific message and auto-corrects it to localDateNow`() {
+        val code =
+            """
+            val a = x.ifNull(LocalDate.now())
+            """.trimIndent()
+        val formattedCode =
+            """
+            import no.nav.pensjon.brev.template.dsl.expression.localDateNow
+            val a = x.ifNull(localDateNow)
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolation(
+                1,
+                18,
+                "ifNull(...) argument calls 'LocalDate.now()', which changes stableHashCode every day even though " +
+                    "the template didn't change. Use 'no.nav.pensjon.brev.template.dsl.expression.localDateNow' " +
+                    "instead: it resolves the date when the expression is evaluated, instead of baking it into " +
+                    "the expression tree.",
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `flags LocalDate now wrapped with expr as ifNull fallback and auto-corrects it to localDateNow`() {
+        val code =
+            """
+            val a = x.ifNull(LocalDate.now().expr())
+            """.trimIndent()
+        val formattedCode =
+            """
+            import no.nav.pensjon.brev.template.dsl.expression.localDateNow
+            val a = x.ifNull(localDateNow)
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolation(
+                1,
+                18,
+                "ifNull(...) argument calls 'LocalDate.now()', which changes stableHashCode every day even though " +
+                    "the template didn't change. Use 'no.nav.pensjon.brev.template.dsl.expression.localDateNow' " +
+                    "instead: it resolves the date when the expression is evaluated, instead of baking it into " +
+                    "the expression tree.",
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `flags non-deterministic call nested inside the ifNull fallback expression`() {
+        val code =
+            """
+            val a = x.ifNull(then = Wrapper(Instant.now()))
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                18,
+                "ifNull(...) argument must be a compile-time constant, but calls non-deterministic 'now()'. " +
+                    "This makes stableHashCode change over time even though the template didn't change. " +
+                    "Use a fixed literal/constant value instead.",
+            )
+    }
+
+    @Test
+    fun `flags Instant now as ifNull fallback with the generic message and no auto-correct`() {
+        val code =
+            """
+            val a = x.ifNull(Instant.now())
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                18,
+                "ifNull(...) argument must be a compile-time constant, but calls non-deterministic 'now()'. " +
+                    "This makes stableHashCode change over time even though the template didn't change. " +
+                    "Use a fixed literal/constant value instead.",
+            )
+    }
+
+    @Test
+    fun `flags random number generator calls used as ifNull fallback`() {
+        val code =
+            """
+            val a = x.ifNull(Random.nextInt())
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                18,
+                "ifNull(...) argument must be a compile-time constant, but calls non-deterministic 'nextInt()'. " +
+                    "This makes stableHashCode change over time even though the template didn't change. " +
+                    "Use a fixed literal/constant value instead.",
+            )
+    }
+
+    @Test
+    fun `does not flag literal, enum, or constant-built ifNull fallbacks`() {
+        val code =
+            """
+            val a = x.ifNull(Kroner(0))
+            val b = x.ifNull(emptyList())
+            val c = x.ifNull(LocalDate.of(2000, 1, 1))
+            val d = x.ifNull(AlderspensjonBeregnetEtter.EGEN)
+            val e = x.ifNull(false)
+            val f = x.ifNull("some text")
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag unrelated functions named ifNull`() {
+        val code =
+            """
+            fun ifNull(value: Int) = value
+
+            val a = ifNull(LocalDate.now().year)
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `flags non-deterministic value used as ifElse branch with a specific message and auto-corrects it`() {
+        val code =
+            """
+            val a = ifElse(somePredicate, someDate, LocalDate.now().expr())
+            """.trimIndent()
+        val formattedCode =
+            """
+            import no.nav.pensjon.brev.template.dsl.expression.localDateNow
+            val a = ifElse(somePredicate, someDate, localDateNow)
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolation(
+                1,
+                41,
+                "ifElse(...) argument calls 'LocalDate.now()', which changes stableHashCode every day even though " +
+                    "the template didn't change. Use 'no.nav.pensjon.brev.template.dsl.expression.localDateNow' " +
+                    "instead: it resolves the date when the expression is evaluated, instead of baking it into " +
+                    "the expression tree.",
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `flags non-deterministic value used as first ifElse branch with a specific message and auto-corrects it`() {
+        val code =
+            """
+            val a = ifElse(somePredicate, LocalDate.now(), someDate)
+            """.trimIndent()
+        val formattedCode =
+            """
+            import no.nav.pensjon.brev.template.dsl.expression.localDateNow
+            val a = ifElse(somePredicate, localDateNow, someDate)
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolation(
+                1,
+                31,
+                "ifElse(...) argument calls 'LocalDate.now()', which changes stableHashCode every day even though " +
+                    "the template didn't change. Use 'no.nav.pensjon.brev.template.dsl.expression.localDateNow' " +
+                    "instead: it resolves the date when the expression is evaluated, instead of baking it into " +
+                    "the expression tree.",
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `flags non-deterministic call used in the ifElse condition too`() {
+        val code =
+            """
+            val a = ifElse(someFlag.equalTo(Random.nextInt()), someDate, otherDate)
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                16,
+                "ifElse(...) argument must be a compile-time constant, but calls non-deterministic 'nextInt()'. " +
+                    "This makes stableHashCode change over time even though the template didn't change. " +
+                    "Use a fixed literal/constant value instead.",
+            )
+    }
+
+    @Test
+    fun `does not flag ifElse with literal or constant-built branches`() {
+        val code =
+            """
+            val a = ifElse(data.harUtbetaling, Kroner(0), Kroner(1))
+            val b = ifElse(sakType.equalTo(SakType.BARNEPENSJON), Constants.URL.expr(), Constants.OTHER_URL.expr())
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag localDateNow used as ifNull fallback or ifElse branch`() {
+        val code =
+            """
+            val a = x.ifNull(localDateNow)
+            val b = ifElse(somePredicate, localDateNow, someDate)
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not add a duplicate import when localDateNow is already imported`() {
+        val code =
+            """
+            import no.nav.pensjon.brev.template.dsl.expression.localDateNow
+
+            val a = x.ifNull(LocalDate.now())
+            """.trimIndent()
+        val formattedCode =
+            """
+            import no.nav.pensjon.brev.template.dsl.expression.localDateNow
+
+            val a = x.ifNull(localDateNow)
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolation(
+                3,
+                18,
+                "ifNull(...) argument calls 'LocalDate.now()', which changes stableHashCode every day even though " +
+                    "the template didn't change. Use 'no.nav.pensjon.brev.template.dsl.expression.localDateNow' " +
+                    "instead: it resolves the date when the expression is evaluated, instead of baking it into " +
+                    "the expression tree.",
+            ).isFormattedAs(formattedCode)
+    }
+}

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/render/TemplateDocumentationRenderer.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/template/render/TemplateDocumentationRenderer.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import no.nav.brev.InterneDataklasser
 import no.nav.pensjon.brev.template.*
 import no.nav.pensjon.brev.template.BinaryOperation.Documentation
 import no.nav.pensjon.brev.template.dsl.expression.expr
@@ -261,6 +260,8 @@ object TemplateDocumentationRenderer {
             is UnaryOperation.AbsoluteValue -> Operation("abs", Documentation.Notation.FUNCTION)
 
             is UnaryOperation.AbsoluteValueKroner -> Operation("abs", Documentation.Notation.FUNCTION)
+
+            is UnaryOperation.LocalDateNow -> Operation("today", Documentation.Notation.FUNCTION)
 
             is UnaryOperation.MapCollection<*, *> -> TODO()
             is UnaryOperation.Not -> Operation("!", Documentation.Notation.PREFIX)

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/LegacyFunksjoner.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/LegacyFunksjoner.kt
@@ -47,6 +47,7 @@ import no.nav.pensjon.brev.template.dsl.expression.size
 import no.nav.pensjon.brev.template.dsl.expression.year
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Kroner
 import java.time.LocalDate
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 
 
 fun Expression<PEgruppe10>.ut_trygdetid(): Expression<Boolean> =
@@ -178,7 +179,7 @@ fun Expression<PEgruppe10>.ut_firstday(): Expression<LocalDate?> = vedtaksbrev_g
 fun Expression<PEgruppe10>.ut_lastday(): Expression<LocalDate?> = vedtaksbrev_grunnlag_persongrunnlagsliste_uforetrygdetteroppgjor_periodefom().ifNull(LocalDate.of(2014,10,14)).lastDayOfYear
 
 fun Expression<PEgruppe10>.aarstall_trygdetid(): Expression<Int> =
-    vedtaksbrev.safe { vedtaksdata }.safe { kravhode }.safe { kravmottattdato }.ifNull(LocalDate.now()).year
+    vedtaksbrev.safe { vedtaksdata }.safe { kravhode }.safe { kravmottattdato }.ifNull(localDateNow).year
 
 fun Expression<PEgruppe10>.aars_trygdetid(): Expression<String> {
     val erEngelsk = Expression.FromScope.Language.equalTo(English)

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/LegacySelectors.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/LegacySelectors.kt
@@ -77,6 +77,7 @@ import no.nav.pensjon.brev.template.dsl.expression.*
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Kroner
 import java.time.LocalDate
 import java.time.Month
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 
 
 fun Expression<PEgruppe10>.avdodHarOpptjeningUTMedFoerstegangstjenesteOgIkkeOmsorg(): Expression<Boolean> = functions.avdodHarOpptjeningUTMedFoerstegangstjenesteOgIkkeOmsorg
@@ -299,7 +300,7 @@ fun Expression<PEgruppe10>.vedtaksdata_kravhode_boddarbeidutlandavdod(): Express
 fun Expression<PEgruppe10>.vedtaksdata_kravhode_kravarsaktype(): Expression<String> = vedtaksbrev.safe{ vedtaksdata }.safe{ kravhode }.safe{ kravarsaktype }.ifNull("")
 fun Expression<PEgruppe10>.vedtaksdata_kravhode_kravgjelder(): Expression<String> = vedtaksbrev.safe{ vedtaksdata }.safe{ kravhode }.safe{ kravgjelder }.ifNull("")
 fun Expression<PEgruppe10>.vedtaksdata_kravhode_kravlinjeliste_kravlinje_kravlinjetype(): Expression<String> = vedtaksbrev.vedtaksdata.safe{ kravhode }.safe{ kravlinjeliste }.getOrNull().safe{ kravlinjetype }.ifNull("")
-fun Expression<PEgruppe10>.vedtaksdata_kravhode_kravmottatdato(): Expression<LocalDate> = vedtaksbrev.vedtaksdata.safe{ kravhode }.safe{ kravmottattdato }.ifNull(LocalDate.now())
+fun Expression<PEgruppe10>.vedtaksdata_kravhode_kravmottatdato(): Expression<LocalDate> = vedtaksbrev.vedtaksdata.safe{ kravhode }.safe{ kravmottattdato }.ifNull(localDateNow)
 fun Expression<PEgruppe10>.vedtaksdata_kravhode_onsketvirkningsdato(): Expression<LocalDate?> = vedtaksbrev.safe{ vedtaksdata }.safe{ kravhode }.safe{ onsketvirkningsdato }
 fun Expression<PEgruppe10>.vedtaksdata_kravhode_vurderetrygdeavtale(): Expression<Boolean> = vedtaksbrev.safe{ vedtaksdata }.safe{ kravhode }.safe{ vurderetrygdeavtale }.ifNull(false)
 fun Expression<PEgruppe10>.vedtaksdata_trygdetidavdod_fatt_a10_netto(): Expression<Int> = vedtaksbrev.safe{ vedtaksdata }.safe{ trygdetidavdod }.safe{ fatta10netto }.ifNull(0)
@@ -355,7 +356,7 @@ fun Expression<PEgruppe10>.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_vilkar_un
 fun Expression<PEgruppe10>.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_vilkar_yrkesskadebegrunnelse(): Expression<String> = vedtaksbrev.vedtaksdata.safe{ vilkarsvedtaklist }.safe{ vilkarsvedtak }.getOrNull().safe{ vilkar }.safe{ yrkesskadebegrunnelse }.ifNull("")
 fun Expression<PEgruppe10>.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_vilkar_yrkesskaderesultat(): Expression<String> = vedtaksbrev.safe{ vedtaksdata }.safe{ vilkarsvedtaklist }.safe{ vilkarsvedtak }.getOrNull().safe{ vilkar }.safe{ yrkesskaderesultat }.ifNull("")
 fun Expression<PEgruppe10>.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_vilkarvirkningfom(): Expression<LocalDate?> = vedtaksbrev.safe{ vedtaksdata }.safe{ vilkarsvedtaklist }.safe{ vilkarsvedtak }.getOrNull().safe{ vilkarvirkningfom }
-fun Expression<PEgruppe10>.vedtaksdata_virkningfom(): Expression<LocalDate> = vedtaksbrev.safe{ vedtaksdata }.safe{ virkningfom }.ifNull(LocalDate.now())
+fun Expression<PEgruppe10>.vedtaksdata_virkningfom(): Expression<LocalDate> = vedtaksbrev.safe{ vedtaksdata }.safe{ virkningfom }.ifNull(localDateNow)
 fun Expression<PEgruppe10>.vedtaksdata_beregningsdata_beregningsresultattilrevurderingtotalnetto(): Expression<Kroner> = vedtaksbrev.safe{ vedtaksdata }.safe{ beregningsdata }.safe{ beregningsresultattilrevurderingtotalnetto }.ifNull(Kroner(0))
 fun Expression<PEgruppe10>.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningbegrunnelse(): Expression<String> = vedtaksbrev.safe{ vedtaksdata }.safe{ vilkarsvedtaklist }.safe{ vilkarsvedtak }.getOrNull().safe{ beregningsvilkar }.safe{ virkningbegrunnelse }.ifNull("")
 fun Expression<PEgruppe10>.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_vilkar_forutgaendemedlemskap_unntakfraforutgaendemedlemskap(): Expression<Boolean> = vedtaksbrev.safe{ vedtaksdata }.safe{ vilkarsvedtaklist }.safe{ vilkarsvedtak }.getOrNull().safe{ vilkar }.safe{ forutgaendemedlemskap }.safe{ unntakfraforutgaendemedlemskap }.ifNull(false)

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/AvslagUfoeretrygd.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/AvslagUfoeretrygd.kt
@@ -23,7 +23,7 @@ import no.nav.pensjon.brev.template.dsl.helpers.TemplateModelHelpers
 import no.nav.pensjon.brev.template.dsl.languages
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
-import java.time.LocalDate
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 
 @TemplateModelHelpers
 object AvslagUfoeretrygd : RedigerbarTemplate<AvslagUfoeretrygdDto> {
@@ -278,7 +278,7 @@ object AvslagUfoeretrygd : RedigerbarTemplate<AvslagUfoeretrygdDto> {
             }
 
             //IF(FF_GetArrayElement_String(PE_Vedtaksdata_VilkarsVedtakList_VilkarsVedtak_Vilkar_ForutgaendeMedlemskapResultat) = "ikke_oppfylt" AND PE_Vedtaksdata_Kravhode_VurdereTrygdeavtale = false) THEN      INCLUDE ENDIF
-            val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(LocalDate.now())
+            val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(localDateNow)
             showIf(
                 (pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_vilkar_forutgaendemedlemskapresultat().equalTo("ikke_oppfylt") and not(
                     pe.vedtaksdata_kravhode_vurderetrygdeavtale()

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/EndringUforetrygd.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/EndringUforetrygd.kt
@@ -30,7 +30,7 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.namedReference
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Kroner
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
-import java.time.LocalDate
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 
 @TemplateModelHelpers
 object EndringUforetrygd : RedigerbarTemplate<EndringUfoeretrygdDto> {
@@ -53,10 +53,10 @@ object EndringUforetrygd : RedigerbarTemplate<EndringUfoeretrygdDto> {
         val pe = pesysData.pe
 
         val kravarsak = pe.vedtaksdata_kravhode_kravarsaktype()
-        val onsketvirkningsdato = pe.vedtaksdata_kravhode_onsketvirkningsdato().ifNull(LocalDate.now())
+        val onsketvirkningsdato = pe.vedtaksdata_kravhode_onsketvirkningsdato().ifNull(localDateNow)
 
-        val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(LocalDate.now())
-        val skadetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_skadetidspunkt().ifNull(LocalDate.now())
+        val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(localDateNow)
+        val skadetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_skadetidspunkt().ifNull(localDateNow)
         val virkningstidspunktBegrunnelse = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningbegrunnelse()
         val virkningbegrunnelseStdbegr_22_12_1_5 = virkningstidspunktBegrunnelse.equalTo("stdbegr_22_12_1_5")
         val uforegradFraBeregning = pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_uforegrad()

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygd.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygd.kt
@@ -29,7 +29,7 @@ import no.nav.pensjon.brev.template.dsl.languages
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Kroner
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
-import java.time.LocalDate
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 
 @TemplateModelHelpers
 object InnvilgelseUforetrygd : RedigerbarTemplate<InnvilgelseUfoeretrygdDto> {
@@ -51,8 +51,8 @@ object InnvilgelseUforetrygd : RedigerbarTemplate<InnvilgelseUfoeretrygdDto> {
     ) {
         val pe = pesysData.pe
 
-        val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(LocalDate.now())
-        val virkningstidpunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningstidpunkt().ifNull(LocalDate.now())
+        val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(localDateNow)
+        val virkningstidpunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningstidpunkt().ifNull(localDateNow)
         val virkningbegrunnelseStdbegr_22_12_1_5 = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningbegrunnelse().equalTo("stdbegr_22_12_1_5")
         val uforegrad = pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_uforegrad()
 

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdMedEndring.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdMedEndring.kt
@@ -31,6 +31,7 @@ import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Kroner
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import java.time.LocalDate
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 
 @TemplateModelHelpers
 object InnvilgelseUforetrygdMedEndring : RedigerbarTemplate<InnvilgelseUforetrygdMedEndringDto> {
@@ -59,11 +60,11 @@ object InnvilgelseUforetrygdMedEndring : RedigerbarTemplate<InnvilgelseUforetryg
         outline {
             val pe = pesysData.pe
 
-            val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(LocalDate.now())
-            val trygdetidfombilateral = pe.grunnlag_persongrunnlagsliste_trygdetidsgrunnlaglistebilateral_trygdetidsgrunnlagbilateral_trygdetidfombilateral().ifNull(LocalDate.now())
-            val trygdetidtombilateral = pe.grunnlag_persongrunnlagsliste_trygdetidsgrunnlaglistebilateral_trygdetidsgrunnlagbilateral_trygdetidtombilateral().ifNull(LocalDate.now())
-            val trygdetidfom = pe.grunnlag_persongrunnlagsliste_trygdetidsgrunnlaglistenor_trygdetidsgrunnlag_trygdetidfom().ifNull(LocalDate.now())
-            val trygdetidtom = pe.grunnlag_persongrunnlagsliste_trygdetidsgrunnlaglistenor_trygdetidsgrunnlag_trygdetidtom().ifNull(LocalDate.now())
+            val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(localDateNow)
+            val trygdetidfombilateral = pe.grunnlag_persongrunnlagsliste_trygdetidsgrunnlaglistebilateral_trygdetidsgrunnlagbilateral_trygdetidfombilateral().ifNull(localDateNow)
+            val trygdetidtombilateral = pe.grunnlag_persongrunnlagsliste_trygdetidsgrunnlaglistebilateral_trygdetidsgrunnlagbilateral_trygdetidtombilateral().ifNull(localDateNow)
+            val trygdetidfom = pe.grunnlag_persongrunnlagsliste_trygdetidsgrunnlaglistenor_trygdetidsgrunnlag_trygdetidfom().ifNull(localDateNow)
+            val trygdetidtom = pe.grunnlag_persongrunnlagsliste_trygdetidsgrunnlaglistenor_trygdetidsgrunnlag_trygdetidtom().ifNull(localDateNow)
             val trygdetideosland = pe.vedtaksbrev_grunnlag_persongrunnlagsliste_trygdetidsgrunnlageos_trygdetidsgrunnlageos_trygdetideosland().notEqualTo("")
 
             val uforegrad = pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_uforegrad()

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdMellombehandling.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdMellombehandling.kt
@@ -31,7 +31,7 @@ import no.nav.pensjon.brev.template.dsl.languages
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Kroner
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
-import java.time.LocalDate
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 
 @TemplateModelHelpers
 object InnvilgelseUforetrygdMellombehandling : RedigerbarTemplate<InnvilgelseUfoeretrygdMellombehandlingDto> {
@@ -53,8 +53,8 @@ object InnvilgelseUforetrygdMellombehandling : RedigerbarTemplate<InnvilgelseUfo
     ) {
         val pe = pesysData.pe
 
-        val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(LocalDate.now())
-        val virkningstidpunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningstidpunkt().ifNull(LocalDate.now())
+        val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(localDateNow)
+        val virkningstidpunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningstidpunkt().ifNull(localDateNow)
         val virkningbegrunnelseStdbegr_22_12_1_5 = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningbegrunnelse().equalTo("stdbegr_22_12_1_5")
         val uforegrad = pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_uforegrad()
 

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdUtland.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/InnvilgelseUforetrygdUtland.kt
@@ -31,7 +31,7 @@ import no.nav.pensjon.brev.template.dsl.languages
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Kroner
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
-import java.time.LocalDate
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 
 @TemplateModelHelpers
 object InnvilgelseUforetrygdUtland : RedigerbarTemplate<InnvilgelseUfoeretrygdUtlandDto> {
@@ -53,8 +53,8 @@ object InnvilgelseUforetrygdUtland : RedigerbarTemplate<InnvilgelseUfoeretrygdUt
     ) {
         val pe = pesysData.pe
 
-        val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(LocalDate.now())
-        val virkningstidpunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningstidpunkt().ifNull(LocalDate.now())
+        val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(localDateNow)
+        val virkningstidpunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningstidpunkt().ifNull(localDateNow)
         val virkningbegrunnelseStdbegr_22_12_1_5 = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningbegrunnelse().equalTo("stdbegr_22_12_1_5")
         val uforegrad = pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_uforegrad()
 

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/OkningUforegrad.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/OkningUforegrad.kt
@@ -32,6 +32,7 @@ import no.nav.pensjon.brev.template.namedReference
 import no.nav.pensjon.brevbaker.api.model.BrevbakerType.Kroner
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import java.time.LocalDate
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 
 @TemplateModelHelpers
 object OkningUforegrad : RedigerbarTemplate<OkningUforegradDto> {
@@ -60,10 +61,10 @@ object OkningUforegrad : RedigerbarTemplate<OkningUforegradDto> {
         outline {
             val pe = pesysData.pe
 
-            val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(LocalDate.now())
-            val virkningstidpunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningstidpunkt().ifNull(LocalDate.now())
-            val onsketvirkningsdato = pe.vedtaksdata_kravhode_onsketvirkningsdato().ifNull(LocalDate.now())
-            val skadetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_skadetidspunkt().ifNull(LocalDate.now())
+            val uforetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_uforetidspunkt().ifNull(localDateNow)
+            val virkningstidpunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningstidpunkt().ifNull(localDateNow)
+            val onsketvirkningsdato = pe.vedtaksdata_kravhode_onsketvirkningsdato().ifNull(localDateNow)
+            val skadetidspunkt = pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_skadetidspunkt().ifNull(localDateNow)
             val bostedutland = (pe.grunnlag_persongrunnlagsliste_personbostedsland().notEqualTo("nor") and (pe.grunnlag_persongrunnlagsliste_personbostedsland()).notEqualTo(""))
 
             val uforegradFraBeregning = pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_uforegrad()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 rootProject.name = "pensjonsbrev"
 
+include("ktlint-rules")
+
 include("brevbaker:core")
 include("brevbaker:api-model-common")
 include("brevbaker:dsl")


### PR DESCRIPTION
## Bakgrunn

`stableHashCode` for `Expression`-trær forutsetter at literaler (`.expr()`) er kompilerte konstanter. I praksis brøt vi denne forutsetningen ved bruk av `.ifNull(LocalDate.now())` og tilsvarende `ifElse(...)`-mønstre, som gjorde at `stableHashCode` for berørte brev endret seg daglig selv om malen ikke var endret.

## Endringer

- **Ny modul `:ktlint-rules`** med regelen `pensjonsbrev:no-nondeterministic-expression-literal`, som flagger ikke-deterministiske kall (`now()`, `today()`, `randomUUID()`, `nextInt()`, m.fl.) brukt som argumenter til `.ifNull(...)` og `ifElse(...)` (inkludert `condition`).
  - Spesifikk feilmelding og autokorreksjon for `LocalDate.now()` → `localDateNow` (inkl. automatisk import).
  - Andre ikke-deterministiske kall får generisk feilmelding uten autokorreksjon.
- Regelen er koblet inn via `ktlintRuleset(project(":ktlint-rules"))` for alle moduler.
- `ktlintEngineVersion` og alle avhengigheter for `:ktlint-rules` er flyttet til `gradle/libs.versions.toml`.
- Fikset de 22 reelle forekomstene av `.ifNull(LocalDate.now())` i legacy-malene (`pensjon/maler/.../legacy/**`) ved å bruke den nye autokorreksjonen — disse bruker nå `localDateNow`, som har en fast `stableHashCode`.

## Verifisering

- 13 nye enhetstester for regelen (deteksjon, generisk/spesifikk melding, autokorreksjon inkl. import-håndtering).
- `:pensjon:maler:compileKotlin` kompilerer.
- `:pensjon:maler:ktlintMainSourceSetCheck` kjørt med `CI=true` (uten autokorreksjon) – ingen gjenværende brudd.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>