### PR TITLE
Utvid ktlint-regelen til å dekke showIf/orShowIf/ifNotNull-predikater

### DIFF
--- a/alder/maler/src/main/kotlin/no/nav/pensjon/brev/alder/maler/felles/Vedtak.kt
+++ b/alder/maler/src/main/kotlin/no/nav/pensjon/brev/alder/maler/felles/Vedtak.kt
@@ -6,11 +6,12 @@ import no.nav.pensjon.brev.template.OutlinePhrase
 import no.nav.pensjon.brev.template.PlainTextOnlyPhrase
 import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
 import no.nav.pensjon.brev.template.dsl.PlainTextOnlyScope
+import no.nav.pensjon.brev.template.dsl.expression.firstDayOfYear
 import no.nav.pensjon.brev.template.dsl.expression.format
 import no.nav.pensjon.brev.template.dsl.expression.lessThan
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 import no.nav.pensjon.brev.template.dsl.text
 import java.time.LocalDate
-import java.time.Month
 
 
 object Vedtak {
@@ -57,7 +58,7 @@ object Vedtak {
                 )
             }
 
-            showIf(virkDatoFom.lessThan(LocalDate.of(LocalDate.now().year, Month.JANUARY, 1))) {
+            showIf(virkDatoFom.lessThan(localDateNow.firstDayOfYear)) {
                 paragraph {
                     text(
                         bokmal { +"Hvis etterbetalingen gjelder tidligere år, trekker vi skatt etter skatteetatens standardsatser." },

--- a/ktlint-rules/src/main/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRule.kt
+++ b/ktlint-rules/src/main/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRule.kt
@@ -22,13 +22,17 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
  *
  * - `Expression<T?>.ifNull(then)` - the `then` fallback.
  * - `ifElse(condition, ifTrue, ifFalse)` - all three arguments, including `condition`.
+ * - `showIf(predicate) { ... }` / `orShowIf(predicate) { ... }` - the `predicate`.
+ * - `ifNotNull(expr1, ..)` / `orIfNotNull(expr1, ..)` - the `expr1`/`expr2`/... arguments.
  *
  * Background: `stableHashCode` is computed over the whole `Expression` tree (including its `condition`/branch
  * sub-expressions), which brevbaker relies on to detect whether a rendered letter's content changed. A fallback,
- * branch, or condition such as `.ifNull(LocalDate.now())` or `ifElse(date.equalTo(LocalDate.now()), a, b)` makes that
- * hash change every day even though nothing about the letter template itself changed. These arguments must evaluate
- * to the same value on every evaluation - i.e. effectively a compile-time constant (literal, enum constant, or a
- * constructor/function call built purely from such constants).
+ * branch, or condition such as `.ifNull(LocalDate.now())`, `ifElse(date.equalTo(LocalDate.now()), a, b)`, or
+ * `showIf(virkFom.greaterThan(LocalDate.now()))` makes that hash change every day even though nothing about the
+ * letter template itself changed - `showIf`/`orShowIf`'s `predicate` becomes the `predicate` of a
+ * `ContentOrControlStructure.Conditional`, which is included in its `stableHashCode` exactly like `ifElse`'s
+ * `condition` is. These arguments must evaluate to the same value on every evaluation - i.e. effectively a
+ * compile-time constant (literal, enum constant, or a constructor/function call built purely from such constants).
  *
  * If you actually need "today's date" inside a template, use `no.nav.pensjon.brev.template.dsl.expression.localDateNow`
  * instead of `LocalDate.now()`: it is a dedicated `Expression<LocalDate>` (`UnaryOperation.LocalDateNow`) whose
@@ -71,6 +75,12 @@ class NoNonDeterministicExpressionLiteralRule :
                 // `ifElse(condition, ifTrue, ifFalse)`: check every argument, `condition` included, since it is
                 // also part of the `Expression` tree that `stableHashCode` is computed over.
                 "ifElse" -> valueArguments
+                // `showIf(predicate) { .. }` / `orShowIf(predicate) { .. }`: `predicate` becomes part of a
+                // `ContentOrControlStructure.Conditional`, whose `stableHashCode` includes it.
+                "showIf", "orShowIf" -> valueArguments
+                // `ifNotNull(expr1, .., scope)` / `orIfNotNull(expr1, .., scope)`: `expr1`/`expr2`/... become part of
+                // that same `Conditional`'s predicate (via `.notNull()`).
+                "ifNotNull", "orIfNotNull" -> valueArguments
                 else -> return
             }
 

--- a/ktlint-rules/src/test/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRuleTest.kt
+++ b/ktlint-rules/src/test/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRuleTest.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.brev.ktlint
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
 
 class NoNonDeterministicExpressionLiteralRuleTest {
@@ -227,4 +228,112 @@ class NoNonDeterministicExpressionLiteralRuleTest {
                     "the expression tree.",
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `flags non-deterministic call nested in a showIf predicate`() {
+        val code =
+            """
+            val a = showIf(virkFom.greaterThan(LocalDate.now())) {
+                paragraph { }
+            }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                16,
+                "showIf(...) argument must be a compile-time constant, but calls non-deterministic 'now()'. " +
+                    "This makes stableHashCode change over time even though the template didn't change. " +
+                    "Use a fixed literal/constant value instead.",
+            )
+    }
+
+    @Test
+    fun `flags non-deterministic call nested in an orShowIf predicate`() {
+        val code =
+            """
+            val a = showIf(somePredicate) {
+                paragraph { }
+            }.orShowIf(virkFom.lessThan(LocalDate.of(LocalDate.now().year, Month.JANUARY, 1))) {
+                paragraph { }
+            }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationWithoutAutoCorrect(
+                3,
+                12,
+                "orShowIf(...) argument must be a compile-time constant, but calls non-deterministic 'now()'. " +
+                    "This makes stableHashCode change over time even though the template didn't change. " +
+                    "Use a fixed literal/constant value instead.",
+            )
+    }
+
+    @Test
+    fun `flags LocalDate now used directly as a showIf predicate expression with a specific message and auto-corrects it`() {
+        val code =
+            """
+            val a = showIf(LocalDate.now().expr().notNull()) {
+                paragraph { }
+            }
+            """.trimIndent()
+        ruleAssertThat(code).hasLintViolationWithoutAutoCorrect(
+            1,
+            16,
+            "showIf(...) argument must be a compile-time constant, but calls non-deterministic 'now()'. " +
+                "This makes stableHashCode change over time even though the template didn't change. " +
+                "Use a fixed literal/constant value instead.",
+        )
+    }
+
+    @Test
+    fun `flags non-deterministic value used as ifNotNull expr1 argument`() {
+        // The nested `.ifNull(LocalDate.now())` is reported twice: once via the outer `ifNotNull(...)` check (generic
+        // message, since the whole `expr1` argument isn't exactly `LocalDate.now()`), and once via the inner
+        // `ifNull(...)` check itself (specific message, auto-correctable).
+        val code =
+            """
+            val a = ifNotNull(someDate.ifNull(LocalDate.now())) { date ->
+                paragraph { }
+            }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(
+                    1,
+                    19,
+                    "ifNotNull(...) argument must be a compile-time constant, but calls non-deterministic 'now()'. " +
+                        "This makes stableHashCode change over time even though the template didn't change. " +
+                        "Use a fixed literal/constant value instead.",
+                    canBeAutoCorrected = false,
+                ),
+                LintViolation(
+                    1,
+                    35,
+                    "ifNull(...) argument calls 'LocalDate.now()', which changes stableHashCode every day even though " +
+                        "the template didn't change. Use 'no.nav.pensjon.brev.template.dsl.expression.localDateNow' " +
+                        "instead: it resolves the date when the expression is evaluated, instead of baking it into " +
+                        "the expression tree.",
+                ),
+            ).isFormattedAs(
+                """
+                import no.nav.pensjon.brev.template.dsl.expression.localDateNow
+                val a = ifNotNull(someDate.ifNull(localDateNow)) { date ->
+                    paragraph { }
+                }
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `does not flag showIf or orShowIf with literal or constant-built predicates`() {
+        val code =
+            """
+            val a = showIf(sakType.equalTo(SakType.BARNEPENSJON)) {
+                paragraph { }
+            }.orShowIf(antallBarn.greaterThan(0)) {
+                paragraph { }
+            }
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
 }

--- a/ktlint-rules/src/test/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRuleTest.kt
+++ b/ktlint-rules/src/test/kotlin/no/nav/pensjon/brev/ktlint/NoNonDeterministicExpressionLiteralRuleTest.kt
@@ -268,7 +268,7 @@ class NoNonDeterministicExpressionLiteralRuleTest {
     }
 
     @Test
-    fun `flags LocalDate now used directly as a showIf predicate expression with a specific message and auto-corrects it`() {
+    fun `flags non-deterministic call in a showIf predicate expression`() {
         val code =
             """
             val a = showIf(LocalDate.now().expr().notNull()) {

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/alder/omregning/opptjening/fraser/EndringPgaOpptjeningAutoFraser.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/alder/omregning/opptjening/fraser/EndringPgaOpptjeningAutoFraser.kt
@@ -23,7 +23,6 @@ import no.nav.pensjon.brev.template.dsl.expression.*
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.namedReference
 import java.time.LocalDate
-import java.time.Month
 
 data class AvsnittBeskrivelse(
     val opptjeningType: Expression<OpptjeningType>,
@@ -473,7 +472,7 @@ data class AvsnittEtterbetaling(
             opptjeningType.equalTo(OpptjeningType.KORRIGERING) and
                     beloepEndring.equalTo(BeloepEndring.ENDR_OKT) and
                     antallAarEndretOpptjening.greaterThan(0) and
-                    virkFom.greaterThan(LocalDate.now())
+                    virkFom.greaterThan(localDateNow)
         ) {
             title2 {
                 text(
@@ -490,7 +489,7 @@ data class AvsnittEtterbetaling(
                 )
             }
 
-            showIf(virkFom.lessThan(LocalDate.of(LocalDate.now().year, Month.JANUARY, 1))) {
+            showIf(virkFom.lessThan(localDateNow.firstDayOfYear)) {
                 paragraph {
                     text(
                         bokmal { +"Hvis etterbetalingen gjelder tidligere år, trekker vi skatt etter skatteetatens standardsatser." },

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/common/Vedtak.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/fraser/common/Vedtak.kt
@@ -9,9 +9,10 @@ import no.nav.pensjon.brev.template.dsl.OutlineOnlyScope
 import no.nav.pensjon.brev.template.dsl.PlainTextOnlyScope
 import no.nav.pensjon.brev.template.dsl.expression.format
 import no.nav.pensjon.brev.template.dsl.expression.lessThan
+import no.nav.pensjon.brev.template.dsl.expression.firstDayOfYear
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 import no.nav.pensjon.brev.template.dsl.text
 import java.time.LocalDate
-import java.time.Month
 
 
 object Vedtak {
@@ -61,7 +62,7 @@ object Vedtak {
                 )
             }
 
-            showIf(virkDatoFom.lessThan(LocalDate.of(LocalDate.now().year, Month.JANUARY, 1))) {
+            showIf(virkDatoFom.lessThan(localDateNow.firstDayOfYear)) {
                 paragraph {
                     text(
                         bokmal { +"Hvis etterbetalingen gjelder tidligere år, trekker vi skatt etter skatteetatens standardsatser." },

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/redigerbar/VedtakEndringAvAlderspensjonFordiOpptjeningErEndret.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/redigerbar/VedtakEndringAvAlderspensjonFordiOpptjeningErEndret.kt
@@ -39,9 +39,11 @@ import no.nav.pensjon.brev.template.RedigerbarTemplate
 import no.nav.pensjon.brev.template.createTemplate
 import no.nav.pensjon.brev.template.dsl.expression.and
 import no.nav.pensjon.brev.template.dsl.expression.equalTo
+import no.nav.pensjon.brev.template.dsl.expression.firstDayOfYear
 import no.nav.pensjon.brev.template.dsl.expression.format
 import no.nav.pensjon.brev.template.dsl.expression.isOneOf
 import no.nav.pensjon.brev.template.dsl.expression.lessThan
+import no.nav.pensjon.brev.template.dsl.expression.localDateNow
 import no.nav.pensjon.brev.template.dsl.expression.not
 import no.nav.pensjon.brev.template.dsl.expression.notNull
 import no.nav.pensjon.brev.template.dsl.expression.or
@@ -50,8 +52,6 @@ import no.nav.pensjon.brev.template.dsl.languages
 import no.nav.pensjon.brev.template.dsl.text
 import no.nav.pensjon.brev.template.namedReference
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
-import java.time.LocalDate
-import java.time.Month
 
 // 119 i doksys
 @TemplateModelHelpers
@@ -270,7 +270,7 @@ object VedtakEndringAvAlderspensjonFordiOpptjeningErEndret : RedigerbarTemplate<
                         english { +"You will receive retroactive pension payments from " + pesysData.krav.virkDatoFom.format() + ". The retroactive payments will normally be made in the course of seven working days. We can make deductions for tax and benefits you have received, for example, from Nav or occupational pension schemes. Therefore, your retroactive payment may be delayed. Occupational pension schemes have a deadline of nine weeks to demand a deduction from the retroactive payments. You can check if there are any deductions from the payment notice at $DITT_NAV." }
                     )
                 }
-                showIf(pesysData.krav.virkDatoFom.lessThan(LocalDate.of(LocalDate.now().year, Month.JANUARY, 1))) {
+                showIf(pesysData.krav.virkDatoFom.lessThan(localDateNow.firstDayOfYear)) {
                     paragraph {
                         text(
                             bokmal { +"Hvis etterbetalingen gjelder tidligere år, trekker vi skatt etter skatteetatens standardsatser." },


### PR DESCRIPTION
predicate til showIf(...)/orShowIf(...) og expr1/expr2/... til ifNotNull(...)/orIfNotNull(...) blir del av
ContentOrControlStructure.Conditional, hvis stableHashCode inkluderer predicate på samme måte som ifElse sin condition. Regelen sjekket tidligere ikke disse, og fanget derfor ikke opp
virkFom.greaterThan(LocalDate.now()) og
LocalDate.of(LocalDate.now().year, Month.JANUARY, 1) brukt i showIf i tre Etterbetaling-relaterte maler.

Disse tilfellene kan ikke autokorrigeres (hele argumentet er ikke nøyaktig LocalDate.now()), så de er rettet manuelt: sammenligning mot localDateNow, og "1. januar i år" uttrykkes nå som localDateNow.firstDayOfYear.