### PR TITLE
fix(bff): unngå polynomisk backtracking i STACK_FRAME_REGEX

### DIFF
--- a/skribenten-web/bff/src/sourceMapResolver.ts
+++ b/skribenten-web/bff/src/sourceMapResolver.ts
@@ -13,7 +13,10 @@ const sourcemapsRoot = path.resolve("./sourcemaps");
 // Matches a stack frame referencing one of our built assets, e.g.
 // "at Component (https://skribenten.intern.dev.nav.no/assets/index-CzilmHAy.js:1:12345)"
 // or "at https://skribenten.intern.dev.nav.no/assets/index-CzilmHAy.js:1:12345".
-const STACK_FRAME_REGEX = /https?:\/\/[^\s)]+(\/assets\/[^\s):]+\.js):(\d+):(\d+)/;
+// The character classes are kept mutually exclusive (the host part cannot
+// contain "/", the asset name cannot contain "/") so the regex has no
+// ambiguity and runs in linear time on untrusted input.
+const STACK_FRAME_REGEX = /https?:\/\/[^\s)/]+(\/assets\/[^\s):/]+\.js):(\d+):(\d+)/;
 
 const traceMapCache = new Map<string, TraceMap | undefined>();
 


### PR DESCRIPTION
Host-delen [^\s)]+ og (\/assets\/[^\s):]+\.js) kunne begge matche "/assets/...", noe som ga flertydig oppdeling og O(n^2) backtracking på lange stack-trace-linjer fra frontend (ukontrollert input).

Ekskluderer "/" i begge tegnklassene slik at kun én oppdeling er mulig, og regexen kjører i lineær tid. Trygt fordi Vite ikke setter "base", så assets serveres fra rot.

Rettar https://github.com/navikt/pensjonsbrev/security/code-scanning/66