### PR TITLE
Resolve minified frontend stacktraces via sourcemaps

### DIFF
--- a/.github/workflows/.build-frontend.yaml
+++ b/.github/workflows/.build-frontend.yaml
@@ -42,6 +42,16 @@ jobs:
         working-directory: ${{ inputs.workingDir }}/frontend
         run: npm run build
 
+      - name: Move sourcemaps out of the publicly served build output
+        working-directory: ${{ inputs.workingDir }}/frontend
+        run: |
+          mkdir -p ../bff/sourcemaps
+          find dist -name '*.map' -print0 | while IFS= read -r -d '' map; do
+            dest="../bff/sourcemaps/${map#dist/}"
+            mkdir -p "$(dirname "$dest")"
+            mv "$map" "$dest"
+          done
+
       - name: Copy frontend dist into public directory of bff
         working-directory: ${{ inputs.workingDir }}/frontend
         run: cp -r dist/ ../bff/public

--- a/.github/workflows/.build-frontend.yaml
+++ b/.github/workflows/.build-frontend.yaml
@@ -42,19 +42,16 @@ jobs:
         working-directory: ${{ inputs.workingDir }}/frontend
         run: npm run build
 
-      - name: Move sourcemaps out of the publicly served build output
-        working-directory: ${{ inputs.workingDir }}/frontend
-        run: |
-          mkdir -p ../bff/sourcemaps
-          find dist -name '*.map' -print0 | while IFS= read -r -d '' map; do
-            dest="../bff/sourcemaps/${map#dist/}"
-            mkdir -p "$(dirname "$dest")"
-            mv "$map" "$dest"
-          done
-
       - name: Copy frontend dist into public directory of bff
         working-directory: ${{ inputs.workingDir }}/frontend
         run: cp -r dist/ ../bff/public
+
+      - name: Copy extracted sourcemaps into bff, if any were produced
+        working-directory: ${{ inputs.workingDir }}/frontend
+        run: |
+          if [ -d dist-sourcemaps ]; then
+            cp -r dist-sourcemaps/ ../bff/sourcemaps
+          fi
 
       - name: Install bff dependencies
         working-directory: ${{ inputs.workingDir }}/bff

--- a/skribenten-web/bff/.dockerignore
+++ b/skribenten-web/bff/.dockerignore
@@ -7,5 +7,6 @@
 !tsconfig.json
 !package*.json
 !public/
+!sourcemaps/
 !node_modules
 !dist

--- a/skribenten-web/bff/.gitignore
+++ b/skribenten-web/bff/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 /.env
 public
+sourcemaps

--- a/skribenten-web/bff/package-lock.json
+++ b/skribenten-web/bff/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
         "@navikt/oasis": "^4.1.4",
         "@navikt/vite-mode": "0.16.1",
         "cookie-parser": "^1.4.7",
@@ -200,6 +201,31 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@navikt/oasis": {

--- a/skribenten-web/bff/package.json
+++ b/skribenten-web/bff/package.json
@@ -14,6 +14,7 @@
   "author": "Nav",
   "license": "MIT",
   "dependencies": {
+    "@jridgewell/trace-mapping": "^0.3.31",
     "@navikt/oasis": "^4.1.4",
     "@navikt/vite-mode": "0.16.1",
     "cookie-parser": "^1.4.7",

--- a/skribenten-web/bff/src/internalRoutes.ts
+++ b/skribenten-web/bff/src/internalRoutes.ts
@@ -3,6 +3,7 @@ import cookieParser from "cookie-parser";
 import { type Express } from "express";
 
 import config from "./config.js";
+import { resolveStackTrace } from "./sourceMapResolver.js";
 
 export const internalRoutes = (server: Express) => {
   server.get("/bff/api/logout", (_request, response) => {
@@ -37,7 +38,7 @@ export const internalRoutes = (server: Express) => {
         statusCode: body.status,
         timestamp: body.jsonContent.timestamp,
         message: `Feil fra frontend: ${body.message}: ${body.jsonContent.url}`,
-        stack_trace: body.stack,
+        stack_trace: resolveStackTrace(body.stack),
         x_correlationId: body.requestId,
       }),
     );

--- a/skribenten-web/bff/src/sourceMapResolver.ts
+++ b/skribenten-web/bff/src/sourceMapResolver.ts
@@ -24,9 +24,17 @@ function loadTraceMap(assetPath: string): TraceMap | undefined {
 
   let traceMap: TraceMap | undefined;
   try {
-    const mapPath = path.join(sourcemapsRoot, `${assetPath}.map`);
-    const rawSourceMap = fs.readFileSync(mapPath, "utf-8");
-    traceMap = new TraceMap(rawSourceMap);
+    // assetPath comes from an untrusted stack trace string - resolve it and
+    // verify it can't escape sourcemapsRoot (e.g. via ".." segments) before
+    // reading anything from disk.
+    const mapPath = path.resolve(sourcemapsRoot, `.${assetPath}.map`);
+    const relativeToRoot = path.relative(sourcemapsRoot, mapPath);
+    if (relativeToRoot.startsWith("..") || path.isAbsolute(relativeToRoot)) {
+      traceMap = undefined;
+    } else {
+      const rawSourceMap = fs.readFileSync(mapPath, "utf-8");
+      traceMap = new TraceMap(rawSourceMap);
+    }
   } catch {
     // No sourcemap available for this asset (e.g. running locally without a
     // build, or an unrecognized/legacy asset) - fall back to the raw frame.
@@ -54,7 +62,7 @@ function resolveStackFrame(line: string): string {
     column: Number.parseInt(columnNumber, 10),
   });
 
-  if (!originalPosition.source) {
+  if (originalPosition.source === null || originalPosition.line === null || originalPosition.column === null) {
     return line;
   }
 

--- a/skribenten-web/bff/src/sourceMapResolver.ts
+++ b/skribenten-web/bff/src/sourceMapResolver.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { originalPositionFor, TraceMap } from "@jridgewell/trace-mapping";
+
+// Sourcemaps for the built frontend are copied here at build time (see
+// .github/workflows/.build-frontend.yaml) and baked into the docker image.
+// They are intentionally kept out of ./public so they are never served to
+// the browser - they are only used here, server-side, to resolve minified
+// stack traces reported by the frontend before they are written to the log.
+const sourcemapsRoot = path.resolve("./sourcemaps");
+
+// Matches a stack frame referencing one of our built assets, e.g.
+// "at Component (https://skribenten.intern.dev.nav.no/assets/index-CzilmHAy.js:1:12345)"
+// or "at https://skribenten.intern.dev.nav.no/assets/index-CzilmHAy.js:1:12345".
+const STACK_FRAME_REGEX = /https?:\/\/[^\s)]+(\/assets\/[^\s):]+\.js):(\d+):(\d+)/;
+
+const traceMapCache = new Map<string, TraceMap | undefined>();
+
+function loadTraceMap(assetPath: string): TraceMap | undefined {
+  if (traceMapCache.has(assetPath)) {
+    return traceMapCache.get(assetPath);
+  }
+
+  let traceMap: TraceMap | undefined;
+  try {
+    const mapPath = path.join(sourcemapsRoot, `${assetPath}.map`);
+    const rawSourceMap = fs.readFileSync(mapPath, "utf-8");
+    traceMap = new TraceMap(rawSourceMap);
+  } catch {
+    // No sourcemap available for this asset (e.g. running locally without a
+    // build, or an unrecognized/legacy asset) - fall back to the raw frame.
+    traceMap = undefined;
+  }
+
+  traceMapCache.set(assetPath, traceMap);
+  return traceMap;
+}
+
+function resolveStackFrame(line: string): string {
+  const match = STACK_FRAME_REGEX.exec(line);
+  if (!match) {
+    return line;
+  }
+
+  const [, assetPath, lineNumber, columnNumber] = match;
+  const traceMap = loadTraceMap(assetPath);
+  if (!traceMap) {
+    return line;
+  }
+
+  const originalPosition = originalPositionFor(traceMap, {
+    line: Number.parseInt(lineNumber, 10),
+    column: Number.parseInt(columnNumber, 10),
+  });
+
+  if (!originalPosition.source) {
+    return line;
+  }
+
+  const originalLocation = `${originalPosition.source}:${originalPosition.line}:${originalPosition.column}`;
+  return originalPosition.name
+    ? line.replace(match[0], `${originalLocation} (${originalPosition.name})`)
+    : line.replace(match[0], originalLocation);
+}
+
+/**
+ * Resolves a minified stack trace produced by the built (minified) frontend
+ * bundle back to its original source locations, using the sourcemaps that
+ * were generated at build time. Falls back to the untouched frame whenever
+ * a sourcemap can't be found or a position can't be resolved.
+ */
+export function resolveStackTrace(stack: string | undefined): string | undefined {
+  if (!stack) {
+    return stack;
+  }
+
+  return stack
+    .split("\n")
+    .map((line) => resolveStackFrame(line))
+    .join("\n");
+}

--- a/skribenten-web/frontend/.gitignore
+++ b/skribenten-web/frontend/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+dist-sourcemaps
 *.local
 
 # Playwright

--- a/skribenten-web/frontend/vite.config.ts
+++ b/skribenten-web/frontend/vite.config.ts
@@ -32,6 +32,12 @@ export default defineConfig(({ command }) => ({
   },
   build: {
     chunkSizeWarningLimit: 700,
+    // "hidden" writes .map files next to the bundles without adding a
+    // "//# sourceMappingURL" comment, so browsers never auto-fetch them.
+    // The maps are stripped out of the publicly served folder before the
+    // bff docker image is built (see .build-frontend.yaml) and are only
+    // used server-side to resolve stack traces reported by the frontend.
+    sourcemap: "hidden",
     rollupOptions: {
       output: {
         manualChunks: (id) => {

--- a/skribenten-web/frontend/vite.config.ts
+++ b/skribenten-web/frontend/vite.config.ts
@@ -1,4 +1,6 @@
 /// <reference types="vitest" />
+import fs from "node:fs";
+import path from "node:path";
 import { fileURLToPath, URL } from "node:url";
 
 import { tanstackRouter } from "@tanstack/router-vite-plugin";
@@ -16,6 +18,48 @@ function umamiConfigPlugin(): Plugin {
   };
 }
 
+function moveMapFiles(root: string, dir: string, destRoot: string) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      moveMapFiles(root, fullPath, destRoot);
+      continue;
+    }
+    if (!entry.name.endsWith(".map")) continue;
+
+    const relativePath = path.relative(root, fullPath);
+    const destinationPath = path.join(destRoot, relativePath);
+    fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+    fs.renameSync(fullPath, destinationPath);
+  }
+}
+
+// Vite/Rolldown always write sourcemaps next to the bundles they describe -
+// there's no built-in option to output them to a separate directory. This
+// plugin moves the generated .map files out of the publicly served build
+// output into a sibling "dist-sourcemaps" directory right after they're
+// written to disk, so they never ship to the browser (see build.sourcemap
+// below) regardless of how/where "vite build" is invoked (CI or locally).
+function extractSourcemapsPlugin(): Plugin {
+  let outDir: string;
+  let sourcemapsDir: string;
+
+  return {
+    name: "extract-sourcemaps",
+    apply: "build",
+    configResolved(config) {
+      outDir = path.resolve(config.root, config.build.outDir);
+      sourcemapsDir = path.resolve(outDir, "..", "dist-sourcemaps");
+    },
+    writeBundle() {
+      fs.rmSync(sourcemapsDir, { recursive: true, force: true });
+      if (fs.existsSync(outDir)) {
+        moveMapFiles(outDir, outDir, sourcemapsDir);
+      }
+    },
+  };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => ({
   plugins: [
@@ -23,7 +67,7 @@ export default defineConfig(({ command }) => ({
       jsxImportSource: "@emotion/react",
     }),
     tanstackRouter(),
-    ...(command === "serve" ? [umamiConfigPlugin()] : []),
+    ...(command === "serve" ? [umamiConfigPlugin()] : [extractSourcemapsPlugin()]),
   ],
   resolve: {
     alias: {
@@ -32,11 +76,9 @@ export default defineConfig(({ command }) => ({
   },
   build: {
     chunkSizeWarningLimit: 700,
-    // "hidden" writes .map files next to the bundles without adding a
-    // "//# sourceMappingURL" comment, so browsers never auto-fetch them.
-    // The maps are stripped out of the publicly served folder before the
-    // bff docker image is built (see .build-frontend.yaml) and are only
-    // used server-side to resolve stack traces reported by the frontend.
+    // "hidden" writes .map files without adding a "//# sourceMappingURL"
+    // comment, so browsers never auto-fetch them even before the
+    // extractSourcemapsPlugin above moves them out of dist/.
     sourcemap: "hidden",
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Why

`logError` (invoked from `GlobalError`) forwards unhandled frontend exception stacktraces to the bff, which logs them for the centralized log system. Since the frontend build is minified, those stacktraces only showed minified `assets/*.js:line:col` frames, making it hard to locate the actual failure point.

## What

- **Frontend build** (`vite.config.ts`): enable `build.sourcemap: "hidden"` so `.map` files are generated without a `//# sourceMappingURL` comment (no auto-fetch by browsers). A new `extractSourcemapsPlugin` moves the generated `.map` files out of `dist/` into a sibling `dist-sourcemaps/` directory right after `vite build` writes them to disk (via the `writeBundle` hook), so the publicly served build output never contains sourcemaps - regardless of whether the build is run in CI or locally (e.g. via docker compose).
- **CI** (`.build-frontend.yaml`): copies `dist-sourcemaps/` into `bff/sourcemaps` alongside the existing `dist/` -> `bff/public` copy (skipped if a project doesn't produce sourcemaps, e.g. `brevoppskrift-web`).
- **bff**:
  - `.dockerignore` whitelists `sourcemaps/` so it's baked into the docker image.
  - New `src/sourceMapResolver.ts` uses `@jridgewell/trace-mapping` to resolve minified stack frames (both Chrome `at fn (url:line:col)` and Firefox `fn@url:line:col` styles) back to original file/line/column, with function name when available. Falls back to the raw frame if no matching sourcemap is found.
  - `/bff/api/logg` (`internalRoutes.ts`) now logs the resolved stack trace instead of the raw minified one.

Sourcemaps are never served to the browser - they're only used server-side, at the point logs are written, to resolve stack traces for the centralized log system.

## Verification

- Confirmed hidden sourcemaps are generated with no `sourceMappingURL` comment, and that `dist/` contains zero `.map` files after build while `dist-sourcemaps/` contains all of them.
- Confirmed stale `dist-sourcemaps/` contents are cleared on rebuild.
- `tsc`/`biome check` pass for both `frontend` and `bff`.
- Tested end-to-end locally in docker compose: verified real Chrome and Firefox stack traces logged via `/bff/api/logg` are now fully resolved to original source locations (e.g. `src/routes/saksnummer.index.tsx:44:29`, `src/main.tsx:54:9`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>