### PR TITLE
fix(skribenten): unngå døde HikariCP-forbindelser mot Cloud SQL

### DIFF
--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/Databaseoppsett.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/Databaseoppsett.kt
@@ -14,6 +14,8 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.sql.DataSource
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 val databaseReady: AtomicBoolean = AtomicBoolean(false)
 
@@ -63,10 +65,10 @@ fun initDatabase(jdbcUrl: String, username: String, password: String, maxPoolSiz
         // Cloud SQL/proxy kan lukke inaktive forbindelser før Hikari sin default maxLifetime (30 min),
         // som gir "Failed to validate connection ... This connection has been closed".
         // Poolen er bevisst fixed-size (minimumIdle == maximumPoolSize), så idleTimeout settes ikke.
-        maxLifetime = 600_000
-        keepaliveTime = 120_000
-        connectionTimeout = 5_000
-        validationTimeout = 3_000
+        maxLifetime = 10.minutes.inWholeMilliseconds
+        keepaliveTime = 2.minutes.inWholeMilliseconds
+        connectionTimeout = 5.seconds.inWholeMilliseconds
+        validationTimeout = 3.seconds.inWholeMilliseconds
         validate()
     }).also { konfigurerFlyway(it) }
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/Databaseoppsett.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/Databaseoppsett.kt
@@ -60,6 +60,13 @@ fun initDatabase(jdbcUrl: String, username: String, password: String, maxPoolSiz
         this.password = password
         this.initializationFailTimeout = 6000
         maximumPoolSize = maxPoolSize
+        // Cloud SQL/proxy kan lukke inaktive forbindelser før Hikari sin default maxLifetime (30 min),
+        // som gir "Failed to validate connection ... This connection has been closed."
+        maxLifetime = 600_000
+        idleTimeout = 300_000
+        keepaliveTime = 120_000
+        connectionTimeout = 5_000
+        validationTimeout = 3_000
         validate()
     }).also { konfigurerFlyway(it) }
 

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/Databaseoppsett.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/db/Databaseoppsett.kt
@@ -61,9 +61,9 @@ fun initDatabase(jdbcUrl: String, username: String, password: String, maxPoolSiz
         this.initializationFailTimeout = 6000
         maximumPoolSize = maxPoolSize
         // Cloud SQL/proxy kan lukke inaktive forbindelser før Hikari sin default maxLifetime (30 min),
-        // som gir "Failed to validate connection ... This connection has been closed."
+        // som gir "Failed to validate connection ... This connection has been closed".
+        // Poolen er bevisst fixed-size (minimumIdle == maximumPoolSize), så idleTimeout settes ikke.
         maxLifetime = 600_000
-        idleTimeout = 300_000
         keepaliveTime = 120_000
         connectionTimeout = 5_000
         validationTimeout = 3_000


### PR DESCRIPTION
Hikari brukte defaults (maxLifetime 30 min, keepalive av), mens Cloud SQL/proxy lukker inaktive forbindelser tidligere. Det ga "Failed to validate connection ... This connection has been closed."

Setter maxLifetime=10m, keepaliveTime=2m, idleTimeout=5m og eksplisitte connection-/validationTimeout for fail-fast i containere.

Adresserer denne: https://nav-it.slack.com/archives/C035WFB3W1F/p1785451430068929