### PR TITLE
Ymse ut

### DIFF
--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/EndringUforetrygd.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/EndringUforetrygd.kt
@@ -134,8 +134,8 @@ object EndringUforetrygd : RedigerbarTemplate<EndringUfoeretrygdDto> {
                 paragraph {
                     showIf(kravarsak.equalTo("soknad_bt")) {
                         text(
-                            bokmal { +"Du er innvilget barnetillegg i uføretrygden din for" },
-                            nynorsk { +"Du er innvilga barnetillegg i uføretrygda di for" },
+                            bokmal { +"Vi har innvilget søknaden din om barnetillegg som vi mottok " + soknadsdato.format() + ". Du er innvilget barnetillegg i uføretrygden din for" },
+                            nynorsk { +"Vi har innvilga søknaden din om barnetillegg som vi fekk " + soknadsdato.format() + ". Du er innvilga barnetillegg i uføretrygda di for" },
                         )
                     } orShow {
                         text(

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/EndringUforetrygd.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/EndringUforetrygd.kt
@@ -1096,8 +1096,8 @@ object EndringUforetrygd : RedigerbarTemplate<EndringUfoeretrygdDto> {
             }.orShowIf(virkningbegrunnelseStdbegr_22_12_1_5) {
                 paragraph {
                     text(
-                        bokmal { +"Du har fått innvilget uføretrygd fra " + onsketvirkningsdato.format() + ". Dette kaller vi virkningstidspunktet. Vi mottok søknaden din " + soknadsdato.format() + ". Dersom vilkårene for rett til uføretrygd var oppfylt før dette, kan uføretrygden innvilges opptil tre måneder før denne datoen. <FRITEKST>" },
-                        nynorsk { +"Du har fått innvilga uføretrygd frå " + onsketvirkningsdato.format() + ". Dette kallar vi verknadstidspunktet. Vi fekk søknaden din " + soknadsdato.format() + ". Dersom vilkåra for rett til uføretrygd var oppfylte før dette, kan vi innvilge uføretrygd opptil tre månader før denne datoen. <FRITEKST>" },
+                        bokmal { +"Du har fått innvilget uføretrygd fra " + onsketvirkningsdato.format() + ". Dette kaller vi virkningstidspunktet. Vi mottok søknaden din " + soknadsdato.format() + ". Dersom vilkårene for rett til uføretrygd var oppfylt før dette, kan uføretrygden innvilges opptil tre måneder før denne datoen. " + fritekst("Fritekst") },
+                        nynorsk { +"Du har fått innvilga uføretrygd frå " + onsketvirkningsdato.format() + ". Dette kallar vi verknadstidspunktet. Vi fekk søknaden din " + soknadsdato.format() + ". Dersom vilkåra for rett til uføretrygd var oppfylte før dette, kan vi innvilge uføretrygd opptil tre månader før denne datoen. " + fritekst("Fritekst") },
                     )
                 }
             }.orShowIf(((virkningstidspunktBegrunnelse).equalTo("stdbegr_22_12_1_12"))) {

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/OkningUforegrad.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/OkningUforegrad.kt
@@ -111,8 +111,8 @@ object OkningUforegrad : RedigerbarTemplate<OkningUforegradDto> {
                 )
                 showIf(pe.vedtaksdata_kravhode_kravarsaktype().isNotAnyOf("omgj_etter_klage", "omgj_etter_anke")) {
                     text(
-                        bokmal { +"Uføregraden din øker fra " + fritekst("Forrige Uforegrad") + " til " + uforegradFraBeregning.format() + " prosent fra " + virkningstidpunkt.format() + ". " },
-                        nynorsk { +"Uføregraden din aukar frå " + fritekst("Forrige Uforegrad") + " til " + uforegradFraBeregning.format() + " prosent frå " + virkningstidpunkt.format() + ". " },
+                        bokmal { +"Uføregraden din øker fra " + fritekst("Forrige uføregrad") + " til " + uforegradFraBeregning.format() + " prosent fra " + virkningstidpunkt.format() + ". " },
+                        nynorsk { +"Uføregraden din aukar frå " + fritekst("Forrige uføregrad") + " til " + uforegradFraBeregning.format() + " prosent frå " + virkningstidpunkt.format() + ". " },
                     )
                 }.orShow {
                     text(
@@ -622,8 +622,8 @@ object OkningUforegrad : RedigerbarTemplate<OkningUforegradDto> {
 
             paragraph {
                 text(
-                    bokmal { +"Vi har tidligere fastsatt uføretidspunktet ditt til " + fritekst("Første Uforetidspunkt") + ". Når uføregraden øker, fastsetter vi et nytt uføretidspunkt. Det nye uføretidspunktet ditt er " + uforetidspunkt.format() + "." },
-                    nynorsk { +"Vi har tidlegare fastsett uføretidspunktet ditt til " + fritekst("Første Uforetidspunkt") + ". Når uføregraden aukar, fastset vi eit nytt uføretidspunkt. Det nye uføretidspunktet ditt er " + uforetidspunkt.format() + "." },
+                    bokmal { +"Vi har tidligere fastsatt uføretidspunktet ditt til " + fritekst("Første uføretidspunkt") + ". Når uføregraden øker, fastsetter vi et nytt uføretidspunkt. Det nye uføretidspunktet ditt er " + uforetidspunkt.format() + "." },
+                    nynorsk { +"Vi har tidlegare fastsett uføretidspunktet ditt til " + fritekst("Første uføretidspunkt") + ". Når uføregraden aukar, fastset vi eit nytt uføretidspunkt. Det nye uføretidspunktet ditt er " + uforetidspunkt.format() + "." },
                 )
             }
 

--- a/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/OkningUforegrad.kt
+++ b/pensjon/maler/src/main/kotlin/no/nav/pensjon/brev/maler/legacy/redigerbar/OkningUforegrad.kt
@@ -598,8 +598,8 @@ object OkningUforegrad : RedigerbarTemplate<OkningUforegradDto> {
             showIf(((pe.vedtaksdata_vilkarsvedtaklist_vilkarsvedtak_beregningsvilkar_virkningbegrunnelse()).equalTo("stdbegr_22_12_1_5"))) {
                 paragraph {
                     text(
-                        bokmal { +"Du har fått innvilget økt uføretrygd fra " + pe.vedtaksdata_virkningfom().format() + ". Dette kaller vi virkningstidspunktet. Vi mottok søknaden din " + soknadsdato.format() + ". Dersom vilkårene for rett til uføretrygd var oppfylt før dette, kan uføretrygden innvilges opptil tre måneder før denne datoen.<FRITEKST>." },
-                        nynorsk { +"Du har fått innvilga auka uføretrygd frå " + pe.vedtaksdata_virkningfom().format() + ". Dette kallar vi verknadstidspunktet. Vi fekk søknaden din " + soknadsdato.format() + ". Dersom vilkåra for rett til uføretrygd var oppfylte før dette, kan vi innvilge uføretrygd for opptil tre månader før denne datoen.<FRITEKST>." },
+                        bokmal { +"Du har fått innvilget økt uføretrygd fra " + pe.vedtaksdata_virkningfom().format() + ". Dette kaller vi virkningstidspunktet. Vi mottok søknaden din " + soknadsdato.format() + ". Dersom vilkårene for rett til uføretrygd var oppfylt før dette, kan uføretrygden innvilges opptil tre måneder før denne datoen. " + fritekst("Fritekst") },
+                        nynorsk { +"Du har fått innvilga auka uføretrygd frå " + pe.vedtaksdata_virkningfom().format() + ". Dette kallar vi verknadstidspunktet. Vi fekk søknaden din " + soknadsdato.format() + ". Dersom vilkåra for rett til uføretrygd var oppfylte før dette, kan vi innvilge uføretrygd for opptil tre månader før denne datoen. " + fritekst("Fritekst") },
                     )
                 }
             }
@@ -1158,7 +1158,8 @@ object OkningUforegrad : RedigerbarTemplate<OkningUforegradDto> {
                             btSerkullInnvilget = barnetilleggSerkullInnvilget,
                             grunnbelop = pe.vedtaksdata_beregningsdata_beregningufore_uforetrygdberegning_grunnbelop(),
                             pe = pe,
-                            periodisertInntekt = saksbehandlerValg.periodisertInntekt)
+                            periodisertInntekt = saksbehandlerValg.periodisertInntekt
+                        )
                     )
                 }
 

--- a/ufoere/maler/src/main/kotlin/no/nav/pensjon/brev/ufore/maler/uforeavslag/UforeAvslagIFUIkkeVarig.kt
+++ b/ufoere/maler/src/main/kotlin/no/nav/pensjon/brev/ufore/maler/uforeavslag/UforeAvslagIFUIkkeVarig.kt
@@ -86,8 +86,8 @@ object UforeAvslagIFUIkkeVarig : RedigerbarTemplate<UforeAvslagEnkelDto> {
                     nynorsk { + "Du oppfyller ikkje vilkåret for å endre inntektsgrensa, og vi avslår derfor søknaden din." })
             }
             paragraph {
-                text(bokmal { +"Vedtaket har vi gjort etter folketrygdloven § 12-9 og forskrift om uføretrygd fra folketrygden § 2-2." },
-                    nynorsk { +"Vedtaket har vi gjort etter folketrygdlova § 12-9 og forskrift om uføretrygd frå folketrygda § 2-2." })
+                text(bokmal { +"Vedtaket har vi gjort etter folketrygdloven § 12-9 og forskrift om uføretrygd fra folketrygden § 2-3." },
+                    nynorsk { +"Vedtaket har vi gjort etter folketrygdlova § 12-9 og forskrift om uføretrygd frå folketrygda § 2-3." })
             }
 
             includePhrase(Felles.RettTilAKlageLang)

--- a/ufoere/maler/src/main/kotlin/no/nav/pensjon/brev/ufore/maler/uforeavslag/UforeAvslagIFUOktStilling.kt
+++ b/ufoere/maler/src/main/kotlin/no/nav/pensjon/brev/ufore/maler/uforeavslag/UforeAvslagIFUOktStilling.kt
@@ -83,8 +83,8 @@ object UforeAvslagIFUOktStilling : RedigerbarTemplate<UforeAvslagEnkelDto> {
                     nynorsk { + "Du oppfyller ikkje vilkåret for å endre inntektsgrensa, og vi avslår derfor søknaden din."})
             }
             paragraph {
-                text(bokmal { +"Vedtaket har vi gjort etter folketrygdloven § 12-9 og forskrift om uføretrygd fra folketrygden § 2-2." },
-                    nynorsk { +"Vedtaket har vi gjort etter folketrygdlova § 12-9 og forskrift om uføretrygd frå folketrygda § 2-2." })
+                text(bokmal { +"Vedtaket har vi gjort etter folketrygdloven § 12-9 og forskrift om uføretrygd fra folketrygden § 2-3." },
+                    nynorsk { +"Vedtaket har vi gjort etter folketrygdlova § 12-9 og forskrift om uføretrygd frå folketrygda § 2-3." })
             }
 
             includePhrase(Felles.RettTilAKlageLang)


### PR DESCRIPTION
Fikser:
Kom over at det bare står <FRITEKST> noen steder, endret til ordentlig fritekst
Ø i fritekst, rapportert i jira
Innvilgelse av barnetillegg fra jira
Feil lovreferanse, rapportert i teams