### PR TITLE
Dokumenter alarmstrategi for applikasjonene vi forvalter

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -8,6 +8,7 @@
 * xref:skribenten-beskrivelse.adoc[Skribenten – teknisk beskrivelse]
 * xref:brevbaker-arkitektur.adoc[Brevbaker – arkitektur]
 * xref:brevbaker-pdfbygger-beskrivelse.adoc[PDFbygger – teknisk beskrivelse]
+* xref:alarmstrategi.adoc[Alarmstrategi]
 * xref:dsl/index.adoc[DSL (WIP)]
 ** xref:dsl/index.adoc[Quickstart]
 ** xref:dsl/stegvis guide nytt brev.adoc[]

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -29,7 +29,7 @@ Alt som ikke oppfyller alarmkriteriene under hører hjemme på et dashboard, ikk
 . *Hver alarm skal ha en handling.* Kan vi ikke beskrive hva mottakeren skal gjøre, skal alarmen ikke finnes.
 . *Alarmér på rate og varighet, ikke enkelthendelser.* Én 500-respons er ikke en hendelse. 5 % feilrate i 10 minutter er det. Alle alarmer skal ha en `for`-periode som filtrerer bort forbigående støy.
 . *Terskler skal begrunnes.* Enhver terskel i dette dokumentet skal ha en kort begrunnelse, slik at den kan justeres bevisst i stedet for tilfeldig.
-. *Skille mellom våre feil og andres feil.* Feil som skyldes nedstrøms systemer (Pesys, SAF, KRR) skal være gjenkjennelige som nettopp det, slik at vi ikke kalles ut for noe vi ikke kan fikse. De skal likevel alarmeres når de rammer våre brukere.
+. *Nedstrøms feil skal attribueres, ikke nedprioriteres.* Når et nedstrøms system (Pesys, SAF, KRR) feiler og rammer brukerne våre, alarmerer vi like fullt — brukerne er like blokkert uansett hvem som eier feilen. Poenget er at alarmen umiddelbart skal peke på *hvem* som feiler, slik at vi kan videreformidle til riktig team i stedet for å feilsøke vårt eget system forgjeves. En alarm vi ikke kan attribuere koster oss mest tid.
 . *4xx er som hovedregel ikke vår feil.* Vi alarmerer på 5xx. Unntaket er en brå økning i 4xx, som ofte betyr at vi har brutt en API-kontrakt for en konsument.
 . *Alarmer er kode.* Alle alarmer versjoneres i repoet sammen med applikasjonen de gjelder, og gjennomgås i PR som all annen kode.
 
@@ -152,7 +152,7 @@ Logger brukes primært til *undersøkelse*, ikke til alarmering — logbaserte a
 Vi gjør likevel unntak der metrikker ikke finnes, og der loggmeldingen er stabil og entydig:
 
 * `Won't retry for exception` — brevbaker mot pdf-bygger, og skribenten-backend mot nedstrøms tjenester. Betyr at en ikke-retriable feil har oppstått.
-* `Error executing one-shot job` — engangsjobb i skribenten-backend feilet.
+* `Error executing one-shot job` — engangsjobb i skribenten-backend feilet. Se også `did not complete successfully`, som dekker jobber som avslutter uten å sette `completed` og dermed heller ikke registreres som fullført.
 * `typst command failed` — kompileringsfeil i pdf-bygger.
 
 Alle logbaserte alarmer skal ha en kommentar i regelen som peker på filen og linjen meldingen kommer fra, slik at den som endrer meldingen ser sammenhengen.
@@ -193,7 +193,7 @@ Brevbaker er navet i automatisk brevproduksjon. Feiler den, produseres det ikke 
 
 | Logg: `Alle toggles må være definert i Unleash`
 | `warning`
-| Feiltilstand i feature toggle-oppsettet som gir uforutsigbar malvalg.
+| En brevmal har en feature toggle som ikke finnes i Unleash. Unleash returnerer da `false`, slik at malen blir *stille utilgjengelig* — ingenting feiler, brevet kan bare ikke bestilles. Uten denne alarmen oppdages det først når noen etterlyser brevet.
 |===
 
 === pensjon-pdf-bygger
@@ -253,7 +253,7 @@ Kritiske alarmer gjelder i praksis kontortid.
 
 | Logg: `Error executing one-shot job`
 | `warning`
-| Engangsjobber er idempotente og kjøres under leader election. En feilet jobb er ikke akutt, men blir aldri fanget opp av noe annet.
+| En feilet engangsjobb stopper *ikke* oppstarten — jobbene kjøres i en egen coroutine etter `ServerReady` med forsinkelse, og fullføring registreres kun i `OneShotJobTable` ved suksess. En jobb kan derfor feile ved hver oppstart uten at noe annet indikerer det. Denne alarmen er eneste signal.
 
 | Databasetilkoblinger nær maks
 | `warning`
@@ -345,7 +345,7 @@ Denne meldingen betyr at sensitive data ble *vellykket fjernet* før logging —
 `cleanSensitiveDataAndLog` i `SkribentenApp.kt` fanger dette og erstatter verdien før noe skrives til logg.
 +
 Dette er derfor *ikke* en personvernhendelse, og skal ikke alarmeres — hverken som `critical` eller `warning`.
-Riktig løsning er en oppretting oppstrøms i Exposed, sporet i https://youtrack.jetbrains.com/issue/EXPOSED-1012[EXPOSED-1012].
+Riktig løsning er en retting oppstrøms i Exposed, sporet i https://youtrack.jetbrains.com/issue/EXPOSED-1012[EXPOSED-1012].
 Sanitiseringen kan først fjernes når den feilen er rettet og vi har oppgradert.
 +
 Den underliggende feilen gir uansett en 500-respons, og fanges dermed allerede av feilrate-alarmen for skribenten-backend. En egen alarm ville kun vært duplikat.

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -37,23 +37,26 @@ Alt som ikke oppfyller alarmkriteriene under hører hjemme på et dashboard, ikk
 
 Vi bruker to nivåer. Flere nivåer i praksis betyr at det midterste ignoreres.
 
+Teamet har *ingen vaktordning*. Ingen alarm forventes håndtert utenfor arbeidstid, uansett nivå.
+Alvorlighetsgraden sier derfor ikke noe om når på døgnet vi rykker ut, men hvor raskt vi tar tak i alarmen når vi er på jobb, og hvor mye den skal få avbryte annet arbeid.
+
 [cols="1,3,2,2", options="header"]
 |===
-| Nivå | Betyr | Når | Kanal
+| Nivå | Betyr | Håndtering | Kanal
 
 | `critical`
-| Brukere er rammet nå, eller brev produseres ikke. Krever umiddelbar handling.
-| Hele døgnet for automatiske brev (batch fra Pesys kjører om natten). Kontortid for saksbehandlerflaten.
+| Brukere er rammet nå, eller brev produseres ikke.
+| Tas foran annet arbeid. Har den utløst utenfor arbeidstid, er den det første vi ser på neste arbeidsdag.
 | Slack-kanal med varsling
 
 | `warning`
-| Noe er på vei galt, eller noe er ødelagt uten at brukerne merker det ennå. Håndteres i arbeidstiden.
-| Kontortid
+| Noe er på vei galt, eller noe er ødelagt uten at brukerne merker det ennå.
+| Tas i den ordinære arbeidsflyten.
 | Slack-kanal uten varsling
 |===
 
-Merk skillet i døgndekning: *pensjon-brevbaker* og *pensjon-pdf-bygger* betjener automatisk brevproduksjon fra Pesys som kjører utenfor kontortid, mens *skribenten-backend* og *skribenten-web* i praksis kun brukes av saksbehandlere i kontortid.
-En nedetid i Skribenten kl. 03 er ikke en kritisk hendelse; det samme i brevbaker er det.
+Merk skillet i *når feil faktisk rammer noen*: *pensjon-brevbaker* og *pensjon-pdf-bygger* betjener automatisk brevproduksjon fra Pesys som kjører utenfor kontortid, mens *skribenten-backend* og *skribenten-web* i praksis kun brukes av saksbehandlere i kontortid.
+Skillet avgjør ikke om noen blir vekket, men hvordan vi tolker en alarm i etterkant: en `critical` fra brevbaker kl. 03 betyr at brev ikke ble produsert i natt og skal prioriteres når vi kommer på jobb, mens det samme i Skribenten som regel ikke har rammet noen.
 
 == Signalkilder
 
@@ -161,7 +164,7 @@ Alle logbaserte alarmer skal ha en kommentar i regelen som peker på filen og li
 
 === pensjon-brevbaker
 
-Brevbaker er navet i automatisk brevproduksjon. Feiler den, produseres det ikke brev — og fordi Pesys kjører batch utenfor kontortid, må kritiske alarmer her gjelde hele døgnet.
+Brevbaker er navet i automatisk brevproduksjon. Feiler den, produseres det ikke brev — og fordi Pesys kjører batch utenfor kontortid, må alarmene her være aktive hele døgnet, selv om de først håndteres i arbeidstiden.
 
 [cols="3,1,3", options="header"]
 |===
@@ -411,6 +414,6 @@ Disse er bevisste, prioriterte oppgaver — ikke forglemmelser — og listes her
 
 Eierskap:: Alarmene eies av teamet i fellesskap. Den som mottar en alarm eier den til den er lukket eller eksplisitt overlevert.
 Runbook:: Hver `critical`-alarm skal ha en kort beskrivelse i selve alarmen: hva som er galt, hvem som rammes, og første feilsøkingssteg. En alarm uten dette er ikke ferdig.
-Gjennomgang:: Alarmene gjennomgås jevnlig. For hver alarm spør vi: har den utløst? Førte den til handling? Hvis den har utløst mange ganger uten å føre til handling, skal terskelen justeres eller alarmen fjernes.
+Gjennomgang:: Alarmer vurderes i etterkant av at de har utløst, ikke etter en fast kalender. For hver alarm som har gått: var den reell, og førte den til handling? En alarm som gjentatte ganger utløser uten å føre til handling, skal justeres eller fjernes.
 Endringer:: Nye og endrede alarmer går gjennom PR som all annen kode. Terskelendringer skal begrunnes i commit-meldingen.
 Ved falske positiver:: Juster terskel eller `for`-periode framfor å slå av alarmen. En avslått alarm blir sjelden slått på igjen.

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -1,0 +1,416 @@
+= Alarmstrategi
+
+Denne siden beskriver hvordan Team Pensjonsbrev alarmerer på applikasjonene vi har forvaltningsansvar for:
+
+* *pensjon-brevbaker*
+* *pensjon-pdf-bygger*
+* *skribenten-backend*
+* *skribenten-web* (SPA + BFF)
+
+Dokumentet definerer prinsippene, alvorlighetsgradene og hvilke konkrete signaler vi alarmerer på.
+Selve alarmreglene defineres senere som `PrometheusRule`/nais `Alert`-manifester; denne siden er kilden de skal utledes fra.
+
+== Formål
+
+Alarmer skal gi oss beskjed *før brukerne melder fra*, og bare når *et menneske faktisk må gjøre noe*.
+En alarm som ingen handler på er ikke en alarm — det er støy som svekker tilliten til alle de andre alarmene.
+
+Vi skiller derfor tydelig mellom:
+
+Alarm:: Noe er galt nå, noen må undersøke. Krever mottaker og handling.
+Dashboard:: Noe vi vil kunne se på når vi undersøker. Krever ingen mottaker.
+
+Alt som ikke oppfyller alarmkriteriene under hører hjemme på et dashboard, ikke i en alarm.
+
+== Prinsipper
+
+[[prinsipper]]
+. *Alarmér på symptomer, ikke årsaker.* Vi alarmerer på det brukeren merker (feil, treghet, manglende brev), ikke på hver enkelt underliggende årsak. Høy CPU er ikke i seg selv et problem hvis brevene kommer ut i tide.
+. *Hver alarm skal ha en handling.* Kan vi ikke beskrive hva mottakeren skal gjøre, skal alarmen ikke finnes.
+. *Alarmér på rate og varighet, ikke enkelthendelser.* Én 500-respons er ikke en hendelse. 5 % feilrate i 10 minutter er det. Alle alarmer skal ha en `for`-periode som filtrerer bort forbigående støy.
+. *Terskler skal begrunnes.* Enhver terskel i dette dokumentet skal ha en kort begrunnelse, slik at den kan justeres bevisst i stedet for tilfeldig.
+. *Skille mellom våre feil og andres feil.* Feil som skyldes nedstrøms systemer (Pesys, SAF, KRR) skal være gjenkjennelige som nettopp det, slik at vi ikke kalles ut for noe vi ikke kan fikse. De skal likevel alarmeres når de rammer våre brukere.
+. *4xx er som hovedregel ikke vår feil.* Vi alarmerer på 5xx. Unntaket er en brå økning i 4xx, som ofte betyr at vi har brutt en API-kontrakt for en konsument.
+. *Alarmer er kode.* Alle alarmer versjoneres i repoet sammen med applikasjonen de gjelder, og gjennomgås i PR som all annen kode.
+
+== Alvorlighetsgrader
+
+Vi bruker to nivåer. Flere nivåer i praksis betyr at det midterste ignoreres.
+
+[cols="1,3,2,2", options="header"]
+|===
+| Nivå | Betyr | Når | Kanal
+
+| `critical`
+| Brukere er rammet nå, eller brev produseres ikke. Krever umiddelbar handling.
+| Hele døgnet for automatiske brev (batch fra Pesys kjører om natten). Kontortid for saksbehandlerflaten.
+| Slack-kanal med varsling
+
+| `warning`
+| Noe er på vei galt, eller noe er ødelagt uten at brukerne merker det ennå. Håndteres i arbeidstiden.
+| Kontortid
+| Slack-kanal uten varsling
+|===
+
+Merk skillet i døgndekning: *pensjon-brevbaker* og *pensjon-pdf-bygger* betjener automatisk brevproduksjon fra Pesys som kjører utenfor kontortid, mens *skribenten-backend* og *skribenten-web* i praksis kun brukes av saksbehandlere i kontortid.
+En nedetid i Skribenten kl. 03 er ikke en kritisk hendelse; det samme i brevbaker er det.
+
+== Signalkilder
+
+=== Applikasjonsmetrikker
+
+Alle tre Kotlin-applikasjonene eksponerer Prometheus-metrikker på `/metrics` via `MicrometerMetrics`, og scrapes av nais (`prometheus.enabled: true`).
+nais legger automatisk på labels som `app`, `namespace` og `pod`, slik at alle spørringer kan filtreres på `app="pensjon-brevbaker"` osv.
+
+Tilgjengelige metrikker:
+
+[cols="2,3", options="header"]
+|===
+| Metrikk | Merknad
+
+| `ktor_http_server_requests_seconds_count`
+| Teller per `route`, `method`, `status` og `throwable`. Grunnlaget for alle feilrate-alarmer.
+
+| `ktor_http_server_requests_seconds_sum`
+| Sum av responstid. Sammen med `_count` gir dette gjennomsnittlig responstid.
+
+| `ktor_http_server_requests_seconds_max`
+| Høyeste observerte responstid i vinduet. Nyttig for å fange enkelttreghet.
+
+| `ktor_http_server_requests_active`
+| Antall requests under behandling. Stigende verdi = kø bygger seg opp.
+
+| `pensjon_brevbaker_letter_request_count_total`
+| *Kun brevbaker.* Teller per `brevkode`. Vår eneste domenespesifikke metrikk.
+
+| `jvm_memory_used_bytes`, `jvm_gc_pause_seconds_*`, `jvm_threads_*`
+| Standard JVM-metrikker.
+
+| `process_cpu_usage`, `system_cpu_usage`
+| Standard prosessmetrikker.
+|===
+
+[IMPORTANT]
+====
+`ktor_http_server_requests_seconds` er en Micrometer *summary* med klientside-kvantiler (`quantile="0.5"`, `0.9`, `0.95`, `0.99`) — *ikke* et histogram med buckets.
+
+Konsekvensen er at `histogram_quantile()` ikke kan brukes, og at kvantilene *ikke kan aggregeres på tvers av poder*.
+En p99 fra én pod sier ingenting om p99 for tjenesten som helhet.
+
+Latensalarmer må derfor baseres på ett av:
+
+* gjennomsnitt: `rate(..._sum[5m]) / rate(..._count[5m])`, som kan aggregeres korrekt
+* `max(ktor_http_server_requests_seconds{quantile="0.99"})` som en grov indikasjon på verste pod
+
+Se <<hull, Kjente hull>> for tiltaket som fjerner denne begrensningen.
+====
+
+=== Plattformmetrikker fra nais
+
+nais leverer i tillegg hele settet av Kubernetes-metrikker, uten at vi trenger å instrumentere noe selv.
+Disse er spesielt verdifulle for oss fordi de dekker feilmoduser applikasjonen *ikke kan rapportere selv* — en pod som er OOM-drept eller ikke starter, rekker aldri å eksponere `/metrics`.
+
+[cols="2,3", options="header"]
+|===
+| Kilde | Brukes til
+
+| `kube_deployment_status_replicas_unavailable`, `kube_deployment_status_replicas_available`
+| Deployment får ikke opp poder — feilet utrulling, manglende ressurser, crashloop.
+
+| `kube_pod_container_status_restarts_total`
+| Crashloop og gjentatte restarter.
+
+| `kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}`
+| Minnelekkasjer og for lave minnegrenser. Direkte relevant for brevbaker og pdf-bygger som begge har `limits.memory: 2Gi`.
+
+| `kube_pod_container_status_waiting_reason`
+| `CrashLoopBackOff`, `ImagePullBackOff` etter en deploy.
+
+| `container_memory_working_set_bytes` / `kube_pod_container_resource_limits`
+| Nærhet til minnegrensen, før OOM-kill inntreffer.
+
+| `container_cpu_cfs_throttled_seconds_total`
+| CPU-struping. Særlig relevant for pdf-bygger, der typst-prosesser er CPU-tunge.
+
+| `kube_horizontalpodautoscaler_status_current_replicas` / `..._spec_max_replicas`
+| Autoskalering står i taket og kan ikke absorbere mer last.
+
+| `up`
+| Prometheus klarer ikke å scrape applikasjonen.
+
+| Ingress-metrikker (`nginx_ingress_controller_requests`)
+| Trafikk og statuskoder sett fra utsiden. *Eneste metrikkilde for skribenten-web*, se <<hull, Kjente hull>>.
+|===
+
+Fordi plattformmetrikkene er like for alle fire applikasjonene, definerer vi dem én gang som <<felles, felles plattformalarmer>> i stedet for å gjenta dem per app.
+
+=== Logger
+
+Logger går til både Elastic og Loki for alle fire applikasjonene.
+Logger brukes primært til *undersøkelse*, ikke til alarmering — logbaserte alarmer er skjøre fordi de knytter seg til fritekst som endres uten at noen tenker på alarmen.
+
+Vi gjør likevel unntak der metrikker ikke finnes, og der loggmeldingen er stabil og entydig:
+
+* `Won't retry for exception` — brevbaker mot pdf-bygger, og skribenten-backend mot nedstrøms tjenester. Betyr at en ikke-retriable feil har oppstått.
+* `Error executing one-shot job` — engangsjobb i skribenten-backend feilet.
+* `typst command failed` — kompileringsfeil i pdf-bygger.
+
+Alle logbaserte alarmer skal ha en kommentar i regelen som peker på filen og linjen meldingen kommer fra, slik at den som endrer meldingen ser sammenhengen.
+
+== Alarmer per applikasjon
+
+=== pensjon-brevbaker
+
+Brevbaker er navet i automatisk brevproduksjon. Feiler den, produseres det ikke brev — og fordi Pesys kjører batch utenfor kontortid, må kritiske alarmer her gjelde hele døgnet.
+
+[cols="3,1,3", options="header"]
+|===
+| Alarm | Nivå | Begrunnelse
+
+| Feilrate: andel 5xx på `/letter/*` over 5 % i 10 min
+| `critical`
+| Brev produseres ikke. Dette er den viktigste alarmen vi har. `/letter/autobrev/pdf` er den kritiske ruten.
+
+| Uventede exceptions: `throwable != "n/a"` øker på `/letter/*`
+| `critical`
+| Fanger feil som slipper gjennom `StatusPages` uten å bli oversatt til en kontrollert respons.
+
+| Gjennomsnittlig responstid på `/letter/autobrev/pdf` over terskel i 15 min
+| `warning`
+| Treghet her går rett inn i Pesys' batchvindu. Terskelen settes etter observert normalnivå før regelen tas i bruk.
+
+| `ktor_http_server_requests_active` vokser jevnt i 15 min
+| `warning`
+| Requests fullføres ikke. Typisk tegn på at pdf-bygger henger og at retry-logikken holder tråder opptatt.
+
+| Ingen brev produsert (`pensjon_brevbaker_letter_request_count_total` flat) i et forventet batchvindu
+| `critical`
+| Fanger den stille feilen: alt ser friskt ut, men ingen bestiller brev fordi Pesys ikke når fram. Ingen andre alarmer fanger dette.
+
+| Brå fall i `pensjon_brevbaker_letter_request_count_total` for en enkelt `brevkode`
+| `warning`
+| Kan bety at én brevmal er ødelagt selv om totalen ser normal ut. Vurderes først når vi har nok historikk til å definere «normalt» per brevkode.
+
+| Logg: `Alle toggles må være definert i Unleash`
+| `warning`
+| Feiltilstand i feature toggle-oppsettet som gir uforutsigbar malvalg.
+|===
+
+=== pensjon-pdf-bygger
+
+pdf-bygger har kun brevbaker som konsument. Den har *ingen egne domenemetrikker*, og er samtidig den mest ressursintensive applikasjonen vår (typst-prosesser, autoskalering opp til 150 poder).
+Alarmene her lener seg derfor tyngre på plattform- og ressursmetrikker.
+
+[cols="3,1,3", options="header"]
+|===
+| Alarm | Nivå | Begrunnelse
+
+| Feilrate: andel 5xx over 5 % i 10 min
+| `critical`
+| Serverfeil betyr at typst-kompilering feiler. Brevbaker vil retry-e, men vedvarende feil stopper brevproduksjonen.
+
+| Gjennomsnittlig responstid over terskel i 15 min
+| `warning`
+| Tidlig varsel før brevbaker begynner å time ut. Fordi brevbaker retry-er, ser vi treghet her *før* vi ser feil der.
+
+| CPU-strupning (`container_cpu_cfs_throttled_seconds_total`) vedvarende høy
+| `warning`
+| Typst er CPU-bundet. Strupning gir direkte treghet, og readiness-probene er allerede spesialtilpasset for å tåle korte CPU-spikes — vedvarende strupning betyr at tilpasningen ikke lenger holder.
+
+| HPA på maks replicas (150) i over 15 min
+| `warning`
+| Vi har ikke mer kapasitet å skalere ut med. Neste steg er økt latens og timeouts i brevbaker.
+
+| Logg: `typst command failed`, rate over normalnivå
+| `warning`
+| Skiller malfeil (én brevmal kompilerer ikke) fra infrastrukturfeil. Bør på sikt erstattes av en metrikk, se <<hull, Kjente hull>>.
+|===
+
+=== skribenten-backend
+
+Saksbehandlerflaten. Har database, og et stort antall nedstrøms integrasjoner (PEN/Pesys, SAF, KRR, TSS/Samhandler, Navansatt, Skjerming, brevbaker, førstesidegenerator).
+Kritiske alarmer gjelder i praksis kontortid.
+
+[cols="3,1,3", options="header"]
+|===
+| Alarm | Nivå | Begrunnelse
+
+| Feilrate: andel 5xx over 5 % i 10 min
+| `critical`
+| Saksbehandlere blir blokkert i arbeidet sitt.
+
+| `/isReady` returnerer 503 på flere poder i over 5 min
+| `critical`
+| Readiness sjekker databasetilgjengelighet. Vedvarende 503 betyr at databasen er utilgjengelig og at applikasjonen er ute av drift.
+
+| Brå økning i 4xx
+| `warning`
+| Tyder på brutt API-kontrakt mot skribenten-web, typisk etter en deploy av én av dem.
+
+| Feil mot en enkelt nedstrøms tjeneste over terskel
+| `warning`
+| Skal identifisere *hvilken* tjeneste som feiler. Krever instrumentering av HTTP-klientene, se <<hull, Kjente hull>>. Nivå `warning` fordi vi sjelden kan fikse andres tjenester selv — men vi må vite det, og kunne informere.
+
+| Logg: `Error executing one-shot job`
+| `warning`
+| Engangsjobber er idempotente og kjøres under leader election. En feilet jobb er ikke akutt, men blir aldri fanget opp av noe annet.
+
+| Databasetilkoblinger nær maks
+| `warning`
+| Tilkoblingslekkasje ender i total utilgjengelighet. Krever at connection pool-metrikker eksponeres, se <<hull, Kjente hull>>.
+|===
+
+=== skribenten-web
+
+React-SPA servert av en Node/Express-BFF, med Wonderwall-sidecar for autentisering.
+
+[WARNING]
+====
+BFF-en har *ikke* `prometheus`-blokk i `.nais/nais.yaml` og eksponerer ingen metrikker.
+Health-endepunktene `/internal/health/liveness` og `/internal/health/readiness` returnerer alltid `200` uten å sjekke noe.
+
+Vi har derfor i praksis ingen applikasjonssignaler for denne appen, og må inntil videre alarmere via plattform- og ingress-metrikker.
+====
+
+[cols="3,1,3", options="header"]
+|===
+| Alarm | Nivå | Begrunnelse
+
+| Ingress: andel 5xx over 5 % i 10 min
+| `critical`
+| Eneste tilgjengelige mål på om saksbehandlerne faktisk får opp applikasjonen.
+
+| Færre enn 2 tilgjengelige poder i over 5 min
+| `critical`
+| Appen er fastlåst til `min: 2, max: 2` og har ingen autoskalering å falle tilbake på. Én tapt pod halverer kapasiteten umiddelbart.
+
+| Trafikken faller til null i kontortid
+| `warning`
+| Fanger tilfellet der appen er «oppe» men utilgjengelig for brukerne, f.eks. ved feil i Wonderwall-innlogging.
+
+| Podrestarter
+| `warning`
+| Uten applikasjonsmetrikker er restarter et av få signaler vi har på at noe er galt i BFF-en.
+|===
+
+[[felles]]
+== Felles plattformalarmer
+
+Disse gjelder *alle fire* applikasjonene og defineres én gang, parametrisert på `app`.
+De fanger feilmoduser applikasjonen selv ikke kan rapportere.
+
+[cols="3,1,3", options="header"]
+|===
+| Alarm | Nivå | Begrunnelse
+
+| Ingen tilgjengelige poder i over 5 min
+| `critical`
+| Applikasjonen er nede. Den enkleste og viktigste plattformalarmen.
+
+| Færre tilgjengelige poder enn ønsket i over 15 min
+| `warning`
+| Redusert redundans. Vanligvis en deploy som ikke fullførte.
+
+| Container restarter gjentatte ganger (crashloop)
+| `critical`
+| Applikasjonen klarer ikke å starte. Nesten alltid en nylig deploy eller manglende konfigurasjon/secret.
+
+| `OOMKilled` som siste termineringsårsak
+| `warning`
+| Minnegrensen er nådd. For brevbaker og pdf-bygger, som begge har `limits.memory: 2Gi`, er dette en reell og forventet feilmodus ved store brev.
+
+| Minnebruk over 90 % av grensen i 15 min
+| `warning`
+| Varsler *før* OOM-kill, mens vi fortsatt kan handle.
+
+| Prometheus klarer ikke å scrape (`up == 0`) i 10 min
+| `warning`
+| Vi er blinde på appen. Alarmen som beskytter alle de andre alarmene.
+
+| Pod i `CrashLoopBackOff` eller `ImagePullBackOff`
+| `warning`
+| Feilet deploy. Skiller seg fra crashloop-alarmen ved å fange feil som oppstår før applikasjonen i det hele tatt kjører.
+|===
+
+[[ikke-alarmer]]
+== Bevisste ikke-alarmer
+
+Noen loggmeldinger og feilsituasjoner ser alarmerende ut, men skal *ikke* utløse alarm.
+De dokumenteres her slik at de ikke legges inn på nytt av noen som ser dem for første gang.
+
+`***stripped sensitive Edit.Letter value***`::
+Denne meldingen betyr at sensitive data ble *vellykket fjernet* før logging — altså at kontrollen virket etter hensikten.
++
+Årsaken er en feil i Exposed, der `BasicBinaryColumnType::valueFromDB` kaster en `IllegalStateException` med `toString()` av `Edit.Letter` i feilmeldingen.
+`cleanSensitiveDataAndLog` i `SkribentenApp.kt` fanger dette og erstatter verdien før noe skrives til logg.
++
+Dette er derfor *ikke* en personvernhendelse, og skal ikke alarmeres — hverken som `critical` eller `warning`.
+Riktig løsning er en oppretting oppstrøms i Exposed, sporet i https://youtrack.jetbrains.com/issue/EXPOSED-1012[EXPOSED-1012].
+Sanitiseringen kan først fjernes når den feilen er rettet og vi har oppgradert.
++
+Den underliggende feilen gir uansett en 500-respons, og fanges dermed allerede av feilrate-alarmen for skribenten-backend. En egen alarm ville kun vært duplikat.
+
+Forventede 4xx-responser::
+`401`/`403` fra Wonderwall og manglende tilgang er normal drift, ikke feil. Kun brå *endringer* i 4xx-nivået er interessante, jf. <<prinsipper, prinsipp 6>>.
+
+Enkeltstående retries mot pdf-bygger::
+Retry-logikken finnes nettopp for å absorbere forbigående feil. Vi alarmerer på *oppbrukte* retries og på resulterende feilrate, ikke på at en retry skjedde.
+
+Utløpte brevreservasjoner::
+En brevreservasjon kan ikke «henge». Gyldighet beregnes ved lesing i `BrevreservasjonPolicy.erGyldig` som `sistReservert + timeout > nå`, med en timeout på 10 minutter.
+Det finnes ingen lås som må frigis og ingen jobb som må rydde opp — en reservasjon opphører av seg selv når tiden har gått, også om poden som holdt den døde midt i redigeringen.
+Utløp er derfor normal drift og ikke en feiltilstand.
+
+[[hull]]
+== Kjente hull og tiltak
+
+Arbeidet med denne strategien avdekket flere mangler i instrumenteringen.
+Disse er bevisste, prioriterte oppgaver — ikke forglemmelser — og listes her slik at alarmdekningen kan forbedres stegvis.
+
+[cols="1,3,3,1", options="header"]
+|===
+| # | Hull | Tiltak | Prioritet
+
+| 1
+| Ktor-timeren er en summary uten histogram-buckets. Latens kan ikke aggregeres på tvers av poder.
+| Konfigurér `MicrometerMetrics` med `distributionStatisticConfig` og `percentilesHistogram`, slik at `histogram_quantile()` kan brukes. Gjelder alle tre Kotlin-appene.
+| Høy
+
+| 2
+| `skribenten-web` BFF eksponerer ingen metrikker.
+| Legg til `prometheus`-blokk i `.nais/nais.yaml` og et `/metrics`-endepunkt med `prom-client`.
+| Høy
+
+| 3
+| Ingen metrikker på nedstrøms kall fra skribenten-backend. Vi kan ikke skille «PEN er nede» fra «SAF er nede» uten å lese logger.
+| Instrumentér Ktor-klientene med `MicrometerMetrics`, tagget med tjenestenavn og statuskode.
+| Høy
+
+| 4
+| `/isReady` i brevbaker og pdf-bygger returnerer alltid `200` uten å sjekke noe. En pod som ikke kan nå pdf-bygger tas aldri ut av rotasjon.
+| Vurdér reell readiness-sjekk i brevbaker mot pdf-bygger. Må balanseres mot risikoen for at hele deployment tas ut av rotasjon samtidig ved en forbigående nedstrøms feil.
+| Middels
+
+| 5
+| pdf-bygger har ingen domenemetrikker. Typst-feil og kompileringstid er kun synlig i logg.
+| Legg til teller for typst-resultat (suksess/kompileringsfeil/eksekveringsfeil) og timer for kompileringstid.
+| Middels
+
+| 6
+| Retry-logikken i brevbaker mot pdf-bygger er usynlig i metrikker. Vi ser ikke at systemet sliter før det feiler helt.
+| Legg til teller for antall retries og for oppbrukte retries.
+| Middels
+
+| 7
+| Ingen metrikker på database og connection pool i skribenten-backend.
+| Bind HikariCP-metrikker til meter-registeret.
+| Middels
+|===
+
+== Forvaltning av alarmene
+
+Eierskap:: Alarmene eies av teamet i fellesskap. Den som mottar en alarm eier den til den er lukket eller eksplisitt overlevert.
+Runbook:: Hver `critical`-alarm skal ha en kort beskrivelse i selve alarmen: hva som er galt, hvem som rammes, og første feilsøkingssteg. En alarm uten dette er ikke ferdig.
+Gjennomgang:: Alarmene gjennomgås jevnlig. For hver alarm spør vi: har den utløst? Førte den til handling? Hvis den har utløst mange ganger uten å føre til handling, skal terskelen justeres eller alarmen fjernes.
+Endringer:: Nye og endrede alarmer går gjennom PR som all annen kode. Terskelendringer skal begrunnes i commit-meldingen.
+Ved falske positiver:: Juster terskel eller `for`-periode framfor å slå av alarmen. En avslått alarm blir sjelden slått på igjen.

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -50,7 +50,7 @@ Alvorlighetsgraden sier derfor ikke noe om når på døgnet vi rykker ut, men hv
 | Slack-kanal med varsling
 
 | `warning`
-| Noe er på vei galt, eller noe er ødelagt uten at brukerne merker det ennå.
+| Noe er i ferd med å gå galt, eller noe er allerede ødelagt uten at brukerne merker det ennå.
 | Tas i den ordinære arbeidsflyten.
 | Slack-kanal uten varsling
 |===
@@ -414,6 +414,6 @@ Disse er bevisste, prioriterte oppgaver — ikke forglemmelser — og listes her
 
 Eierskap:: Alarmene eies av teamet i fellesskap. Den som mottar en alarm eier den til den er lukket eller eksplisitt overlevert.
 Runbook:: Hver `critical`-alarm skal ha en kort beskrivelse i selve alarmen: hva som er galt, hvem som rammes, og første feilsøkingssteg. En alarm uten dette er ikke ferdig.
-Gjennomgang:: Alarmer vurderes i etterkant av at de har utløst, ikke etter en fast kalender. For hver alarm som har gått: var den reell, og førte den til handling? En alarm som gjentatte ganger utløser uten å føre til handling, skal justeres eller fjernes.
+Gjennomgang:: Alarmer vurderes i etterkant av at de har utløst. For hver alarm som har gått: var den reell, og førte den til handling? En alarm som gjentatte ganger utløser uten å føre til handling, skal justeres eller fjernes.
 Endringer:: Nye og endrede alarmer går gjennom PR som all annen kode. Terskelendringer skal begrunnes i commit-meldingen.
 Ved falske positiver:: Juster terskel eller `for`-periode framfor å slå av alarmen. En avslått alarm blir sjelden slått på igjen.


### PR DESCRIPTION
Vi har i dag ingen definerte alarmer for `pensjon-brevbaker`, `pensjon-pdf-bygger`, `skribenten-backend` eller `skribenten-web`.

Denne PR-en legger til en side under **For utviklere** som etablerer prinsippene og signalene alarmene skal utledes fra. Hensikten er å bli enige om strategien *før* vi begynner å skrive `PrometheusRule`-manifester — så her er det ingen alarmer som deployes, kun dokumentasjon.

## Hva som foreslås

- **To alvorlighetsgrader** (`critical`/`warning`). Flere nivåer i praksis betyr at det midterste ignoreres. Brevbaker og pdf-bygger betjener Pesys' nattbatch og må dekkes hele døgnet, mens Skribenten i praksis kun brukes i kontortid — en nedetid i Skribenten kl. 03 er ikke en kritisk hendelse.
- **Symptomer framfor årsaker**, alltid som rate over en `for`-periode, og med begrunnelse for hver terskel slik at de kan justeres bevisst framfor tilfeldig.
- **Plattformalarmene fra nais** (kube-state-metrics, cAdvisor, HPA, ingress) er definert én gang felles, parametrisert på `app`. De dekker feilmoduser applikasjonen ikke kan rapportere selv — en pod som er OOM-drept rekker aldri å eksponere `/metrics`.
- **Bevisste ikke-alarmer** er dokumentert eksplisitt, slik at de ikke legges inn igjen av noen som ser dem for første gang.

Konkrete alarmer er listet per applikasjon med nivå og begrunnelse.

## Hull som ble avdekket

Arbeidet avdekket sju mangler i instrumenteringen. De er listet med prioritet i dokumentet, men disse tre er verdt en ekstra titt:

1. `ktor_http_server_requests_seconds` er en **summary med kvantiler per pod, ikke et histogram**. `histogram_quantile()` kan derfor ikke brukes, og en p99 fra én pod sier ingenting om p99 for tjenesten. Latensalarmer må inntil videre baseres på `_sum`/`_count`.
2. **`skribenten-web` sin bff har ingen `prometheus`-blokk** i `nais.yaml` og eksponerer ingen metrikker. Health-endepunktene returnerer alltid `200` uten å sjekke noe. Vi har i praksis ingen applikasjonssignaler for den appen.
3. **Nedstrøms kall fra skribenten-backend er ikke instrumentert**, så vi kan ikke skille «PEN er nede» fra «SAF er nede» uten å lese logger.

## Hva jeg ønsker tilbakemelding på

- Er døgndekningen riktig delt mellom brevbaker/pdf-bygger og Skribenten?
- Terskelverdiene er satt som utgangspunkt, ikke fasit. Særlig feilrate på 5 % og latensterskene bør kalibreres mot observert normalnivå før vi tar reglene i bruk.
- Er det feilmoduser dere har sett i drift som ikke er dekket her?
- Stemmer prioriteringen i «Kjente hull og tiltak»?
