### PR TITLE
Sett fokus på første uredigerte fritekst etter lukking av modal

### DIFF
--- a/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/common.ts
+++ b/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/common.ts
@@ -1200,15 +1200,16 @@ export const countUneditedFritekstPlaceholders = (letter: EditedLetter): number 
  * is still `null`.
  *
  * Used to move the editor's focus to the first fritekst felt the user still needs to fill in, e.g.
- * when the user chooses to stay on the page after a "du må fylle ut fritekstfelt" warning. Setting
- * `editorState.focus` to the returned value is enough to both scroll it into view and select its full
- * text — see ContentGroup.tsx's `focusAtOffset` (calls `.focus()`) and `handleOnFocus` (selects the
- * whole fritekst on native focus).
+ * when the user chooses to stay on the page after a "du må fylle ut fritekstfelt" warning. The
+ * returned Focus has `selectAll: true`, which tells ContentGroup.tsx to select the literal's full text
+ * (rather than just placing a caret) once it scrolls into view and receives focus — replicating what
+ * happens when the user clicks the fritekst directly.
  */
 export function findFirstUneditedFritekstFocus(letter: EditedLetter): Focus | null {
   return (
-    findLiteral(letter, (literal, focus) => (isFritekst(literal) && literal.editedText === null ? focus : undefined)) ??
-    null
+    findLiteral(letter, (literal, focus) =>
+      isFritekst(literal) && literal.editedText === null ? { ...focus, selectAll: true } : undefined,
+    ) ?? null
   );
 }
 

--- a/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/common.ts
+++ b/skribenten-web/frontend/src/Brevredigering/LetterEditor/actions/common.ts
@@ -30,6 +30,7 @@ import {
   type Row,
   type Table,
   type TextContent,
+  TITLE_INDEX,
   type Title1Block,
   type Title2Block,
   type Title3Block,
@@ -1065,45 +1066,151 @@ export function normalizeDeletedArrays(obj: unknown): unknown {
   return obj;
 }
 
-export function collectAllLiteralValues(letter: EditedLetter): LiteralValue[] {
-  const blockLiterals = letter.blocks.flatMap((block) => {
-    switch (block.type) {
-      case "TITLE1":
-      case "TITLE2":
-      case "TITLE3":
-        return (block.content ?? []).filter((content) => isLiteral(content));
-      case "PARAGRAPH":
-        return (block.content ?? []).flatMap((content) => {
-          if (isLiteral(content)) return [content];
-          if (isItemList(content))
-            return content?.items.flatMap((item) => (item?.content ?? []).filter((literal) => isLiteral(literal)));
-          if (isTable(content)) {
-            const header = content.header?.colSpec?.flatMap((spec) =>
-              (spec.headerContent?.text ?? []).filter(isLiteral),
-            );
-            const body = content.rows?.flatMap((row) =>
-              row.cells?.flatMap((cell) => (cell.text ?? []).filter(isLiteral)),
-            );
-            return [...header, ...body];
-          }
-          return [];
-        });
-      default:
-        return [];
+/**
+ * Walks every text literal in the letter in document order — title first, then blocks in order
+ * (paragraph content, item-list items, table header/rows) — invoking `visit` with the literal and the
+ * Focus pointing at its position. Traversal stops as soon as `visit` returns a value other than
+ * `undefined`, and that value becomes the result; if `visit` never does, `findLiteral` returns
+ * `undefined` once every literal has been visited.
+ *
+ * This is the single traversal used by both {@link collectAllLiteralValues} (visits every literal to
+ * build a flat list) and {@link findFirstUneditedFritekstFocus} (stops at the first literal matching a
+ * predicate), so the two can't drift apart if the letter's content model changes.
+ */
+function findLiteral<T>(
+  letter: EditedLetter,
+  visit: (literal: LiteralValue, focus: Focus) => T | undefined,
+): T | undefined {
+  for (let contentIndex = 0; contentIndex < (letter.title?.text.length ?? 0); contentIndex++) {
+    const content = letter.title.text[contentIndex];
+    if (isLiteral(content)) {
+      const result = visit(content, { blockIndex: TITLE_INDEX, contentIndex, cursorPosition: 0 });
+      if (result !== undefined) return result;
     }
-  });
-  const topTitleLiterals = (letter.title?.text ?? []).filter(isLiteral);
+  }
 
-  return [...topTitleLiterals, ...blockLiterals];
+  for (let blockIndex = 0; blockIndex < letter.blocks.length; blockIndex++) {
+    const block = letter.blocks[blockIndex];
+
+    if (block.type !== "PARAGRAPH") {
+      for (let contentIndex = 0; contentIndex < (block.content?.length ?? 0); contentIndex++) {
+        const content = block.content[contentIndex];
+        if (isLiteral(content)) {
+          const result = visit(content, { blockIndex, contentIndex, cursorPosition: 0 });
+          if (result !== undefined) return result;
+        }
+      }
+      continue;
+    }
+
+    for (let contentIndex = 0; contentIndex < block.content.length; contentIndex++) {
+      const content = block.content[contentIndex];
+
+      if (isLiteral(content)) {
+        const result = visit(content, { blockIndex, contentIndex, cursorPosition: 0 });
+        if (result !== undefined) return result;
+        continue;
+      }
+
+      if (isItemList(content)) {
+        for (let itemIndex = 0; itemIndex < content.items.length; itemIndex++) {
+          const item = content.items[itemIndex];
+          for (let itemContentIndex = 0; itemContentIndex < item.content.length; itemContentIndex++) {
+            const literal = item.content[itemContentIndex];
+            if (isLiteral(literal)) {
+              const result = visit(literal, {
+                blockIndex,
+                contentIndex,
+                itemIndex,
+                itemContentIndex,
+                cursorPosition: 0,
+              });
+              if (result !== undefined) return result;
+            }
+          }
+        }
+        continue;
+      }
+
+      if (isTable(content)) {
+        for (let cellIndex = 0; cellIndex < content.header.colSpec.length; cellIndex++) {
+          const headerText = content.header.colSpec[cellIndex].headerContent?.text ?? [];
+          for (let cellContentIndex = 0; cellContentIndex < headerText.length; cellContentIndex++) {
+            const literal = headerText[cellContentIndex];
+            if (isLiteral(literal)) {
+              const result = visit(literal, {
+                blockIndex,
+                contentIndex,
+                rowIndex: -1,
+                cellIndex,
+                cellContentIndex,
+                cursorPosition: 0,
+              });
+              if (result !== undefined) return result;
+            }
+          }
+        }
+        for (let rowIndex = 0; rowIndex < content.rows.length; rowIndex++) {
+          const row = content.rows[rowIndex];
+          for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex++) {
+            const cellText = row.cells[cellIndex].text ?? [];
+            for (let cellContentIndex = 0; cellContentIndex < cellText.length; cellContentIndex++) {
+              const literal = cellText[cellContentIndex];
+              if (isLiteral(literal)) {
+                const result = visit(literal, {
+                  blockIndex,
+                  contentIndex,
+                  rowIndex,
+                  cellIndex,
+                  cellContentIndex,
+                  cursorPosition: 0,
+                });
+                if (result !== undefined) return result;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function collectAllLiteralValues(letter: EditedLetter): LiteralValue[] {
+  const result: LiteralValue[] = [];
+  findLiteral(letter, (literal) => {
+    result.push(literal);
+    return undefined;
+  });
+  return result;
 }
 
 export function collectFritekstLiterals(letter: EditedLetter): LiteralValue[] {
   return collectAllLiteralValues(letter).filter((literal) => isFritekst(literal));
 }
 
-export const countUnfilledFritekstPlaceholders = (letter: EditedLetter): number => {
+export const countUneditedFritekstPlaceholders = (letter: EditedLetter): number => {
   return collectFritekstLiterals(letter).filter((literal) => literal.editedText === null).length;
 };
+
+/**
+ * Finds the Focus of the first unedited fritekst felt in document order. "Unedited" mirrors the
+ * predicate used by {@link countUneditedFritekstPlaceholders}: a fritekst literal whose `editedText`
+ * is still `null`.
+ *
+ * Used to move the editor's focus to the first fritekst felt the user still needs to fill in, e.g.
+ * when the user chooses to stay on the page after a "du må fylle ut fritekstfelt" warning. Setting
+ * `editorState.focus` to the returned value is enough to both scroll it into view and select its full
+ * text — see ContentGroup.tsx's `focusAtOffset` (calls `.focus()`) and `handleOnFocus` (selects the
+ * whole fritekst on native focus).
+ */
+export function findFirstUneditedFritekstFocus(letter: EditedLetter): Focus | null {
+  return (
+    findLiteral(letter, (literal, focus) => (isFritekst(literal) && literal.editedText === null ? focus : undefined)) ??
+    null
+  );
+}
 
 export const countMissingFromTemplateBlocks = (letter: EditedLetter): number => {
   return letter.blocks.filter((block) => block.missingFromTemplate).length;

--- a/skribenten-web/frontend/src/Brevredigering/LetterEditor/components/ContentGroup.tsx
+++ b/skribenten-web/frontend/src/Brevredigering/LetterEditor/components/ContentGroup.tsx
@@ -220,6 +220,16 @@ export function EditableText({ literalIndex, content }: { literalIndex: LiteralI
         return;
       }
 
+      // Focus jumped here programmatically (not via a real click/DOM focus event) and wants the whole
+      // fritekst selected, mirroring click behavior. Just call .focus(): handleOnFocus's native
+      // onFocus listener selects the full text for erFritekst elements. We must NOT also call
+      // focusAtOffset here, since it collapses the selection to a single offset right after focusing,
+      // which would immediately undo the selection handleOnFocus just made.
+      if (editorState.focus.selectAll && erFritekst && element.childNodes[0]) {
+        element.focus();
+        return;
+      }
+
       // If we do NOT yet have a stored cursorPosition, respect any existing DOM caret/selection.
       if (editorState.focus.cursorPosition === undefined || editorState.focus.cursorPosition < 0) {
         const selection = globalThis.getSelection();
@@ -251,7 +261,15 @@ export function EditableText({ literalIndex, content }: { literalIndex: LiteralI
         focusAtOffset(element.childNodes[0], resolvedCursorPosition);
       }
     }
-  }, [text, shouldBeFocused, editorState.focus.cursorPosition, freeze, setEditorState, erFritekst]);
+  }, [
+    text,
+    shouldBeFocused,
+    editorState.focus.cursorPosition,
+    editorState.focus.selectAll,
+    freeze,
+    setEditorState,
+    erFritekst,
+  ]);
 
   const handleEnter = (event: React.KeyboardEvent<HTMLSpanElement>) => {
     event.preventDefault();

--- a/skribenten-web/frontend/src/Brevredigering/LetterEditor/components/warnModal.tsx
+++ b/skribenten-web/frontend/src/Brevredigering/LetterEditor/components/warnModal.tsx
@@ -73,7 +73,6 @@ export const WarnModal: React.FC<WarnModalProps> = ({ kind, open, onClose, onFor
         <Button
           onClick={() => {
             onFortsett();
-            onClose();
           }}
           type="button"
           variant="tertiary"

--- a/skribenten-web/frontend/src/Brevredigering/LetterEditor/model/state.ts
+++ b/skribenten-web/frontend/src/Brevredigering/LetterEditor/model/state.ts
@@ -19,7 +19,17 @@ export type TableCellIndex = BlockContentIndex & {
 
 export type LiteralIndex = BlockContentIndex | ItemContentIndex | TableCellIndex;
 
-export type Focus = LiteralIndex & { cursorPosition?: number };
+export type Focus = LiteralIndex & {
+  cursorPosition?: number;
+  /**
+   * When true, and the focused literal is an untouched fritekst, ContentGroup.tsx selects its full
+   * text instead of placing a caret — replicating the click behavior, for focus changes that don't
+   * originate from a real DOM focus/click event (e.g. jumping to the first unedited fritekst felt).
+   * Cleared automatically once handleOnFocus rebuilds `focus` from `literalIndex` on the resulting
+   * native focus event.
+   */
+  selectAll?: boolean;
+};
 
 export type LetterEditorState = {
   info: BrevInfo;

--- a/skribenten-web/frontend/src/hooks/useBrevEditorWarnings.ts
+++ b/skribenten-web/frontend/src/hooks/useBrevEditorWarnings.ts
@@ -3,7 +3,7 @@ import { type UseFormReturn } from "react-hook-form";
 
 import {
   countMissingFromTemplateBlocks,
-  countUnfilledFritekstPlaceholders,
+  countUneditedFritekstPlaceholders,
 } from "~/Brevredigering/LetterEditor/actions/common";
 import { type WarnModalKind } from "~/Brevredigering/LetterEditor/components/warnModal";
 import {
@@ -58,8 +58,8 @@ export function useBrevEditorWarnings<FormSchema extends { saksbehandlerValg: Sa
     });
   }, [form, filteredSpecification, status]);
 
-  const numberOfUnfilledFritekstPlaceholders = useCallback(
-    () => countUnfilledFritekstPlaceholders(redigertBrev),
+  const numberOfUneditedFritekstPlaceholders = useCallback(
+    () => countUneditedFritekstPlaceholders(redigertBrev),
     [redigertBrev],
   );
 
@@ -69,15 +69,15 @@ export function useBrevEditorWarnings<FormSchema extends { saksbehandlerValg: Sa
   );
 
   const getWarning = useCallback((): WarningResult => {
-    const unfilled = numberOfUnfilledFritekstPlaceholders();
+    const unedited = numberOfUneditedFritekstPlaceholders();
     const missingRequired = hasMissingRequiredSaksbehandlerValg();
     const missingFromTemplate = numberOfMissingFromTemplateBlocks();
 
-    if (unfilled > 0 && missingRequired) {
-      return { kind: "fritekstOgTekstValg", count: unfilled };
+    if (unedited > 0 && missingRequired) {
+      return { kind: "fritekstOgTekstValg", count: unedited };
     }
-    if (unfilled > 0) {
-      return { kind: "fritekst", count: unfilled };
+    if (unedited > 0) {
+      return { kind: "fritekst", count: unedited };
     }
     if (missingRequired) {
       return { kind: "tekstValg" };
@@ -86,7 +86,7 @@ export function useBrevEditorWarnings<FormSchema extends { saksbehandlerValg: Sa
       return { kind: "avsnittIkkeIMal", count: missingFromTemplate };
     }
     return null;
-  }, [hasMissingRequiredSaksbehandlerValg, numberOfUnfilledFritekstPlaceholders, numberOfMissingFromTemplateBlocks]);
+  }, [hasMissingRequiredSaksbehandlerValg, numberOfUneditedFritekstPlaceholders, numberOfMissingFromTemplateBlocks]);
 
-  return { getWarning, hasMissingRequiredSaksbehandlerValg, numberOfUnfilledFritekstPlaceholders };
+  return { getWarning, hasMissingRequiredSaksbehandlerValg, numberOfUneditedFritekstPlaceholders };
 }

--- a/skribenten-web/frontend/src/routes/saksnummer_/$saksId/attester.$brevId/redigering.tsx
+++ b/skribenten-web/frontend/src/routes/saksnummer_/$saksId/attester.$brevId/redigering.tsx
@@ -10,6 +10,7 @@ import { z } from "zod";
 
 import { getBrevAttestering, getBrevReservasjon, oppdaterBrev } from "~/api/brev-queries";
 import { attesterBrev } from "~/api/sak-api-endpoints";
+import { findFirstUneditedFritekstFocus } from "~/Brevredigering/LetterEditor/actions/common";
 import { WarnModal, type WarnModalKind } from "~/Brevredigering/LetterEditor/components/warnModal";
 import {
   createLetterSnapshot,
@@ -394,6 +395,12 @@ const Vedtak = (props: { saksId: string; brev: BrevResponse; doReload: () => voi
           onClose={() => {
             pendingSubmitValuesRef.current = null;
             setWarnOpen(false);
+            if (warn?.kind === "fritekst" || warn?.kind === "fritekstOgTekstValg") {
+              const focus = findFirstUneditedFritekstFocus(editorState.redigertBrev);
+              if (focus) {
+                setEditorState((s) => ({ ...s, focus }));
+              }
+            }
             setWarn(null);
           }}
           onFortsett={() => {

--- a/skribenten-web/frontend/src/routes/saksnummer_/$saksId/brev.$brevId.tsx
+++ b/skribenten-web/frontend/src/routes/saksnummer_/$saksId/brev.$brevId.tsx
@@ -7,6 +7,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { getBrev, getBrevmetadata, getBrevReservasjon, oppdaterBrev } from "~/api/brev-queries";
+import { findFirstUneditedFritekstFocus } from "~/Brevredigering/LetterEditor/actions/common";
 import { WarnModal, type WarnModalKind } from "~/Brevredigering/LetterEditor/components/warnModal";
 import { createLetterSnapshot, createSaksbehandlerValgEndretHistoryEntry } from "~/Brevredigering/LetterEditor/history";
 import {
@@ -456,6 +457,12 @@ function RedigerBrev({
               onClose={() => {
                 pendingSubmitValuesRef.current = null;
                 setWarnOpen(false);
+                if (warn?.kind === "fritekst" || warn?.kind === "fritekstOgTekstValg") {
+                  const focus = findFirstUneditedFritekstFocus(editorState.redigertBrev);
+                  if (focus) {
+                    setEditorState((s) => ({ ...s, focus }));
+                  }
+                }
                 setWarn(null);
               }}
               onFortsett={() => {

--- a/skribenten-web/frontend/test/modules/LetterEditor/actions/common.test.ts
+++ b/skribenten-web/frontend/test/modules/LetterEditor/actions/common.test.ts
@@ -6,6 +6,7 @@ import {
   buildMergedItemList,
   coalesceAdjacentSameTypeLists,
   findAdjoiningContent,
+  findFirstUneditedFritekstFocus,
   isFromTemplate,
   isNew,
   removeElements,
@@ -15,14 +16,16 @@ import {
 import { isTextContent } from "~/Brevredigering/LetterEditor/model/utils";
 import {
   type Content,
+  ElementTags,
   type Identifiable,
   type ItemList,
   ListType,
   type LiteralValue,
   type TextContent,
+  TITLE_INDEX,
 } from "~/types/brevbakerTypes";
 
-import { item, itemList, letter, literal, paragraph } from "../utils";
+import { cell, editedLetter, item, itemList, letter, literal, paragraph, row, table, title1 } from "../utils";
 
 describe("findAdjoiningContent", () => {
   describe("entire array matches", () => {
@@ -438,5 +441,128 @@ describe("isNew / isFromTemplate", () => {
     expect(isNew(obj)).toBe(true);
     expect(isFromTemplate(obj)).toBe(false);
     expect(isNew(obj)).toBe(!isFromTemplate(obj));
+  });
+});
+
+describe("findFirstUneditedFritekstFocus", () => {
+  const fritekst = (text: string, editedText?: string | null) =>
+    literal({ text, tags: [ElementTags.FRITEKST], editedText });
+
+  test("returns null when the letter has no fritekst literals at all", () => {
+    const letterState = editedLetter({ blocks: [paragraph([literal("plain text")])] });
+    expect(findFirstUneditedFritekstFocus(letterState)).toBeNull();
+  });
+
+  test("returns null when every fritekst felt has already been edited", () => {
+    const letterState = editedLetter({
+      blocks: [paragraph([fritekst("skriv her", "utfylt tekst")])],
+    });
+    expect(findFirstUneditedFritekstFocus(letterState)).toBeNull();
+  });
+
+  test("finds a single unedited fritekst felt directly in a paragraph", () => {
+    const letterState = editedLetter({
+      blocks: [paragraph([literal("before "), fritekst("skriv her"), literal(" after")])],
+    });
+    expect(findFirstUneditedFritekstFocus(letterState)).toEqual({
+      blockIndex: 0,
+      contentIndex: 1,
+      cursorPosition: 0,
+    });
+  });
+
+  test("returns the first unedited fritekst felt in document order when several exist", () => {
+    const letterState = editedLetter({
+      blocks: [
+        paragraph([literal("first paragraph")]),
+        paragraph([fritekst("first fritekst"), fritekst("second fritekst")]),
+      ],
+    });
+    expect(findFirstUneditedFritekstFocus(letterState)).toEqual({
+      blockIndex: 1,
+      contentIndex: 0,
+      cursorPosition: 0,
+    });
+  });
+
+  test("skips already-edited fritekst felt and returns the next unedited one", () => {
+    const letterState = editedLetter({
+      blocks: [paragraph([fritekst("first", "already filled in"), fritekst("second")])],
+    });
+    expect(findFirstUneditedFritekstFocus(letterState)).toEqual({
+      blockIndex: 0,
+      contentIndex: 1,
+      cursorPosition: 0,
+    });
+  });
+
+  test("finds an unedited fritekst felt nested inside an item-list item", () => {
+    const letterState = editedLetter({
+      blocks: [
+        paragraph([
+          itemList({
+            items: [item(literal("regular item")), item(fritekst("fritekst i liste"))],
+          }),
+        ]),
+      ],
+    });
+    expect(findFirstUneditedFritekstFocus(letterState)).toEqual({
+      blockIndex: 0,
+      contentIndex: 0,
+      itemIndex: 1,
+      itemContentIndex: 0,
+      cursorPosition: 0,
+    });
+  });
+
+  test("finds an unedited fritekst felt nested inside a table header cell", () => {
+    const letterState = editedLetter({
+      blocks: [paragraph([table([cell(fritekst("kolonneoverskrift"))], [row(cell(literal("celleinnhold")))])])],
+    });
+    expect(findFirstUneditedFritekstFocus(letterState)).toEqual({
+      blockIndex: 0,
+      contentIndex: 0,
+      rowIndex: -1,
+      cellIndex: 0,
+      cellContentIndex: 0,
+      cursorPosition: 0,
+    });
+  });
+
+  test("finds an unedited fritekst felt nested inside a table body cell", () => {
+    const letterState = editedLetter({
+      blocks: [paragraph([table([cell(literal("kolonneoverskrift"))], [row(cell(fritekst("celleinnhold")))])])],
+    });
+    expect(findFirstUneditedFritekstFocus(letterState)).toEqual({
+      blockIndex: 0,
+      contentIndex: 0,
+      rowIndex: 0,
+      cellIndex: 0,
+      cellContentIndex: 0,
+      cursorPosition: 0,
+    });
+  });
+
+  test("finds an unedited fritekst felt in the letter title, before any block", () => {
+    const letterState = editedLetter({
+      title: { text: [fritekst("tittel")], deletedContent: [] },
+      blocks: [paragraph([fritekst("i brødtekst")])],
+    });
+    expect(findFirstUneditedFritekstFocus(letterState)).toEqual({
+      blockIndex: TITLE_INDEX,
+      contentIndex: 0,
+      cursorPosition: 0,
+    });
+  });
+
+  test("finds an unedited fritekst felt in a within-body heading block (TITLE1/2/3)", () => {
+    const letterState = editedLetter({
+      blocks: [title1(fritekst("overskrift")), paragraph([literal("brødtekst")])],
+    });
+    expect(findFirstUneditedFritekstFocus(letterState)).toEqual({
+      blockIndex: 0,
+      contentIndex: 0,
+      cursorPosition: 0,
+    });
   });
 });

--- a/skribenten-web/frontend/test/modules/LetterEditor/actions/common.test.ts
+++ b/skribenten-web/frontend/test/modules/LetterEditor/actions/common.test.ts
@@ -468,6 +468,7 @@ describe("findFirstUneditedFritekstFocus", () => {
       blockIndex: 0,
       contentIndex: 1,
       cursorPosition: 0,
+      selectAll: true,
     });
   });
 
@@ -482,6 +483,7 @@ describe("findFirstUneditedFritekstFocus", () => {
       blockIndex: 1,
       contentIndex: 0,
       cursorPosition: 0,
+      selectAll: true,
     });
   });
 
@@ -493,6 +495,7 @@ describe("findFirstUneditedFritekstFocus", () => {
       blockIndex: 0,
       contentIndex: 1,
       cursorPosition: 0,
+      selectAll: true,
     });
   });
 
@@ -512,6 +515,7 @@ describe("findFirstUneditedFritekstFocus", () => {
       itemIndex: 1,
       itemContentIndex: 0,
       cursorPosition: 0,
+      selectAll: true,
     });
   });
 
@@ -526,6 +530,7 @@ describe("findFirstUneditedFritekstFocus", () => {
       cellIndex: 0,
       cellContentIndex: 0,
       cursorPosition: 0,
+      selectAll: true,
     });
   });
 
@@ -540,6 +545,7 @@ describe("findFirstUneditedFritekstFocus", () => {
       cellIndex: 0,
       cellContentIndex: 0,
       cursorPosition: 0,
+      selectAll: true,
     });
   });
 
@@ -552,6 +558,7 @@ describe("findFirstUneditedFritekstFocus", () => {
       blockIndex: TITLE_INDEX,
       contentIndex: 0,
       cursorPosition: 0,
+      selectAll: true,
     });
   });
 
@@ -563,6 +570,7 @@ describe("findFirstUneditedFritekstFocus", () => {
       blockIndex: 0,
       contentIndex: 0,
       cursorPosition: 0,
+      selectAll: true,
     });
   });
 });


### PR DESCRIPTION
[Hjelp attestand med å fylle ut fritekst](https://nav-it.slack.com/lists/T5LNAMWNA/F0B6WDJUS4W?record_id=Rec0BH8VATS65)

## Hva
Når brukeren klikker "Fortsett" i brevredigering (`brev.$brevId.tsx` eller `attester/redigering.tsx`) og brevet inneholder uredigerte fritekstfelt, vises en advarselsmodal med valget "Bli her" / "Fortsett".
Klikker brukeren "Bli her" (eller lukker modalen med "X"), flyttes fokus nå til det første uredigerte fritekstfeltet i brevet, og hele feltet markeres med samme funksjonalitet som når man klikker på/tabber til et fritekstfelt.

## Endringer
- Ny funksjon `findFirstUneditedFritekstFocus` i `actions/common.ts` som finner `Focus` for det første uredigerte fritekstfeltet i dokumentrekkefølge (tittel → blokker → avsnitt/lister/tabeller).
- Delt traverseringslogikk (`findLiteral`) mellom denne og `collectAllLiteralValues` for å unngå duplisert traversering.
- `onClose`-handler for `WarnModal` («Bli her» og «X») setter nytt fokus når varselet gjelder `fritekst`/`fritekstOgTekstValg`.
- Gjenbruker eksisterende fokus-/markeringsmekanikk i `ContentGroup.tsx` (`focusAtOffset` + `handleOnFocus`)

## Testing
- 11 nye tester i `common.test.ts`