### PR TITLE
Forbedre datastruktur for UnifiedDiff slik at den også inneholder fullstendig slettede elementer

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/DiffBrevHandler.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/brevredigering/application/usecases/DiffBrevHandler.kt
@@ -8,7 +8,7 @@ import no.nav.pensjon.brev.skribenten.fagsystem.BrevmalService
 import no.nav.pensjon.brev.skribenten.letter.DiffSegment
 import no.nav.pensjon.brev.skribenten.letter.Edit
 import no.nav.pensjon.brev.skribenten.letter.EditLetterWordDiff
-import no.nav.pensjon.brev.skribenten.letter.UnifiedDeleteSegment
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.BlockEdit
 import no.nav.pensjon.brev.skribenten.letter.toEdit
 import no.nav.pensjon.brev.skribenten.model.BrevId
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -22,8 +22,8 @@ class DiffBrevHandler(
 
     sealed class Response {
         data class Unified(
-            val inserts: List<DiffSegment>,
-            val deletes: List<UnifiedDeleteSegment>,
+            val editedBlocks: Map<Int, BlockEdit>,
+            val deletedBlocks: Map<Int, List<Edit.Block>>,
         ) : Response()
 
         data class Split(
@@ -47,12 +47,12 @@ class DiffBrevHandler(
 
         val wordDiff = EditLetterWordDiff()
         return if (request.split) {
-            wordDiff.diff(old = rendretBrev, new = request.redigertBrev).let { (inserts, deletes) ->
-                success(Response.Split(inserts = inserts, deletes = deletes, rendretBrev = rendretBrev))
+            wordDiff.diff(old = rendretBrev, new = request.redigertBrev).let { diff ->
+                success(Response.Split(inserts = diff.inserts, deletes = diff.deletes, rendretBrev = rendretBrev))
             }
         } else {
-            wordDiff.unifiedDiff(old = rendretBrev, new = request.redigertBrev).let { (inserts, deletes) ->
-                success(Response.Unified(inserts = inserts, deletes = deletes))
+            wordDiff.unifiedDiff(old = rendretBrev, new = request.redigertBrev).let { diff ->
+                success(Response.Unified(editedBlocks = diff.editedBlocks, deletedBlocks = diff.deletedBlocks))
             }
         }
     }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/common/diff/DiffEntry.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/common/diff/DiffEntry.kt
@@ -19,4 +19,13 @@ sealed class DiffEntry<T> {
         is Replace -> Change.Replace(transform(old), transform(new))
         is Unchanged -> null
     }
+
+    inline fun <reified R : T> narrow(): DiffEntry<R> = map { it as R }
+
+    fun <R> map(transform: (T) -> R): DiffEntry<R> = when (this) {
+        is Insert -> Insert(transform(new))
+        is Delete -> Delete(transform(old))
+        is Replace -> Replace(transform(old), transform(new))
+        is Unchanged -> Unchanged(transform(value))
+    }
 }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/common/diff/ReplaceAwareEditScriptCursor.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/common/diff/ReplaceAwareEditScriptCursor.kt
@@ -66,25 +66,55 @@ class ReplaceAwareEditScriptCursor<T : Any>(editScript: EditScript<T>) {
     }
 
     /**
-     * Like [forEachIndexed], but stabilizes the insert/delete index passed to [action] so that it always refers to
-     * an index that has actually been produced/matched on that side.
+     * The insert/delete index for a single entry yielded by [forEachIndexedStable].
+     *
+     * [insertIndex] only advances when an entry genuinely, non-decoy-ly consumes the insert side (see
+     * [forEachIndexedStable]'s `action` doc for what "decoy" means) - so a [Delete] entry (or a decoy) is paired
+     * with the index that would apply to a *future*, genuinely-established insert-side entry, which may not exist
+     * yet (or at all). This correctly distinguishes a leading delete (attributed to the position before the next
+     * real entry) from a trailing delete (attributed to the position one past the last real entry), and is safe to
+     * use both as a placement key (e.g. into a `deletedContent` map) and as an anchor for nested processing that
+     * needs an already-established position, since it is never used to index into an actual array.
+     *
+     * [rawDeleteIndex]/[stableDeleteIndex] mirror the insert-side distinction from before decoy-correction was
+     * needed, but only for the delete side, where no decoy concept applies: every element of the old sequence is
+     * visited exactly once, so [rawDeleteIndex] (this entry's own position) is always a real, meaningful position for
+     * an entry's own reporting, while [stableDeleteIndex] (the last real position) is what nested processing inside
+     * an [Insert] entry (which doesn't itself consume any delete-side position) should anchor to instead.
+     */
+    class StableIndices(
+        val insertIndex: Int,
+        val rawDeleteIndex: Int,
+        val stableDeleteIndex: Int,
+    )
+
+    /**
+     * Like [forEachIndexed], but additionally provides a decoy-corrected insert index and a stabilized delete index
+     * - see [StableIndices].
      *
      * [forEachIndexed] advances insertIndex/deleteIndex only when an entry actually consumes that side, meaning a
      * pure [Delete] entry is invoked with the (unconsumed) insertIndex that would apply to a *future* insert-side
      * entry - even when no such entry exists (e.g. because the insert-side sequence is already exhausted). Any
      * insert-side content nested inside such an entry's processing (e.g. leftover words belonging to an already
      * matched/Unchanged marker) would then incorrectly be attributed to this non-existent "next" index, rather than
-     * the last real one. This function instead reuses the last real index for the side that isn't consumed by the
-     * current entry, so nested processing always sees a valid, already-established index.
+     * the last real one.
+     *
+     * [action] returns whether the entry's insert-side pairing turned out to be a decoy despite its own [DiffEntry]
+     * classification suggesting otherwise - e.g. an [Unchanged]/[Replace] entry that weak, content-blind equality
+     * paired with an unrelated node, which nested analysis then reveals carries no real surviving content on the
+     * insert side (see e.g. `EditLetterWordTokenizer.consumeTextContent`'s `isWholeNodeGone`). When `true`, this
+     * entry is excluded from [StableIndices.insertIndex]'s bookkeeping (as if it were a [Delete]), so that later
+     * entries aren't advanced past a position that was never genuinely established - which would otherwise
+     * misattribute a later, genuinely leading delete to a spurious "next" position. [Delete] entries are always
+     * excluded regardless of the returned value, since they never consume the insert side to begin with.
      */
-    inline fun <reified E : T> forEachIndexedStable(action: (insertIndex: Int, deleteIndex: Int, DiffEntry<E>) -> Unit) {
-        var lastInsertIndex = 0
+    inline fun <reified E : T> forEachIndexedStable(action: (indices: StableIndices, entry: DiffEntry<E>) -> Boolean) {
+        var insertIndex = 0
         var lastDeleteIndex = 0
-        forEachIndexed<E> { insertIndex, deleteIndex, entry ->
-            val stableInsertIndex = if (entry is Delete) lastInsertIndex else insertIndex
+        forEachIndexed<E> { _, deleteIndex, entry ->
             val stableDeleteIndex = if (entry is Insert) lastDeleteIndex else deleteIndex
-            action(stableInsertIndex, stableDeleteIndex, entry)
-            if (entry !is Delete) lastInsertIndex = insertIndex
+            val insertSideWasDecoy = action(StableIndices(insertIndex, deleteIndex, stableDeleteIndex), entry)
+            if (entry !is Delete && !insertSideWasDecoy) insertIndex++
             if (entry !is Insert) lastDeleteIndex = deleteIndex
         }
     }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/DiffProducer.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/DiffProducer.kt
@@ -15,6 +15,7 @@ interface DiffProducer<R> {
     data class TableInfo(val id: Int?)
     data class RowInfo(val id: Int?)
     data class CellInfo(val id: Int?)
+    data class TextContentInfo(val id: Int?)
     data class TextSegment(val startOffset: Int, val endOffset: Int, val text: String)
 
     fun block(insertIndex: BlockIndex, deleteIndex: BlockIndex, change: Change<BlockInfo>) {}
@@ -23,6 +24,13 @@ interface DiffProducer<R> {
     fun table(insertIndex: BlockContentIndex, deleteIndex: BlockContentIndex, change: Change<TableInfo>) {}
     fun row(insertIndex: TableRowIndex, deleteIndex: TableRowIndex, change: Change<RowInfo>) {}
     fun cell(insertIndex: TableCellIndex, deleteIndex: TableCellIndex, change: Change<CellInfo>) {}
+    // Fires a Delete when an entire Text (Literal/Variable) node's content is genuinely, entirely gone (no word
+    // survived elsewhere); also fires Insert/Delete/Replace for whole NewLine nodes (which have no word-level
+    // content of their own). For Text nodes with any surviving or partial word-level content, textSegment fires
+    // instead (never both for the same node) - see its doc.
+    fun textContent(insertIndex: ContentIndex, deleteIndex: ContentIndex, change: Change<TextContentInfo>) {}
+    // Fires for word-level changes within a Text node whose surrounding node is not being reported via
+    // textContent (i.e. some of its words survived, were reused, or it's otherwise still "there" in some form).
     fun textSegment(insertIndex: ContentIndex, deleteIndex: ContentIndex, change: Change<TextSegment>) {}
 
     fun build(): R

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterDiff.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterDiff.kt
@@ -27,13 +27,81 @@ sealed class ContentIndex {
         fun withTextContentIndex(idx: Int) = TableCellContentIndex(blockIndex, contentIndex, rowIndex, cellIndex, idx)
     }
     data class TableCellContentIndex(val blockIndex: Int, val contentIndex: Int, val rowIndex: Int, val cellIndex: Int, val cellContentIndex: Int) : ContentIndex()
+
+    /** The ContentIndex of the immediate containing element, or null if this is a top-level BlockIndex. */
+    fun parent(): ContentIndex? = when (this) {
+        is BlockIndex -> null
+        is BlockContentIndex -> BlockIndex(blockIndex)
+        is ItemIndex -> BlockContentIndex(blockIndex, contentIndex)
+        is ItemContentIndex -> ItemIndex(blockIndex, contentIndex, itemIndex)
+        is TableRowIndex -> BlockContentIndex(blockIndex, contentIndex)
+        is TableCellIndex -> TableRowIndex(blockIndex, contentIndex, rowIndex)
+        is TableCellContentIndex -> TableCellIndex(blockIndex, contentIndex, rowIndex, cellIndex)
+    }
 }
 
 data class DiffSegment(val index: ContentIndex, val startOffset: Int, val endOffset: Int)
 
-data class UnifiedDeleteSegment(val index: ContentIndex, val startOffset: Int, val endOffset: Int, val text: String)
-
 data class SplitDiff(val inserts: List<DiffSegment>, val deletes: List<DiffSegment>)
 
-data class UnifiedDiff(val inserts: List<DiffSegment>, val deletes: List<UnifiedDeleteSegment>)
+/**
+ * editedBlocks: a map of partially edited blocks where
+ *    - the key is the blockIndex of the blocks with edits
+ *    - the value is a BlockEdit
+ * deletedBlocks: a map of entirely deleted blocks where
+ *    - the key is the blockIndex of where it should be displayed in the unified diff as deleted
+ *    - the value is a list of entire blocks that should be displayed in the unified diff
+ */
+data class UnifiedDiff(val editedBlocks: Map<Int, BlockEdit>, val deletedBlocks: Map<Int, List<Edit.Block>>) {
 
+    /**
+     * Represents the edits inside a block.
+     *
+     * contentEdits: a map of partially edited content where
+     *    - the key is the contentIndex of the content with edits
+     *    - the value is a ContentEdit
+     * deletedContent: a map that is similar to deletedBlocks, just for the content of a block instead, where
+     *  - the key is the contentIndex of where it should be displayed in the unified diff of the block
+     *  - the value is a list of the entirely deleted content that should be displayed in the unified diff
+     */
+    data class BlockEdit(val contentEdits: Map<Int, ContentEdit>, val deletedContent: Map<Int, List<Edit.ParagraphContent>>)
+
+    /** Represents an edit to a single piece of ParagraphContent within a block. */
+    sealed class ContentEdit {
+        data class TextContentEdit(val edit: TextEdit) : ContentEdit()
+
+        data class ItemListEdit(val itemEdits: Map<Int, TextOnlyEdit>, val deletedItems: Map<Int, List<Edit.ParagraphContent.ItemList.Item>>) : ContentEdit()
+
+        data class TableEdit(val rowEdits: Map<Int, RowEdit>, val deletedRows: Map<Int, List<Edit.ParagraphContent.Table.Row>>) : ContentEdit()
+    }
+
+    /** A single word-level range within a still-existing piece of text. */
+    data class TextSegment(val startOffset: Int, val endOffset: Int)
+
+    /** A single word-level range that was removed from a still-existing piece of text, carrying the removed text itself. */
+    data class DeletedTextSegment(val startOffset: Int, val endOffset: Int, val text: String)
+
+    /** Word-level edits within a single, still-existing Text (Literal/Variable/NewLine) content node. */
+    data class TextEdit(val inserts: List<TextSegment>, val deletes: List<DeletedTextSegment>)
+
+    /**
+     * Edits within a content list that only ever holds Text content (ItemList.Item content, Table.Cell content).
+     *
+     * textEdits: a map of word-level edits inside still-existing Text content, where
+     *    - the key is the itemContentIndex/cellContentIndex of the Text content with edits
+     *    - the value is the TextEdit
+     * deletedContent: a map of entirely deleted Text content, where
+     *    - the key is the itemContentIndex/cellContentIndex of where it should be displayed in the unified diff
+     *    - the value is a list of the entirely deleted Text content that should be displayed in the unified diff
+     */
+    data class TextOnlyEdit(val textEdits: Map<Int, TextEdit>, val deletedContent: Map<Int, List<Edit.ParagraphContent.Text>>)
+
+    /**
+     * Edits within a single row of a table.
+     *
+     * cellEdits: similar to contentEdits in BlockEdit, just for the cells of a row instead
+     * deletedCells: similar to deletedContent in BlockEdit, just for the cells of a row instead
+     */
+    data class RowEdit(val cellEdits: Map<Int, TextOnlyEdit>, val deletedCells: Map<Int, List<Edit.ParagraphContent.Table.Cell>>)
+
+}

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordDiff.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordDiff.kt
@@ -3,6 +3,13 @@ package no.nav.pensjon.brev.skribenten.letter
 import no.nav.pensjon.brev.skribenten.common.diff.Change
 import no.nav.pensjon.brev.skribenten.common.diff.shortestEditScript
 import no.nav.pensjon.brev.skribenten.letter.EditLetterWordTokenizer.Token
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.BlockEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.ContentEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.DeletedTextSegment
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.RowEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.TextEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.TextOnlyEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.TextSegment
 
 class EditLetterWordDiff {
 
@@ -14,7 +21,7 @@ class EditLetterWordDiff {
         tokenizer.parseTokens(shortestEditScript(tokenizer.tokenize(old), tokenizer.tokenize(new)), SplitDiffProducer())
 
     fun unifiedDiff(old: Edit.Letter, new: Edit.Letter): UnifiedDiff =
-        tokenizer.parseTokens(shortestEditScript(tokenizer.tokenize(old), tokenizer.tokenize(new)), UnifiedDiffProducer())
+        tokenizer.parseTokens(shortestEditScript(tokenizer.tokenize(old), tokenizer.tokenize(new)), UnifiedDiffProducer(old))
 
     private class SplitDiffProducer : DiffProducer<SplitDiff> {
         private val inserts = mutableListOf<DiffSegment>()
@@ -34,24 +41,234 @@ class EditLetterWordDiff {
         override fun build() = SplitDiff(inserts.toList(), deletes.toList())
     }
 
-    private class UnifiedDiffProducer : DiffProducer<UnifiedDiff> {
-        private val inserts = mutableListOf<DiffSegment>()
-        private val deletes = mutableListOf<UnifiedDeleteSegment>()
+    /**
+     * Builds a [UnifiedDiff]. All positions used to key the resulting maps use insertIndex (not deleteIndex),
+     * since that reflects the position in the merged (unified/`new`) view, unlike deleteIndex which is the
+     * position in `old` and drifts whenever entirely deleted content precedes it.
+     *
+     * Entirely deleted content is looked up in [old] via deleteIndex (which correctly indexes into `old` for
+     * pure deletes) and embedded directly, so the frontend doesn't need `old` sent alongside the diff. Once a
+     * container (block/itemList/item/table/row) is known to be entirely deleted, further nested callbacks for
+     * its content are ignored, since that content is already embedded recursively in the container itself.
+     */
+    private class UnifiedDiffProducer(private val old: Edit.Letter) : DiffProducer<UnifiedDiff> {
+        private val editedBlocks = mutableMapOf<Int, MutableBlockEdit>()
+        private val deletedBlocks = mutableMapOf<Int, MutableList<Edit.Block>>()
 
-        // Deletes use insertIndex (not deleteIndex) since it reflects the position in the merged (unified) view,
-        // unlike deleteIndex which is the position in the old document and drifts whenever entirely deleted
-        // content precedes it.
+        // Keyed by deleteIndex (not insertIndex): deleteIndex uniquely identifies each node in `old`, since the
+        // delete-side cursor advances exactly once per old-side node regardless of whether it's a delete or not.
+        // insertIndex can't be used here, since it does not advance for pure deletes - so a wholly deleted
+        // container and the very next surviving sibling can end up sharing the same insertIndex (they're both
+        // "at" the same unified position), which would make isAncestorDeleted wrongly conflate them.
+        private val deletedPositions = mutableSetOf<ContentIndex>()
+
+        private fun isAncestorDeleted(deleteIndex: ContentIndex): Boolean =
+            generateSequence(deleteIndex.parent(), ContentIndex::parent).any { it in deletedPositions }
+
+        private fun blockEdit(blockIndex: Int): MutableBlockEdit = editedBlocks.getOrPut(blockIndex) { MutableBlockEdit() }
+
+        private fun itemListEdit(blockIndex: Int, contentIndex: Int): MutableContentEdit.ItemListEdit =
+            blockEdit(blockIndex).contentEdits.getOrPut(contentIndex) { MutableContentEdit.ItemListEdit() } as MutableContentEdit.ItemListEdit
+
+        private fun tableEdit(blockIndex: Int, contentIndex: Int): MutableContentEdit.TableEdit =
+            blockEdit(blockIndex).contentEdits.getOrPut(contentIndex) { MutableContentEdit.TableEdit() } as MutableContentEdit.TableEdit
+
+        private fun textContentEdit(blockIndex: Int, contentIndex: Int): MutableContentEdit.TextContentEdit =
+            blockEdit(blockIndex).contentEdits.getOrPut(contentIndex) { MutableContentEdit.TextContentEdit() } as MutableContentEdit.TextContentEdit
+
+        private fun rowEdit(blockIndex: Int, contentIndex: Int, rowIndex: Int): MutableRowEdit =
+            tableEdit(blockIndex, contentIndex).rowEdits.getOrPut(rowIndex) { MutableRowEdit() }
+
+        private fun textOnlyEditFor(index: ContentIndex): MutableTextOnlyEdit = when (index) {
+            is ContentIndex.ItemContentIndex ->
+                itemListEdit(index.blockIndex, index.contentIndex).itemEdits.getOrPut(index.itemIndex) { MutableTextOnlyEdit() }
+            is ContentIndex.TableCellContentIndex ->
+                rowEdit(index.blockIndex, index.contentIndex, index.rowIndex).cellEdits.getOrPut(index.cellIndex) { MutableTextOnlyEdit() }
+            else -> error("textOnlyEditFor called with unexpected index: $index")
+        }
+
+        override fun block(insertIndex: ContentIndex.BlockIndex, deleteIndex: ContentIndex.BlockIndex, change: Change<DiffProducer.BlockInfo>) {
+            if (change is Change.Delete) {
+                deletedPositions += deleteIndex
+                deletedBlocks.getOrPut(insertIndex.blockIndex) { mutableListOf() }.add(old.blocks[deleteIndex.blockIndex])
+            }
+        }
+
+        override fun itemList(insertIndex: ContentIndex.BlockContentIndex, deleteIndex: ContentIndex.BlockContentIndex, change: Change<DiffProducer.ItemListInfo>) {
+            if (isAncestorDeleted(deleteIndex)) return
+            if (change is Change.Delete) {
+                deletedPositions += deleteIndex
+                blockEdit(insertIndex.blockIndex).deletedContent.getOrPut(insertIndex.contentIndex) { mutableListOf() }
+                    .add(old.blocks[deleteIndex.blockIndex].content[deleteIndex.contentIndex])
+            }
+        }
+
+        override fun table(insertIndex: ContentIndex.BlockContentIndex, deleteIndex: ContentIndex.BlockContentIndex, change: Change<DiffProducer.TableInfo>) {
+            if (isAncestorDeleted(deleteIndex)) return
+            if (change is Change.Delete) {
+                deletedPositions += deleteIndex
+                blockEdit(insertIndex.blockIndex).deletedContent.getOrPut(insertIndex.contentIndex) { mutableListOf() }
+                    .add(old.blocks[deleteIndex.blockIndex].content[deleteIndex.contentIndex])
+            }
+        }
+
+        override fun item(insertIndex: ContentIndex.ItemIndex, deleteIndex: ContentIndex.ItemIndex, change: Change<DiffProducer.ItemInfo>) {
+            if (isAncestorDeleted(deleteIndex)) return
+            if (change is Change.Delete) {
+                deletedPositions += deleteIndex
+                val oldItemList = old.blocks[deleteIndex.blockIndex].content[deleteIndex.contentIndex] as Edit.ParagraphContent.ItemList
+                itemListEdit(insertIndex.blockIndex, insertIndex.contentIndex).deletedItems
+                    .getOrPut(insertIndex.itemIndex) { mutableListOf() }
+                    .add(oldItemList.items[deleteIndex.itemIndex])
+            }
+        }
+
+        override fun row(insertIndex: ContentIndex.TableRowIndex, deleteIndex: ContentIndex.TableRowIndex, change: Change<DiffProducer.RowInfo>) {
+            if (isAncestorDeleted(deleteIndex)) return
+            if (change is Change.Delete) {
+                deletedPositions += deleteIndex
+                val oldTable = old.blocks[deleteIndex.blockIndex].content[deleteIndex.contentIndex] as Edit.ParagraphContent.Table
+                tableEdit(insertIndex.blockIndex, insertIndex.contentIndex).deletedRows
+                    .getOrPut(insertIndex.rowIndex) { mutableListOf() }
+                    .add(oldTable.rows[deleteIndex.rowIndex])
+            }
+        }
+
+        override fun cell(insertIndex: ContentIndex.TableCellIndex, deleteIndex: ContentIndex.TableCellIndex, change: Change<DiffProducer.CellInfo>) {
+            if (isAncestorDeleted(deleteIndex)) return
+            if (change is Change.Delete) {
+                deletedPositions += deleteIndex
+                val oldTable = old.blocks[deleteIndex.blockIndex].content[deleteIndex.contentIndex] as Edit.ParagraphContent.Table
+                val oldCell = if (deleteIndex.rowIndex == -1)
+                    oldTable.header.colSpec[deleteIndex.cellIndex].headerContent
+                else
+                    oldTable.rows[deleteIndex.rowIndex].cells[deleteIndex.cellIndex]
+                rowEdit(insertIndex.blockIndex, insertIndex.contentIndex, insertIndex.rowIndex).deletedCells
+                    .getOrPut(insertIndex.cellIndex) { mutableListOf() }
+                    .add(oldCell)
+            }
+        }
+
+        override fun textContent(insertIndex: ContentIndex, deleteIndex: ContentIndex, change: Change<DiffProducer.TextContentInfo>) {
+            if (change !is Change.Delete) return
+            if (isAncestorDeleted(deleteIndex)) return
+
+            val deletedText = textAt(deleteIndex)
+            when (insertIndex) {
+                is ContentIndex.BlockContentIndex ->
+                    blockEdit(insertIndex.blockIndex).deletedContent.getOrPut(insertIndex.contentIndex) { mutableListOf() }.add(deletedText)
+                is ContentIndex.ItemContentIndex ->
+                    textOnlyEditFor(insertIndex).deletedContent.getOrPut(insertIndex.itemContentIndex) { mutableListOf() }.add(deletedText)
+                is ContentIndex.TableCellContentIndex ->
+                    textOnlyEditFor(insertIndex).deletedContent.getOrPut(insertIndex.cellContentIndex) { mutableListOf() }.add(deletedText)
+                else -> error("textContent fired with unexpected index: $insertIndex")
+            }
+        }
+
         override fun textSegment(insertIndex: ContentIndex, deleteIndex: ContentIndex, change: Change<DiffProducer.TextSegment>) {
+            if (isAncestorDeleted(deleteIndex)) return
+
+            val textEdit = when (insertIndex) {
+                is ContentIndex.BlockContentIndex -> textContentEdit(insertIndex.blockIndex, insertIndex.contentIndex).edit
+                is ContentIndex.ItemContentIndex -> textOnlyEditFor(insertIndex).textEdits.getOrPut(insertIndex.itemContentIndex) { MutableTextEdit() }
+                is ContentIndex.TableCellContentIndex -> textOnlyEditFor(insertIndex).textEdits.getOrPut(insertIndex.cellContentIndex) { MutableTextEdit() }
+                else -> error("textSegment fired with unexpected index: $insertIndex")
+            }
+
             when (change) {
-                is Change.Delete -> deletes.add(UnifiedDeleteSegment(insertIndex, change.old.startOffset, change.old.endOffset, change.old.text))
-                is Change.Insert -> inserts.add(DiffSegment(insertIndex, change.new.startOffset, change.new.endOffset))
+                is Change.Insert -> textEdit.inserts.add(TextSegment(change.new.startOffset, change.new.endOffset))
+                is Change.Delete -> textEdit.deletes.add(DeletedTextSegment(change.old.startOffset, change.old.endOffset, change.old.text))
                 is Change.Replace -> {
-                    inserts.add(DiffSegment(insertIndex, change.new.startOffset, change.new.endOffset))
-                    deletes.add(UnifiedDeleteSegment(insertIndex, change.old.startOffset, change.old.endOffset, change.old.text))
+                    textEdit.inserts.add(TextSegment(change.new.startOffset, change.new.endOffset))
+                    textEdit.deletes.add(DeletedTextSegment(change.old.startOffset, change.old.endOffset, change.old.text))
                 }
             }
         }
 
-        override fun build() = UnifiedDiff(inserts.toList(), deletes.toList())
+        private fun textAt(index: ContentIndex): Edit.ParagraphContent.Text = when (index) {
+            is ContentIndex.BlockContentIndex ->
+                old.blocks[index.blockIndex].content[index.contentIndex] as Edit.ParagraphContent.Text
+            is ContentIndex.ItemContentIndex -> {
+                val itemList = old.blocks[index.blockIndex].content[index.contentIndex] as Edit.ParagraphContent.ItemList
+                itemList.items[index.itemIndex].content[index.itemContentIndex]
+            }
+            is ContentIndex.TableCellContentIndex -> {
+                val table = old.blocks[index.blockIndex].content[index.contentIndex] as Edit.ParagraphContent.Table
+                val cell = if (index.rowIndex == -1) table.header.colSpec[index.cellIndex].headerContent else table.rows[index.rowIndex].cells[index.cellIndex]
+                cell.text[index.cellContentIndex]
+            }
+            else -> error("textAt called with unexpected index: $index")
+        }
+
+        override fun build(): UnifiedDiff = UnifiedDiff(
+            editedBlocks = editedBlocks.mapValues { it.value.build() },
+            deletedBlocks = deletedBlocks.mapValues { it.value.toList() },
+        )
+
+        private class MutableBlockEdit {
+            val contentEdits = mutableMapOf<Int, MutableContentEdit>()
+            val deletedContent = mutableMapOf<Int, MutableList<Edit.ParagraphContent>>()
+
+            fun build() = BlockEdit(
+                contentEdits = contentEdits.mapValues { it.value.build() },
+                deletedContent = deletedContent.mapValues { it.value.toList() },
+            )
+        }
+
+        private sealed class MutableContentEdit {
+            abstract fun build(): ContentEdit
+
+            class TextContentEdit : MutableContentEdit() {
+                val edit = MutableTextEdit()
+                override fun build() = ContentEdit.TextContentEdit(edit.build())
+            }
+
+            class ItemListEdit : MutableContentEdit() {
+                val itemEdits = mutableMapOf<Int, MutableTextOnlyEdit>()
+                val deletedItems = mutableMapOf<Int, MutableList<Edit.ParagraphContent.ItemList.Item>>()
+
+                override fun build() = ContentEdit.ItemListEdit(
+                    itemEdits = itemEdits.mapValues { it.value.build() },
+                    deletedItems = deletedItems.mapValues { it.value.toList() },
+                )
+            }
+
+            class TableEdit : MutableContentEdit() {
+                val rowEdits = mutableMapOf<Int, MutableRowEdit>()
+                val deletedRows = mutableMapOf<Int, MutableList<Edit.ParagraphContent.Table.Row>>()
+
+                override fun build() = ContentEdit.TableEdit(
+                    rowEdits = rowEdits.mapValues { it.value.build() },
+                    deletedRows = deletedRows.mapValues { it.value.toList() },
+                )
+            }
+        }
+
+        private class MutableRowEdit {
+            val cellEdits = mutableMapOf<Int, MutableTextOnlyEdit>()
+            val deletedCells = mutableMapOf<Int, MutableList<Edit.ParagraphContent.Table.Cell>>()
+
+            fun build() = RowEdit(
+                cellEdits = cellEdits.mapValues { it.value.build() },
+                deletedCells = deletedCells.mapValues { it.value.toList() },
+            )
+        }
+
+        private class MutableTextOnlyEdit {
+            val textEdits = mutableMapOf<Int, MutableTextEdit>()
+            val deletedContent = mutableMapOf<Int, MutableList<Edit.ParagraphContent.Text>>()
+
+            fun build() = TextOnlyEdit(
+                textEdits = textEdits.mapValues { it.value.build() },
+                deletedContent = deletedContent.mapValues { it.value.toList() },
+            )
+        }
+
+        private class MutableTextEdit {
+            val inserts = mutableListOf<TextSegment>()
+            val deletes = mutableListOf<DeletedTextSegment>()
+
+            fun build() = TextEdit(inserts.toList(), deletes.toList())
+        }
     }
 }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizer.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizer.kt
@@ -18,27 +18,28 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
     sealed interface Token {
         class Block(val id: Int?, val type: Edit.Block.Type) : Token, EqualityBy<Block>(Block::type)
 
-        sealed interface BlockContent : Token
+        sealed interface BlockContent : Token {
+            val id: Int?
+        }
         sealed interface TextContent : BlockContent
 
-        class ItemList(val id: Int?, val listType: Listetype) : BlockContent, EqualityBy<ItemList>(ItemList::listType)
+        class ItemList(override val id: Int?, val listType: Listetype) : BlockContent, EqualityBy<ItemList>(ItemList::listType)
         class Item(val id: Int?) : Token, EqualityBy<Item>()
 
-        class Table(val id: Int?) : BlockContent, EqualityBy<Table>()
+        class Table(override val id: Int?) : BlockContent, EqualityBy<Table>()
         class TableHeader(val id: Int?) : Token, EqualityBy<TableHeader>()
         class ColumnSpec(val id: Int?, val alignment: Edit.ParagraphContent.Table.ColumnAlignment, val span: Int) : Token, EqualityBy<ColumnSpec>(ColumnSpec::alignment, ColumnSpec::span)
         class Row(val id: Int?) : Token, EqualityBy<Row>()
         class Cell(val id: Int?) : Token, EqualityBy<Cell>()
 
         sealed class Text : TextContent, EqualityBy<Text>(Text::fontType) {
-            abstract val id: Int?
             abstract val fontType: FontType
 
             class Literal(override val id: Int?, override val fontType: FontType) : Text()
             class Variable(override val id: Int?, override val fontType: FontType) : Text()
         }
 
-        class NewLine(val id: Int?) : TextContent, EqualityBy<NewLine>()
+        class NewLine(override val id: Int?) : TextContent, EqualityBy<NewLine>()
         data class Word(val word: String) : Token
     }
 
@@ -70,23 +71,57 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
                 val deleteContentIndex = deleteIndex.withContentIndex(deletePos)
 
                 when (entry.token) {
-                    is Token.Text -> consumeText(insertContentIndex, deleteContentIndex)
-                    is Token.NewLine -> {}
+                    is Token.TextContent -> {
+                        consumeTextContent(insertContentIndex, deleteContentIndex, entry.narrow())
+                    }
                     is Token.ItemList -> {
-                        @Suppress("UNCHECKED_CAST")
-                        consumeItemList(insertContentIndex, deleteContentIndex, entry as DiffEntry<Token.ItemList>)
+                        consumeItemList(insertContentIndex, deleteContentIndex, entry.narrow())
                     }
                     is Token.Table -> {
-                        @Suppress("UNCHECKED_CAST")
-                        consumeTable(insertContentIndex, deleteContentIndex, entry as DiffEntry<Token.Table>)
+                        consumeTable(insertContentIndex, deleteContentIndex, entry.narrow())
                     }
                 }
             }
 
-        private fun consumeText(insertIndex: ContentIndex, deleteIndex: ContentIndex) =
-            cursor.fold(WordDiffCollector(), WordDiffCollector::addEntry)
-                .changes()
-                .forEach { producer.textSegment(insertIndex, deleteIndex, it) }
+        // Fires textContent for the whole node (Text or NewLine); for Text nodes, also diffs the words within it.
+        //
+        // A Text node's word-level diff must always be folded from the cursor (it can't be skipped, or its
+        // "genuinely fully deleted" status decided, based on the content-level Change alone): Token.Text equality
+        // only compares fontType (see Token.Text's EqualityBy), so the shortest edit script may pair this node
+        // with an unrelated node elsewhere purely because their fontType matches, then classify it as content-level
+        // Unchanged/Replace even though none of its actual words survive - or, conversely, classify it as a
+        // content-level Delete while one of its words is, word-for-word, reused by an unrelated new node elsewhere
+        // (e.g. old "beta gamma" being classified as a content-level Delete while its "beta" word is reused by new
+        // "beta epsilon"). Only the resulting word-level changes reveal whether this node's text is genuinely,
+        // entirely gone (in which case reporting its words individually would only duplicate the full node already
+        // conveyed via the textContent Delete, so we suppress them) or whether some of its words survived elsewhere
+        // (in which case the word-level segments are the only place that information is captured, so we emit them
+        // instead of a textContent Delete). Similarly, a node that keeps some of its own words as-is (e.g. "hello
+        // world" -> "hello", where "hello" survives Unchanged within this very node's fold) is not genuinely gone
+        // either, even though the resulting changes are delete-only - hence the additional collector.hasUnchanged
+        // check.
+        private fun consumeTextContent(insertIndex: ContentIndex, deleteIndex: ContentIndex, entry: DiffEntry<Token.TextContent>) {
+            when (entry.token) {
+                is Token.NewLine -> {
+                    entry.toChange { DiffProducer.TextContentInfo(it.id) }?.let { producer.textContent(insertIndex, deleteIndex, it) }
+                }
+                is Token.Text -> {
+                    val collector = cursor.fold(WordDiffCollector(), WordDiffCollector::addEntry)
+                    val changes = collector.changes()
+                    val isWholeNodeGone = when {
+                        entry is DiffEntry.Insert || collector.hasUnchanged -> false
+                        changes.isEmpty() -> entry is DiffEntry.Delete
+                        else -> changes.all { it is Change.Delete }
+                    }
+                    if (isWholeNodeGone) {
+                        producer.textContent(insertIndex, deleteIndex, Change.Delete(DiffProducer.TextContentInfo(entry.token.id)))
+                    } else {
+                        changes.forEach { producer.textSegment(insertIndex, deleteIndex, it) }
+                    }
+                }
+            }
+        }
+
 
         private fun consumeItemList(insertIndex: BlockContentIndex, deleteIndex: BlockContentIndex, entry: DiffEntry<Token.ItemList>) {
             entry.toChange { DiffProducer.ItemListInfo(it.id, it.listType) }?.let {
@@ -152,10 +187,7 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
 
         private fun consumeTextOnlyContent(makeInsertIndex: (Int) -> ContentIndex, makeDeleteIndex: (Int) -> ContentIndex) =
             cursor.forEachIndexedStable<Token.TextContent> { insertContentIndex, deleteContentIndex, entry ->
-                when (entry.token) {
-                    is Token.Text -> consumeText(makeInsertIndex(insertContentIndex), makeDeleteIndex(deleteContentIndex))
-                    is Token.NewLine -> {}
-                }
+                consumeTextContent(makeInsertIndex(insertContentIndex), makeDeleteIndex(deleteContentIndex), entry)
             }
     }
 
@@ -226,14 +258,17 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
     private data class WordDiffCollector private constructor(
         private val inserts: RangeState,
         private val deletes: RangeState,
+        // Tracks whether any of this node's own words were seen as Unchanged (i.e. genuinely still present,
+        // as-is, in both old and new) - see consumeTextContent's doc for why this matters.
+        val hasUnchanged: Boolean,
     ) {
-        constructor() : this(RangeState(), RangeState())
+        constructor() : this(RangeState(), RangeState(), false)
 
         fun addEntry(entry: DiffEntry<Token.Word>): WordDiffCollector = when (entry) {
             is DiffEntry.Insert -> copy(inserts = inserts.extend(entry.new.word))
             is DiffEntry.Delete -> copy(deletes = deletes.extend(entry.old.word))
             is DiffEntry.Replace -> copy(inserts = inserts.extend(entry.new.word), deletes = deletes.extend(entry.old.word))
-            is DiffEntry.Unchanged -> copy(inserts = inserts.skip(entry.value.word), deletes = deletes.skip(entry.value.word))
+            is DiffEntry.Unchanged -> copy(inserts = inserts.skip(entry.value.word), deletes = deletes.skip(entry.value.word), hasUnchanged = true)
         }
 
         fun changes(): List<Change<DiffProducer.TextSegment>> =

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizer.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizer.kt
@@ -26,11 +26,28 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
         class ItemList(override val id: Int?, val listType: Listetype) : BlockContent, EqualityBy<ItemList>(ItemList::listType)
         class Item(val id: Int?) : Token, EqualityBy<Item>()
 
+        // Marks the end of an ItemList's items. Since an Item can only ever contain TextContent, and TextContent is
+        // also used both at the top BlockContent level and inside a Table's Cell, the last item's own TextContent
+        // run would otherwise have no way to distinguish "no more content in this item" from "this item happens to
+        // be followed, in the flattened token stream, by a TextContent-shaped token belonging to an unrelated,
+        // sibling or outer scope" (e.g. a NewLine that is actually the ItemList's own sibling in the block's
+        // content). Without this marker, that sibling token could be silently swallowed as if it were this item's
+        // own content - and, since forEachIndexedStable's insert/delete cursors can independently reach this point
+        // out of lockstep (see ReplaceAwareEditScriptCursor.forEachIndexedStable's decoy handling), potentially walk
+        // arbitrarily far past the ItemList's real boundary. ItemListEnd is a bare Token (not BlockContent or
+        // TextContent), so it can never itself be mistaken for content by any of the type-filtered consume loops -
+        // it is only ever explicitly consumed by consumeItemList once its items are done.
+        data object ItemListEnd : Token, EqualityBy<ItemListEnd>()
+
         class Table(override val id: Int?) : BlockContent, EqualityBy<Table>()
         class TableHeader(val id: Int?) : Token, EqualityBy<TableHeader>()
         class ColumnSpec(val id: Int?, val alignment: Edit.ParagraphContent.Table.ColumnAlignment, val span: Int) : Token, EqualityBy<ColumnSpec>(ColumnSpec::alignment, ColumnSpec::span)
         class Row(val id: Int?) : Token, EqualityBy<Row>()
         class Cell(val id: Int?) : Token, EqualityBy<Cell>()
+
+        // Marks the end of a Table's header and rows, for the same reason as ItemListEnd: a Cell's own TextContent
+        // is otherwise unbounded on its trailing side once it is the very last cell in the table.
+        data object TableEnd : Token, EqualityBy<TableEnd>()
 
         sealed class Text : TextContent, EqualityBy<Text>(Text::fontType) {
             abstract val fontType: FontType
@@ -144,6 +161,8 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
         }
 
 
+        // Explicitly consumes the ItemListEnd marker emitted by the tokenizer right after this ItemList's items -
+        // see Token.ItemListEnd's doc for why this is required (bounds the last item's own TextContent run).
         private fun consumeItemList(insertIndex: BlockContentIndex, deleteIndex: BlockContentIndex, entry: DiffEntry<Token.ItemList>) {
             entry.toChange { DiffProducer.ItemListInfo(it.id, it.listType) }?.let {
                 producer.itemList(insertIndex, deleteIndex, it)
@@ -159,8 +178,11 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
                     makeDeleteIndex = deleteItemIndex::withTextContentIndex,
                 )
             }
+            cursor.requireAndConsume<Token.ItemListEnd>()
         }
 
+        // Explicitly consumes the TableEnd marker emitted by the tokenizer right after this Table's header and rows
+        // - see Token.TableEnd's doc for why this is required (bounds the last cell's own TextContent run).
         private fun consumeTable(insertIndex: BlockContentIndex, deleteIndex: BlockContentIndex, entry: DiffEntry<Token.Table>) {
             entry.toChange { DiffProducer.TableInfo(it.id) }?.let {
                 producer.table(insertIndex, deleteIndex, it)
@@ -174,6 +196,7 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
                 }
                 consumeRow(insertRowIndex, deleteRowIndex)
             }
+            cursor.requireAndConsume<Token.TableEnd>()
         }
 
         private fun consumeTableHeader(insertIndex: BlockContentIndex, deleteIndex: BlockContentIndex) {
@@ -244,6 +267,7 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
         override fun visit(itemList: Edit.ParagraphContent.ItemList) {
             emit(Token.ItemList(itemList.id, itemList.editedListType ?: itemList.listType))
             super.visit(itemList)
+            emit(Token.ItemListEnd)
         }
 
         override fun visit(item: Edit.ParagraphContent.ItemList.Item) {
@@ -254,6 +278,7 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
         override fun visit(table: Edit.ParagraphContent.Table) {
             emit(Token.Table(table.id))
             super.visit(table)
+            emit(Token.TableEnd)
         }
 
         override fun visit(header: Edit.ParagraphContent.Table.Header) {

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizer.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizer.kt
@@ -66,19 +66,22 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
         private val producer: DiffProducer<*>,
     ) {
         fun parse() =
-            cursor.forEachIndexedStable<Token.BlockContent> { insertPos, deletePos, entry ->
-                val insertContentIndex = insertIndex.withContentIndex(insertPos)
-                val deleteContentIndex = deleteIndex.withContentIndex(deletePos)
+            cursor.forEachIndexedStable<Token.BlockContent> { indices, entry ->
+                val insertContentIndex = insertIndex.withContentIndex(indices.insertIndex)
+                val deleteContentIndex = deleteIndex.withContentIndex(indices.rawDeleteIndex)
+                val stableDeleteContentIndex = deleteIndex.withContentIndex(indices.stableDeleteIndex)
 
                 when (entry.token) {
                     is Token.TextContent -> {
-                        consumeTextContent(insertContentIndex, deleteContentIndex, entry.narrow())
+                        consumeTextContent(insertContentIndex, deleteContentIndex, stableDeleteContentIndex, entry.narrow())
                     }
                     is Token.ItemList -> {
                         consumeItemList(insertContentIndex, deleteContentIndex, entry.narrow())
+                        false
                     }
                     is Token.Table -> {
                         consumeTable(insertContentIndex, deleteContentIndex, entry.narrow())
+                        false
                     }
                 }
             }
@@ -100,10 +103,27 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
         // world" -> "hello", where "hello" survives Unchanged within this very node's fold) is not genuinely gone
         // either, even though the resulting changes are delete-only - hence the additional collector.hasUnchanged
         // check.
-        private fun consumeTextContent(insertIndex: ContentIndex, deleteIndex: ContentIndex, entry: DiffEntry<Token.TextContent>) {
+        //
+        // insertIndex is decoy-corrected (see ReplaceAwareEditScriptCursor.StableIndices), so it's safe to use both
+        // for the node's own textContent report (distinguishing leading/trailing siblings) and for nested
+        // textSegment reporting (anchoring to an already-established position). deleteIndex/stableDeleteIndex keep
+        // their original distinction: deleteIndex (this entry's own position) for the node's own report,
+        // stableDeleteIndex (the last real position) for nested reporting - relevant when entry is a genuine Insert,
+        // which doesn't itself consume any delete-side position.
+        //
+        // Returns whether this entry's insert-side pairing turned out to be a decoy (isWholeNodeGone despite the
+        // entry's own classification suggesting otherwise, e.g. an ambiguous Unchanged/Replace match) - see
+        // ReplaceAwareEditScriptCursor.forEachIndexedStable's doc for why the caller needs to know this.
+        private fun consumeTextContent(
+            insertIndex: ContentIndex,
+            deleteIndex: ContentIndex,
+            stableDeleteIndex: ContentIndex,
+            entry: DiffEntry<Token.TextContent>,
+        ): Boolean {
             when (entry.token) {
                 is Token.NewLine -> {
                     entry.toChange { DiffProducer.TextContentInfo(it.id) }?.let { producer.textContent(insertIndex, deleteIndex, it) }
+                    return false
                 }
                 is Token.Text -> {
                     val collector = cursor.fold(WordDiffCollector(), WordDiffCollector::addEntry)
@@ -116,8 +136,9 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
                     if (isWholeNodeGone) {
                         producer.textContent(insertIndex, deleteIndex, Change.Delete(DiffProducer.TextContentInfo(entry.token.id)))
                     } else {
-                        changes.forEach { producer.textSegment(insertIndex, deleteIndex, it) }
+                        changes.forEach { producer.textSegment(insertIndex, stableDeleteIndex, it) }
                     }
+                    return isWholeNodeGone && entry !is DiffEntry.Delete
                 }
             }
         }
@@ -186,8 +207,13 @@ class EditLetterWordTokenizer : EditLetterTokenizer<EditLetterWordTokenizer.Toke
             )
 
         private fun consumeTextOnlyContent(makeInsertIndex: (Int) -> ContentIndex, makeDeleteIndex: (Int) -> ContentIndex) =
-            cursor.forEachIndexedStable<Token.TextContent> { insertContentIndex, deleteContentIndex, entry ->
-                consumeTextContent(makeInsertIndex(insertContentIndex), makeDeleteIndex(deleteContentIndex), entry)
+            cursor.forEachIndexedStable<Token.TextContent> { indices, entry ->
+                consumeTextContent(
+                    makeInsertIndex(indices.insertIndex),
+                    makeDeleteIndex(indices.rawDeleteIndex),
+                    makeDeleteIndex(indices.stableDeleteIndex),
+                    entry,
+                )
             }
     }
 

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizerTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizerTest.kt
@@ -116,6 +116,7 @@ class EditLetterWordTokenizerTest {
                 Token.Text.Literal(null, FontType.PLAIN),
                 Token.Word("item"),
                 Token.Word("two"),
+                Token.ItemListEnd,
             ),
             tokens
         )
@@ -148,6 +149,7 @@ class EditLetterWordTokenizerTest {
                 Token.Text.Literal(null, FontType.PLAIN),
                 Token.Word("cell"),
                 Token.Word("body"),
+                Token.TableEnd,
             ),
             tokens
         )
@@ -253,6 +255,7 @@ class EditLetterWordTokenizerTest {
             Token.Item(null),
             Token.Text.Literal(null, FontType.PLAIN),
             Token.Word("hello"),
+            Token.ItemListEnd,
         )
         assertEquals(
             listOf(
@@ -272,6 +275,7 @@ class EditLetterWordTokenizerTest {
             Token.Item(null),
             Token.Text.Literal(null, FontType.PLAIN),
             Token.Word("hello"),
+            Token.ItemListEnd,
         )
         val new = listOf(
             Token.Block(null, PARAGRAPH),
@@ -282,6 +286,7 @@ class EditLetterWordTokenizerTest {
             Token.Item(null),
             Token.Text.Literal(null, FontType.PLAIN),
             Token.Word("world"),
+            Token.ItemListEnd,
         )
         assertEquals(
             listOf(
@@ -309,6 +314,7 @@ class EditLetterWordTokenizerTest {
             Token.Cell(null),
             Token.Text.Literal(null, FontType.PLAIN),
             Token.Word("body"),
+            Token.TableEnd,
         )
         assertEquals(
             listOf(
@@ -336,13 +342,13 @@ class EditLetterWordTokenizerTest {
             Token.Text.Literal(null, FontType.PLAIN),
             Token.Word("body"),
         )
-        val old = listOf(Token.Block(null, PARAGRAPH), Token.Table(null)) + tableHeaderAndFirstRow
-        val new = old + listOf(
+        val old = listOf(Token.Block(null, PARAGRAPH), Token.Table(null)) + tableHeaderAndFirstRow + Token.TableEnd
+        val new = listOf(Token.Block(null, PARAGRAPH), Token.Table(null)) + tableHeaderAndFirstRow + listOf(
             Token.Row(null),
             Token.Cell(null),
             Token.Text.Literal(null, FontType.PLAIN),
             Token.Word("extra"),
-        )
+        ) + Token.TableEnd
         assertEquals(
             listOf(
                 Triple(TableRowIndex(0, 0, 1), TableRowIndex(0, 0, 1), Change.Insert(DiffProducer.RowInfo(null))),
@@ -367,11 +373,24 @@ class EditLetterWordTokenizerTest {
             Token.Cell(null),
             Token.Text.Literal(null, FontType.PLAIN),
             Token.Word("body"),
+            Token.TableEnd,
         )
-        val new = old + listOf(
+        val new = listOf(
+            Token.Block(null, PARAGRAPH),
+            Token.Table(null),
+            Token.TableHeader(null),
+            Token.ColumnSpec(null, LEFT, 1),
+            Token.Cell(null),
+            Token.Text.Literal(null, FontType.PLAIN),
+            Token.Word("col"),
+            Token.Row(null),
+            Token.Cell(null),
+            Token.Text.Literal(null, FontType.PLAIN),
+            Token.Word("body"),
             Token.Cell(null),
             Token.Text.Literal(null, FontType.PLAIN),
             Token.Word("extra"),
+            Token.TableEnd,
         )
         assertEquals(
             listOf(

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizerTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordTokenizerTest.kt
@@ -210,9 +210,10 @@ class EditLetterWordTokenizerTest {
         )
         val new = listOf<Token>()
         assertEquals(
+            // "hello" is genuinely, entirely gone (the whole block is deleted), so it's reported via textContent
+            // (which recordCalls doesn't capture here) rather than as a word-level textSegment delete.
             listOf(
                 Triple(BlockIndex(0), BlockIndex(0), Change.Delete(DiffProducer.BlockInfo(null, PARAGRAPH))),
-                Triple(BlockContentIndex(0, 0), BlockContentIndex(0, 0), Change.Delete(DiffProducer.TextSegment(0, 5, "hello"))),
             ),
             recordCalls(old, new),
         )
@@ -443,7 +444,8 @@ class EditLetterWordTokenizerTest {
     fun `parseTokens deleted NewLine merging two literals with word change produces correct diff`() {
         // Old: "hello" + NewLine + "world" (two literals)
         // New: "hello goodbye" (single literal, word changed)
-        // The word "hello" is unchanged, NewLine is deleted, "world"->"goodbye" is a change
+        // The word "hello" is unchanged, NewLine is deleted, "world" is genuinely gone (none of its words
+        // survive - "goodbye" is a brand new word, not a reuse of "world")
         val old = listOf(
             Token.Block(null, PARAGRAPH),
             Token.Text.Literal(null, FontType.PLAIN),
@@ -460,13 +462,11 @@ class EditLetterWordTokenizerTest {
         )
         val calls = recordCalls(old, new)
         assertEquals(
+            // "goodbye" inserted into the first (unchanged) Text container in both old and new, offset 6-13.
+            // "world" is entirely gone, reported via textContent (which recordCalls doesn't capture here)
+            // rather than as a word-level textSegment delete.
             listOf(
-                // "goodbye" inserted into the first (unchanged) Text container in both old and new, offset 6-13
                 Triple(BlockContentIndex(0, 0), BlockContentIndex(0, 0), Change.Insert(DiffProducer.TextSegment(6, 13, "goodbye"))),
-                // "world" deleted at content index 2 (third BlockContent in old: the second Text), offset 0-5.
-                // insertIndex reuses content index 0, since new has no second Text bucket to advance into - it
-                // stays pinned at the last real new-document bucket rather than an out-of-bounds "next" index.
-                Triple(BlockContentIndex(0, 0), BlockContentIndex(0, 2), Change.Delete(DiffProducer.TextSegment(0, 5, "world"))),
             ),
             calls,
         )

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordUnifiedDiffTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordUnifiedDiffTest.kt
@@ -1,8 +1,5 @@
-@file:OptIn(InterneDataklasser::class)
-
 package no.nav.pensjon.brev.skribenten.letter
 
-import no.nav.brev.InterneDataklasser
 import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.BlockEdit
 import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.ContentEdit
 import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.DeletedTextSegment

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordUnifiedDiffTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordUnifiedDiffTest.kt
@@ -325,11 +325,48 @@ class EditLetterWordUnifiedDiffTest {
         }
         val diff = wordDiff.unifiedDiff(old, new)
         assertThat(diff.deletedBlocks[0]).contains(old.blocks[0])
-        // TODO: this is currently 0 (not 1) because forEachIndexedStable attributes a trailing delete to the last
-        // established insert index ("beta" at 0), rather than distinguishing "before"/"after" that position. This
-        // may need to change once the trailing-delete-ordering issue (deletedContent losing before/after ordering
-        // relative to a surviving sibling) is resolved - see plan discussion.
-        assertThat(diff.editedBlocks[0]!!.deletedContent[0]).contains(old.blocks[1].content[1])
+        // "epsilon" is a trailing delete relative to the surviving "beta" (unified index 0), so it is correctly
+        // attributed to unified index 1 - one past "beta" - rather than colliding with a leading delete at index 0.
+        assertThat(diff.editedBlocks[0]!!.deletedContent[1]).contains(old.blocks[1].content[1])
+    }
+
+    @Test
+    fun `deletedContent distinguishes a leading delete from a trailing delete relative to the same survivor`() {
+        // NewLine sits before the surviving "def" - a leading delete, sharing unified position 0 with "abc".
+        val oldLeading = editedLetter {
+            paragraph {
+                literal(text = "abc")
+                newLine()
+                variable(text = "def")
+            }
+        }
+        // NewLine sits after the surviving "def" - a trailing delete, at unified position 1 (one past "def").
+        val oldTrailing = editedLetter {
+            paragraph {
+                literal(text = "abc")
+                variable(text = "def")
+                newLine()
+            }
+        }
+        val new = editedLetter {
+            paragraph {
+                variable(text = "def")
+            }
+        }
+
+        val leadingDiff = wordDiff.unifiedDiff(oldLeading, new)
+        val leadingContent = (oldLeading.blocks[0] as Edit.Block.Paragraph).content
+        assertEquals(
+            mapOf(0 to listOf(leadingContent[0], leadingContent[1])),
+            leadingDiff.editedBlocks[0]!!.deletedContent,
+        )
+
+        val trailingDiff = wordDiff.unifiedDiff(oldTrailing, new)
+        val trailingContent = (oldTrailing.blocks[0] as Edit.Block.Paragraph).content
+        assertEquals(
+            mapOf(0 to listOf(trailingContent[0]), 1 to listOf(trailingContent[2])),
+            trailingDiff.editedBlocks[0]!!.deletedContent,
+        )
     }
 
     private fun textContentEdit(inserts: List<TextSegment> = emptyList(), deletes: List<DeletedTextSegment> = emptyList()): ContentEdit.TextContentEdit =

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordUnifiedDiffTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordUnifiedDiffTest.kt
@@ -2,10 +2,16 @@
 
 package no.nav.pensjon.brev.skribenten.letter
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.brev.InterneDataklasser
-import no.nav.pensjon.brev.skribenten.letter.ContentIndex.BlockContentIndex
-import no.nav.pensjon.brev.skribenten.letter.ContentIndex.ItemContentIndex
-import no.nav.pensjon.brev.skribenten.letter.ContentIndex.TableCellContentIndex
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.BlockEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.ContentEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.DeletedTextSegment
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.RowEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.TextEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.TextOnlyEdit
+import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.TextSegment
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -14,60 +20,81 @@ class EditLetterWordUnifiedDiffTest {
     private val wordDiff = EditLetterWordDiff()
 
     @Test
-    fun `no change produces empty inserts and deletes`() {
+    fun `no change produces empty editedBlocks and deletedBlocks`() {
         val letter = editedLetter { paragraph { literal(text = "hello world") } }
-        val (inserts, deletes) = wordDiff.unifiedDiff(letter, letter)
-        assertEquals(emptyList<DiffSegment>(), inserts)
-        assertEquals(emptyList<UnifiedDeleteSegment>(), deletes)
+        val diff = wordDiff.unifiedDiff(letter, letter)
+        assertEquals(emptyMap<Int, BlockEdit>(), diff.editedBlocks)
+        assertEquals(emptyMap<Int, List<Edit.Block>>(), diff.deletedBlocks)
     }
 
     @Test
-    fun `changed word produces insert DiffSegment and delete with text`() {
+    fun `changed word produces insert and delete in the TextEdit for that content`() {
         val old = editedLetter { paragraph { literal(text = "hello world") } }
         val new = editedLetter { paragraph { literal(text = "hello goodbye") } }
-        val (inserts, deletes) = wordDiff.unifiedDiff(old, new)
-        assertEquals(listOf(DiffSegment(BlockContentIndex(0, 0), 6, 13)), inserts)
-        assertEquals(listOf(UnifiedDeleteSegment(BlockContentIndex(0, 0), 6, 11, "world")), deletes)
+        val diff = wordDiff.unifiedDiff(old, new)
+        assertEquals(
+            mapOf(0 to BlockEdit(contentEdits = mapOf(0 to textContentEdit(inserts = listOf(TextSegment(6, 13)), deletes = listOf(DeletedTextSegment(6, 11, "world")))), deletedContent = emptyMap())),
+            diff.editedBlocks,
+        )
+        assertEquals(emptyMap<Int, List<Edit.Block>>(), diff.deletedBlocks)
     }
 
     @Test
-    fun `added word produces insert DiffSegment and no delete`() {
+    fun `added word produces insert and no delete`() {
         val old = editedLetter { paragraph { literal(text = "hello") } }
         val new = editedLetter { paragraph { literal(text = "hello world") } }
-        val (inserts, deletes) = wordDiff.unifiedDiff(old, new)
-        assertEquals(listOf(DiffSegment(BlockContentIndex(0, 0), 6, 11)), inserts)
-        assertEquals(emptyList<UnifiedDeleteSegment>(), deletes)
+        val diff = wordDiff.unifiedDiff(old, new)
+        assertEquals(
+            mapOf(0 to BlockEdit(contentEdits = mapOf(0 to textContentEdit(inserts = listOf(TextSegment(6, 11)))), deletedContent = emptyMap())),
+            diff.editedBlocks,
+        )
     }
 
     @Test
     fun `removed word produces no insert and delete with text`() {
         val old = editedLetter { paragraph { literal(text = "hello world") } }
         val new = editedLetter { paragraph { literal(text = "hello") } }
-        val (inserts, deletes) = wordDiff.unifiedDiff(old, new)
-        assertEquals(emptyList<DiffSegment>(), inserts)
-        assertEquals(listOf(UnifiedDeleteSegment(BlockContentIndex(0, 0), 6, 11, "world")), deletes)
+        val diff = wordDiff.unifiedDiff(old, new)
+        assertEquals(
+            mapOf(0 to BlockEdit(contentEdits = mapOf(0 to textContentEdit(deletes = listOf(DeletedTextSegment(6, 11, "world")))), deletedContent = emptyMap())),
+            diff.editedBlocks,
+        )
     }
 
     @Test
     fun `consecutive changed words are merged into one delete segment with combined text`() {
         val old = editedLetter { paragraph { literal(text = "hello foo bar") } }
         val new = editedLetter { paragraph { literal(text = "hello aaa bbb") } }
-        val (inserts, deletes) = wordDiff.unifiedDiff(old, new)
-        assertEquals(listOf(DiffSegment(BlockContentIndex(0, 0), 6, 13)), inserts)
-        assertEquals(listOf(UnifiedDeleteSegment(BlockContentIndex(0, 0), 6, 13, "foo bar")), deletes)
+        val diff = wordDiff.unifiedDiff(old, new)
+        assertEquals(
+            mapOf(0 to BlockEdit(contentEdits = mapOf(0 to textContentEdit(inserts = listOf(TextSegment(6, 13)), deletes = listOf(DeletedTextSegment(6, 13, "foo bar")))), deletedContent = emptyMap())),
+            diff.editedBlocks,
+        )
     }
 
     @Test
-    fun `changed word in item list produces delete with ItemContentIndex and text`() {
+    fun `changed word in item list produces delete in the item's TextOnlyEdit`() {
         val old = editedLetter { paragraph { itemList { item { literal(text = "hello world") } } } }
         val new = editedLetter { paragraph { itemList { item { literal(text = "hello goodbye") } } } }
-        val (inserts, deletes) = wordDiff.unifiedDiff(old, new)
-        assertEquals(listOf(DiffSegment(ItemContentIndex(0, 0, 0, 0), 6, 13)), inserts)
-        assertEquals(listOf(UnifiedDeleteSegment(ItemContentIndex(0, 0, 0, 0), 6, 11, "world")), deletes)
+        val diff = wordDiff.unifiedDiff(old, new)
+        assertEquals(
+            mapOf(
+                0 to BlockEdit(
+                    contentEdits = mapOf(
+                        0 to ContentEdit.ItemListEdit(
+                            itemEdits = mapOf(0 to textOnlyEdit(inserts = listOf(TextSegment(6, 13)), deletes = listOf(DeletedTextSegment(6, 11, "world")))),
+                            deletedItems = emptyMap(),
+                        ),
+                    ),
+                    deletedContent = emptyMap(),
+                ),
+            ),
+            diff.editedBlocks,
+        )
     }
 
     @Test
-    fun `changed word in table body cell produces delete with TableCellContentIndex and text`() {
+    fun `changed word in table body cell produces delete in the cell's TextOnlyEdit`() {
         val old = editedLetter {
             paragraph {
                 table {
@@ -84,13 +111,30 @@ class EditLetterWordUnifiedDiffTest {
                 }
             }
         }
-        val (inserts, deletes) = wordDiff.unifiedDiff(old, new)
-        assertEquals(listOf(DiffSegment(TableCellContentIndex(0, 0, 0, 0, 0), 6, 13)), inserts)
-        assertEquals(listOf(UnifiedDeleteSegment(TableCellContentIndex(0, 0, 0, 0, 0), 6, 11, "world")), deletes)
+        val diff = wordDiff.unifiedDiff(old, new)
+        assertEquals(
+            mapOf(
+                0 to BlockEdit(
+                    contentEdits = mapOf(
+                        0 to ContentEdit.TableEdit(
+                            rowEdits = mapOf(
+                                0 to RowEdit(
+                                    cellEdits = mapOf(0 to textOnlyEdit(inserts = listOf(TextSegment(6, 13)), deletes = listOf(DeletedTextSegment(6, 11, "world")))),
+                                    deletedCells = emptyMap(),
+                                ),
+                            ),
+                            deletedRows = emptyMap(),
+                        ),
+                    ),
+                    deletedContent = emptyMap(),
+                ),
+            ),
+            diff.editedBlocks,
+        )
     }
 
     @Test
-    fun `produces deletes that take into account previously deleted blocks`() {
+    fun `entirely deleted block is embedded in deletedBlocks at its unified position`() {
         val old = editedLetter {
             paragraph(id = 1) {
                 literal(text = "abcdefg")
@@ -110,18 +154,20 @@ class EditLetterWordUnifiedDiffTest {
                 literal(text = "opqrstu")
             }
         }
-        val deletes = wordDiff.unifiedDiff(old, new).deletes
+        val diff = wordDiff.unifiedDiff(old, new)
+
+        // block id=1 is entirely deleted; it retains its unified position (blockIndex 0), since it's the
+        // first block in the merged view. block id=2 is unchanged, so it produces no editedBlocks entry.
+        assertEquals(mapOf(0 to listOf(old.blocks[0])), diff.deletedBlocks)
+        // block id=3 survives at blockIndex 1 in `new`, with "vwxyz" removed from its text.
         assertEquals(
-            listOf(
-                UnifiedDeleteSegment(index = BlockContentIndex(blockIndex = 0, contentIndex = 0), startOffset = 0, endOffset = 7, text = "abcdefg"),
-                UnifiedDeleteSegment(index = BlockContentIndex(blockIndex = 1, contentIndex = 0), startOffset = 8, endOffset = 13, text = "vwxyz")
-            ),
-            deletes
+            mapOf(1 to BlockEdit(contentEdits = mapOf(0 to textContentEdit(deletes = listOf(DeletedTextSegment(8, 13, "vwxyz")))), deletedContent = emptyMap())),
+            diff.editedBlocks,
         )
     }
 
     @Test
-    fun `produces deletes that take into account previously deleted content within a block`() {
+    fun `entirely deleted content within a block is embedded in deletedContent at its unified position`() {
         // Old contentIndex: 0="alpha" (entirely deleted), 1=NewLine (entirely deleted), 2="beta gamma"
         // New contentIndex: 0="beta epsilon"
         val old = editedLetter {
@@ -136,24 +182,27 @@ class EditLetterWordUnifiedDiffTest {
                 literal(text = "beta epsilon")
             }
         }
-        val (inserts, deletes) = wordDiff.unifiedDiff(old, new)
+        val diff = wordDiff.unifiedDiff(old, new)
+        val oldContent = (old.blocks[0] as Edit.Block.Paragraph).content
+
         // "beta epsilon" is the only content in the new block, so it - and everything sharing its unified
         // position - must use contentIndex 0, since there is no contentIndex 1 in the new document.
-        assertEquals(listOf(DiffSegment(BlockContentIndex(0, 0), 5, 12)), inserts)
         assertEquals(
-            listOf(
-                // "alpha" is entirely deleted content, retaining its unified position (contentIndex 0)
-                UnifiedDeleteSegment(BlockContentIndex(0, 0), 0, 5, "alpha"),
-                // "gamma" is deleted from the same literal as the "epsilon" insert, so shares its unified
-                // contentIndex (0) rather than its old-document contentIndex (2)
-                UnifiedDeleteSegment(BlockContentIndex(0, 0), 5, 10, "gamma"),
+            mapOf(
+                0 to BlockEdit(
+                    // "gamma" -> "epsilon" is a word-level change within the still-existing "beta ..." literal
+                    contentEdits = mapOf(0 to textContentEdit(inserts = listOf(TextSegment(5, 12)), deletes = listOf(DeletedTextSegment(5, 10, "gamma")))),
+                    // "alpha" and the NewLine are entirely deleted content, embedded in full, retaining their
+                    // unified position (contentIndex 0) rather than their old-document position (0 and 1)
+                    deletedContent = mapOf(0 to listOf(oldContent[0], oldContent[1])),
+                ),
             ),
-            deletes,
+            diff.editedBlocks,
         )
     }
 
     @Test
-    fun `produces deletes that take into account previously deleted content within an item`() {
+    fun `entirely deleted content within an item is embedded in deletedContent at its unified position`() {
         val old = editedLetter {
             paragraph {
                 itemList {
@@ -174,19 +223,33 @@ class EditLetterWordUnifiedDiffTest {
                 }
             }
         }
-        val (inserts, deletes) = wordDiff.unifiedDiff(old, new)
-        assertEquals(listOf(DiffSegment(ItemContentIndex(0, 0, 0, 0), 5, 12)), inserts)
+        val diff = wordDiff.unifiedDiff(old, new)
+        val oldItemContent = ((old.blocks[0] as Edit.Block.Paragraph).content[0] as Edit.ParagraphContent.ItemList).items[0].content
+
         assertEquals(
-            listOf(
-                UnifiedDeleteSegment(ItemContentIndex(0, 0, 0, 0), 0, 5, "alpha"),
-                UnifiedDeleteSegment(ItemContentIndex(0, 0, 0, 0), 5, 10, "gamma"),
+            mapOf(
+                0 to BlockEdit(
+                    contentEdits = mapOf(
+                        0 to ContentEdit.ItemListEdit(
+                            itemEdits = mapOf(
+                                0 to textOnlyEdit(
+                                    inserts = listOf(TextSegment(5, 12)),
+                                    deletes = listOf(DeletedTextSegment(5, 10, "gamma")),
+                                    deletedContent = mapOf(0 to listOf(oldItemContent[0], oldItemContent[1])),
+                                ),
+                            ),
+                            deletedItems = emptyMap(),
+                        ),
+                    ),
+                    deletedContent = emptyMap(),
+                ),
             ),
-            deletes,
+            diff.editedBlocks,
         )
     }
 
     @Test
-    fun `produces deletes that take into account previously deleted content within a table cell`() {
+    fun `entirely deleted content within a table cell is embedded in deletedContent at its unified position`() {
         val old = editedLetter {
             paragraph {
                 table {
@@ -213,14 +276,68 @@ class EditLetterWordUnifiedDiffTest {
                 }
             }
         }
-        val (inserts, deletes) = wordDiff.unifiedDiff(old, new)
-        assertEquals(listOf(DiffSegment(TableCellContentIndex(0, 0, 0, 0, 0), 5, 12)), inserts)
+        val diff = wordDiff.unifiedDiff(old, new)
+        val oldTable = (old.blocks[0] as Edit.Block.Paragraph).content[0] as Edit.ParagraphContent.Table
+        val oldCellContent = oldTable.rows[0].cells[0].text
+
         assertEquals(
-            listOf(
-                UnifiedDeleteSegment(TableCellContentIndex(0, 0, 0, 0, 0), 0, 5, "alpha"),
-                UnifiedDeleteSegment(TableCellContentIndex(0, 0, 0, 0, 0), 5, 10, "gamma"),
+            mapOf(
+                0 to BlockEdit(
+                    contentEdits = mapOf(
+                        0 to ContentEdit.TableEdit(
+                            rowEdits = mapOf(
+                                0 to RowEdit(
+                                    cellEdits = mapOf(
+                                        0 to textOnlyEdit(
+                                            inserts = listOf(TextSegment(5, 12)),
+                                            deletes = listOf(DeletedTextSegment(5, 10, "gamma")),
+                                            deletedContent = mapOf(0 to listOf(oldCellContent[0], oldCellContent[1])),
+                                        ),
+                                    ),
+                                    deletedCells = emptyMap(),
+                                ),
+                            ),
+                            deletedRows = emptyMap(),
+                        ),
+                    ),
+                    deletedContent = emptyMap(),
+                ),
             ),
-            deletes,
+            diff.editedBlocks,
         )
     }
+
+    @Test
+    fun `succeeding entire container deletions are correctly tracked at their unified positions`() {
+        val old = editedLetter {
+            title1 { literal(text = "alpha") }
+            paragraph {
+                literal(text = "beta")
+                literal(text = "epsilon")
+            }
+            paragraph { literal(text = "hello") }
+        }
+        val new = editedLetter {
+            paragraph {
+                literal(text = "beta")
+            }
+            paragraph { literal(text = "hello") }
+        }
+        val diff = wordDiff.unifiedDiff(old, new)
+        assertThat(diff.deletedBlocks[0]).contains(old.blocks[0])
+        // TODO: this is currently 0 (not 1) because forEachIndexedStable attributes a trailing delete to the last
+        // established insert index ("beta" at 0), rather than distinguishing "before"/"after" that position. This
+        // may need to change once the trailing-delete-ordering issue (deletedContent losing before/after ordering
+        // relative to a surviving sibling) is resolved - see plan discussion.
+        assertThat(diff.editedBlocks[0]!!.deletedContent[0]).contains(old.blocks[1].content[1])
+    }
+
+    private fun textContentEdit(inserts: List<TextSegment> = emptyList(), deletes: List<DeletedTextSegment> = emptyList()): ContentEdit.TextContentEdit =
+        ContentEdit.TextContentEdit(TextEdit(inserts, deletes))
+
+    private fun textOnlyEdit(
+        inserts: List<TextSegment> = emptyList(),
+        deletes: List<DeletedTextSegment> = emptyList(),
+        deletedContent: Map<Int, List<Edit.ParagraphContent.Text>> = emptyMap(),
+    ): TextOnlyEdit = TextOnlyEdit(textEdits = mapOf(0 to TextEdit(inserts, deletes)), deletedContent = deletedContent)
 }

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordUnifiedDiffTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/letter/EditLetterWordUnifiedDiffTest.kt
@@ -2,7 +2,6 @@
 
 package no.nav.pensjon.brev.skribenten.letter
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.brev.InterneDataklasser
 import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.BlockEdit
 import no.nav.pensjon.brev.skribenten.letter.UnifiedDiff.ContentEdit


### PR DESCRIPTION
## Summary

`EditLetterWordDiff.unifiedDiff` had several related index-tracking bugs affecting entirely-deleted structural content (blocks, paragraph content, items, cells):

- Deleting an entire block/paragraph-content/text-content/item/cell shifted `blockIndex`/`contentIndex` for subsequent entries, since indices were derived from the raw edit script rather than the unified (new-document) positions.
- The previous `UnifiedDiff` data structure did not retain enough information for the frontend to render entirely-deleted structural content in the diff view.
- A follow-up edge case: `forEachIndexedStable`'s insert-index bookkeeping reused the same "stable" position for both leading and trailing deletes relative to the same surviving sibling, so e.g. content deleted *before* a survivor and content deleted *after* the same survivor collided into the same `deletedContent` bucket.
- A further edge case discovered while fixing the above: `Token.Text` (`Literal`/`Variable`) equality is deliberately weak (`fontType`-only), so the edit-script algorithm can produce an `Unchanged`/`Replace` pairing between unrelated nodes purely by font-type coincidence. Word-level folding then correctly detects the paired node is actually wholly gone ("decoy"), but the insert-index counter must be corrected to not advance past it, or a genuinely earlier sibling gets misattributed to the wrong position.

## Changes

- Nested `UnifiedDiff`'s edit types (`BlockEdit`, `ContentEdit`, `RowEdit`, `TextOnlyEdit`, `TextEdit`, `TextSegment`, `DeletedTextSegment`) inside `UnifiedDiff` for clearer ownership and enough retained structure to display entirely-deleted content.
- Replaced unsafe casts in `BlockParser.parse` with a reified `narrow()` helper on `DiffEntry`.
- Made `consumeTextContent` dispatch on `Token.TextContent` via an exhaustive `when`, so future `TextContent` subtypes require an explicit branch.
- Reworked deleted-position tracking in the unified diff producer to a single `Set<ContentIndex>`, replacing multiple maps of pairs/triples/lists.
- Added `StableIndices` (wrapping `insertIndex`, `rawDeleteIndex`, `stableDeleteIndex`) passed to `forEachIndexedStable`'s callback, replacing raw positional parameters.
- Made `forEachIndexedStable`'s `action` lambda return a `Boolean` signaling whether an entry's insert-side pairing was a "decoy" (an ambiguous-equality match later discovered, via nested word-level folding, to be wholly gone). Only genuine advances (non-`Delete`, non-decoy entries) move the `insertIndex` counter forward, so trailing deletes now correctly land one position past their anchor instead of colliding with leading deletes.
- Added `Token.ItemListEnd`/`Token.TableEnd` marker tokens (emitted after an `ItemList`'s items / a `Table`'s header+rows) and consume them explicitly in `consumeItemList`/`consumeTable`, fixing a crash caused by ambiguous-equality cursor desync swallowing tokens across nesting scopes (see follow-up section below).

## Testing

- `:skribenten-backend:test --tests "no.nav.pensjon.brev.skribenten.letter.*"` — all pass.
- Full `:skribenten-backend:test` suite — all pass, no regressions.
- Updated `EditLetterWordTokenizerTest`'s hand-built token sequences and expected `tokenize()` output to include the new `ItemListEnd`/`TableEnd` terminator tokens.
- New tests added:
  - `unified produces deletes that take into account previously deleted blocks`
  - `entirely deleted content within a block/item/table cell is embedded in deletedContent at its unified position`
  - `succeeding entire container deletions are correctly tracked at their unified positions`
  - `deletedContent distinguishes a leading delete from a trailing delete relative to the same survivor`

## Note

Commits `6226f4fc2` and `1d501fe4e` (from the earlier `fix/unified-diff-index-drift` branch) are already merged to `main` via #3503 and are **not** part of this diff — this branch is based on current `main` and only contains the two new commits shown above.

## Follow-up: ItemList/Table container-level ambiguity (previously noted as out of scope)

Investigated the previously-noted follow-up and found it was not just cosmetic misattribution but a genuine crash (`IndexOutOfBoundsException`). Root cause: `TextContent` tokens are reused identically at three nesting depths (top-level block content, an `Item`'s own content, a `Cell`'s own content), and nothing structurally distinct previously marked the end of an `ItemList`'s items or a `Table`'s rows. Under Myers' weak/ambiguous token equality, the diff cursors could desync, causing a sibling or unrelated token to be swallowed into the wrong nesting scope and eventually indexed out of bounds.

Fix: added `Token.ItemListEnd`/`Token.TableEnd` marker tokens, emitted after an `ItemList`'s items / a `Table`'s header+rows, and explicitly consumed in `consumeItemList`/`consumeTable`. Earlier items/cells are already bounded by the next sibling's distinct-type token (`Item`/`Cell`), so only a container-level end marker is needed — no per-item/per-cell markers.

There remains a deeper, non-crashing edge case (container-level LCS ambiguity can still choose which of two ambiguous `ItemList`/`Table` instances is "kept" vs "deleted", in rare cases producing a cosmetic gap in edit markup rather than a data-loss or crash) — deemed acceptable and out of scope for this PR.
