### PR TITLE
Eksporter latens som histogram i stedet for summary

### DIFF
--- a/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/Metrics.kt
+++ b/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/Metrics.kt
@@ -1,4 +1,4 @@
-package no.nav.pensjon.brev.skribenten
+package no.nav.pensjon.brev.pdfbygger
 
 import io.ktor.server.application.*
 import io.ktor.server.metrics.micrometer.*
@@ -14,22 +14,18 @@ import kotlin.time.Duration.Companion.seconds
 object Metrics {
     private val prometheusRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 
-    // Skribenten er en interaktiv saksbehandlerflate, så vi er interessert i lavere latens enn i
-    // brevbaker. Ytterpunktene styrer hvor micrometer genererer automatiske buckets.
-    // Den øverste matcher requestTimeout mot brevbaker (BrevbakerService), slik at et kall som
-    // går til timeout havner innenfor histogrammet og ikke i +Inf.
-    // Nedre grense er beholdt selv om metadatarutene (/land, /me/userinfo) ligger på 2-8ms: de
-    // alarmerer vi ikke på, og et gulv på 10ms ville kostet 18 ekstra buckets per rute.
-    private val forventetLavest = 50.milliseconds
+    // Kompilering med typst er CPU-tung, og de tyngste brevene bruker flere sekunder.
+    // Ytterpunktene styrer hvor micrometer genererer automatiske buckets.
+    // Høyest observerte svartid i prod er 7,2s (/produserBrev), så taket har god margin.
+    private val forventetLavest = 100.milliseconds
     private val forventetHoyest = 60.seconds
 
     // SLO-grenser vi vil kunne alarmere eksakt på. Må være sortert.
-    // Den øverste ligger bevisst over forventetHoyest: i prod er høyest observerte svartid 91s
-    // (/external/api/v1/brev), altså over timeouten mot brevbaker, så uten denne ville halen
-    // havnet i +Inf. Grenser over ytterpunktet tas med av micrometer uten at det genereres tett
-    // bucket-oppløsning i et område vi sjelden er i.
+    // De to øverste ligger bevisst over forventetHoyest: brevbaker venter i inntil 300s på et
+    // svar herfra, og uten disse ville alt mellom 60s og 300s havnet i +Inf. Grenser over
+    // ytterpunktet tas med av micrometer uten at det genereres tett bucket-oppløsning i et
+    // område vi sjelden er i.
     private val latencyBuckets = listOf(
-        50.milliseconds,
         100.milliseconds,
         250.milliseconds,
         500.milliseconds,
@@ -37,9 +33,11 @@ object Metrics {
         2.seconds,
         5.seconds,
         10.seconds,
+        20.seconds,
         30.seconds,
         60.seconds,
         120.seconds,
+        300.seconds,
     ).map { it.inWholeNanoseconds.toDouble() }
 
     fun Application.configureMetrics() {
@@ -58,7 +56,8 @@ object Metrics {
             // histogram_quantile() blir presis uansett hvor latensen faktisk legger seg.
             // serviceLevelObjectives kommer i tillegg til disse, og gir oss eksakte grenser å
             // alarmere mot ("andel raskere enn 2s"). Uten min/max ville micrometer generert 69
-            // buckets per rute og statuskode, som blir unødvendig mange tidsserier.
+            // buckets per rute og statuskode, som blir spesielt dyrt her siden pdf-bygger skalerer
+            // opp til mange poder.
             distributionStatisticConfig = DistributionStatisticConfig.Builder()
                 .percentilesHistogram(true)
                 .minimumExpectedValue(forventetLavest.inWholeNanoseconds.toDouble())

--- a/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/PdfByggerApp.kt
+++ b/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/PdfByggerApp.kt
@@ -6,7 +6,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.jackson.jackson
 import io.ktor.server.application.*
 import io.ktor.server.config.*
-import io.ktor.server.metrics.micrometer.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.callid.CallId
 import io.ktor.server.plugins.callid.callIdMdc
@@ -20,11 +19,10 @@ import io.ktor.server.request.receiveText
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.logging.Logger
-import io.micrometer.prometheusmetrics.PrometheusConfig
-import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.serialization.json.Json
 import no.nav.brev.brevbaker.markup.LetterPDFRequest
 import no.nav.brev.brevbaker.PDFRequest
+import no.nav.pensjon.brev.pdfbygger.Metrics.configureMetrics
 import no.nav.pensjon.brev.pdfbygger.typst.TypstCompileService
 import no.nav.pensjon.brev.pdfbygger.typst.documentrender.TypstDocumentRenderer
 import no.nav.pensjon.brev.pdfbygger.typst.documentrender.TypstDocumentRendererV2
@@ -54,17 +52,7 @@ internal fun Application.setUp(typstCompileService: TypstCompileService) {
         it.log.info("Application preparing to shutdown gracefully")
     }
 
-    val prometheusMeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-    install(MicrometerMetrics) {
-        registry = prometheusMeterRegistry
-    }
-
-    routing {
-        get("/metrics") {
-            call.respond(prometheusMeterRegistry.scrape())
-        }
-    }
-
+    configureMetrics()
 
     install(ContentNegotiation) {
         jackson {

--- a/brevbaker/pdf-bygger/src/test/kotlin/no/nav/pensjon/brev/pdfbygger/MetricsRouteTest.kt
+++ b/brevbaker/pdf-bygger/src/test/kotlin/no/nav/pensjon/brev/pdfbygger/MetricsRouteTest.kt
@@ -1,0 +1,65 @@
+package no.nav.pensjon.brev.pdfbygger
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MetricsRouteTest {
+
+    // NB: må ankres på skilletegnet, ellers matcher regexet slutten av throwable="n/a".
+    private fun grenseFra(bucket: String): String? =
+        Regex("""[,{]le="([^"]+)"""").find(bucket)?.groupValues?.get(1)
+
+    private fun withScrape(block: (List<String>) -> Unit) = testApplication {
+        environment { config = ApplicationConfig(null) }
+
+        client.get("/isAlive")
+        val metrikker = client.get("/metrics").bodyAsText().lines()
+            .filter { it.startsWith("ktor_http_server_requests_seconds") }
+        // Uten denne ville assertFalse-testene under passert selv om scrapingen ikke ga noe.
+        assertTrue(metrikker.isNotEmpty()) { "Fant ingen ktor_http_server_requests_seconds-metrikker" }
+        block(metrikker)
+    }
+
+    @Test
+    fun `latens rapporteres som histogram-buckets slik at de kan aggregeres paa tvers av poder`() =
+        withScrape { metrikker ->
+            val buckets = metrikker.filter { it.startsWith("ktor_http_server_requests_seconds_bucket") }
+            assertTrue(buckets.isNotEmpty()) { "Forventet histogram-buckets, fikk:\n${metrikker.joinToString("\n")}" }
+
+            // Grensene oppgis i nanosekunder til Micrometer, men skal rapporteres i sekunder.
+            // Slår dette feil er sannsynligvis tidsenheten på serviceLevelObjectives feil.
+            listOf("0.1", "0.25", "0.5", "1.0", "2.0", "5.0", "10.0", "20.0", "30.0", "60.0", "120.0", "300.0").forEach { grense ->
+                assertTrue(buckets.any { it.contains("le=\"$grense\"") }) {
+                    "Manglet bucket le=\"$grense\". Fant:\n${buckets.joinToString("\n")}"
+                }
+            }
+
+            // percentilesHistogram gir flere buckets enn SLO-grensene alene, men uten min- og
+            // maksgrense genererer micrometer 69 buckets per rute og statuskode.
+            val grenser = buckets.mapNotNull { grenseFra(it) }.distinct()
+            assertTrue(grenser.size in 20..60) {
+                "Forventet et klamret sett med buckets, fant ${grenser.size} grenser: $grenser"
+            }
+        }
+
+    @Test
+    fun `scrapen inneholder ingen klientside-kvantiler som ikke kan aggregeres`() =
+        withScrape { metrikker ->
+            assertFalse(metrikker.any { it.contains("quantile=\"") }) {
+                "Forventet ingen klientside-kvantiler, fant:\n${metrikker.filter { it.contains("quantile=") }.joinToString("\n")}"
+            }
+        }
+
+    @Test
+    fun `address-tagen er fjernet siden nais allerede gir oss pod som label`() =
+        withScrape { metrikker ->
+            assertFalse(metrikker.any { it.contains("address=\"") }) {
+                "Forventet ingen address-tag, fant:\n${metrikker.filter { it.contains("address=") }.joinToString("\n")}"
+            }
+        }
+}

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -62,7 +62,7 @@ Skillet avgjør ikke om noen blir vekket, men hvordan vi tolker en alarm i etter
 
 === Applikasjonsmetrikker
 
-Alle tre Kotlin-applikasjonene eksponerer Prometheus-metrikker på `/metrics` via `MicrometerMetrics`, og scrapes av nais (`prometheus.enabled: true`).
+Alle tre Ktor-applikasjonene eksponerer Prometheus-metrikker på `/metrics` via `MicrometerMetrics`, og scrapes av nais (`prometheus.enabled: true`).
 nais legger automatisk på labels som `app`, `namespace` og `pod`, slik at alle spørringer kan filtreres på `app="pensjon-brevbaker"` osv.
 
 Tilgjengelige metrikker:

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -77,6 +77,9 @@ Tilgjengelige metrikker:
 | `ktor_http_server_requests_seconds_sum`
 | Sum av responstid. Sammen med `_count` gir dette gjennomsnittlig responstid.
 
+| `ktor_http_server_requests_seconds_bucket`
+| Kumulativ fordeling per `le`-grense. Grunnlaget for `histogram_quantile()`, se merknaden under.
+
 | `ktor_http_server_requests_seconds_max`
 | Høyeste observerte responstid i vinduet. Nyttig for å fange enkelttreghet.
 
@@ -95,17 +98,32 @@ Tilgjengelige metrikker:
 
 [IMPORTANT]
 ====
-`ktor_http_server_requests_seconds` er en Micrometer *summary* med klientside-kvantiler (`quantile="0.5"`, `0.9`, `0.95`, `0.99`) — *ikke* et histogram med buckets.
+`ktor_http_server_requests_seconds` er konfigurert som et *histogram* med buckets, ikke som en summary med klientside-kvantiler.
 
-Konsekvensen er at `histogram_quantile()` ikke kan brukes, og at kvantilene *ikke kan aggregeres på tvers av poder*.
-En p99 fra én pod sier ingenting om p99 for tjenesten som helhet.
+Det er et bevisst valg: klientside-kvantiler regnes ut per pod og kan *ikke* aggregeres, slik at en p99 fra én pod ikke sier noe om p99 for tjenesten.
+Med buckets kan `histogram_quantile()` brukes på tvers av alle poder:
 
-Latensalarmer må derfor baseres på ett av:
+[source]
+----
+histogram_quantile(0.95, sum(rate(ktor_http_server_requests_seconds_bucket{app="pensjon-brevbaker", route="/letter/autobrev/pdf"}[5m])) by (le))
+----
 
-* gjennomsnitt: `rate(..._sum[5m]) / rate(..._count[5m])`, som kan aggregeres korrekt
-* `max(ktor_http_server_requests_seconds{quantile="0.99"})` som en grov indikasjon på verste pod
+Merk at `le` *må* være med i `by`-klausulen — uten den har `histogram_quantile()` ingen buckets å regne på.
 
-Se <<hull, Kjente hull>> for tiltaket som fjerner denne begrensningen.
+Spørringen over gir *p95*: den responstiden som 95 % av forespørslene var raskere enn, mens de 5 % tregeste brukte lengre tid.
+Vi bruker p95 i latensalarmene fordi den treffer mellom to ytterpunkter: gjennomsnittet skjuler at en mindre andel har det vondt, mens `max` slår ut på én enkelt treg forespørsel.
+Stiger p95 er det en reell andel brev eller saksbehandlere som merker tregheten.
+
+Bucket-grensene settes i hver app sin `Metrics.kt` og er tilpasset appens forventede latens.
+Den *øverste* grensen er bevisst forankret i timeoutene i koden, ikke i observert latens: et kall som går til timeout skal havne innenfor histogrammet og ikke i `+Inf`, ellers er halen usynlig akkurat når vi trenger den.
+Derfor dekker brevbaker opp til 300s (`withTimeoutOrNull` rundt kallene mot pdf-bygger i `PensjonPdfByggerService`) og skribenten opp til 120s (`requestTimeout` på 60s mot brevbaker, med margin for ruter som gjør flere kall).
+Endres en timeout i koden, må den øverste bucket-grensen følge med.
+
+Grensene er kalibrert mot observert latens i prod.
+Vær oppmerksom på at datagrunnlaget har to begrensninger: ingen store batcher hadde kjørt innenfor retensjonsperioden, og p95 og p99 er identiske for samtlige ruter fordi trafikkvolumet er for lavt til at estimatoren skiller dem.
+Halen er derfor sannsynligvis underestimert, noe som taler for å beholde romslige tak.
+
+Ligger p95 mellom to bucket-grenser, interpolerer `histogram_quantile()` lineært — verdien blir derfor grovere jo grovere grensene er.
 ====
 
 === Plattformmetrikker fra nais
@@ -178,9 +196,9 @@ Brevbaker er navet i automatisk brevproduksjon. Feiler den, produseres det ikke 
 | `critical`
 | Fanger feil som slipper gjennom `StatusPages` uten å bli oversatt til en kontrollert respons.
 
-| Gjennomsnittlig responstid på `/letter/autobrev/pdf` over terskel i 15 min
+| p95 responstid på `/letter/autobrev/pdf` over terskel i 15 min
 | `warning`
-| Treghet her går rett inn i Pesys' batchvindu. Terskelen settes etter observert normalnivå før regelen tas i bruk.
+| Treghet her går rett inn i Pesys' batchvindu. p95 fanger at en betydelig andel brev er trege, uten å utløse på enkelttreghet slik `max` ville gjort. Terskelen settes etter observert normalnivå før regelen tas i bruk.
 
 | `ktor_http_server_requests_active` vokser jevnt i 15 min
 | `warning`
@@ -212,7 +230,7 @@ Alarmene her lener seg derfor tyngre på plattform- og ressursmetrikker.
 | `critical`
 | Serverfeil betyr at typst-kompilering feiler. Brevbaker vil retry-e, men vedvarende feil stopper brevproduksjonen.
 
-| Gjennomsnittlig responstid over terskel i 15 min
+| p95 responstid over terskel i 15 min
 | `warning`
 | Tidlig varsel før brevbaker begynner å time ut. Fordi brevbaker retry-er, ser vi treghet her *før* vi ser feil der.
 
@@ -233,6 +251,15 @@ Alarmene her lener seg derfor tyngre på plattform- og ressursmetrikker.
 
 Saksbehandlerflaten. Har database, og et stort antall nedstrøms integrasjoner (PEN/Pesys, SAF, KRR, TSS/Samhandler, Navansatt, Skjerming, brevbaker, førstesidegenerator).
 Kritiske alarmer gjelder i praksis kontortid.
+
+[NOTE]
+====
+Ved kalibrering av bucket-grensene så vi at ni ruter har en observert maksimal svartid på nøyaktig 60,x sekunder.
+Det er `requestTimeout` på 60s mot brevbaker som slår inn — altså kall som allerede i dag går til timeout i prod.
+`/external/api/v1/brev` og `/sak/{saksId}` ligger enda høyere, på henholdsvis 91s og 76s, som tyder på ruter der flere kall gjøres etter hverandre.
+
+Dette er ikke et hull i alarmdekningen, men verdt å kjenne til: en latensalarm på disse rutene vil se en hale som er avkortet av timeouten, og en økning i feilrate kan like gjerne skyldes treghet nedstrøms som feil hos oss.
+====
 
 [cols="3,1,3", options="header"]
 |===
@@ -375,36 +402,31 @@ Disse er bevisste, prioriterte oppgaver — ikke forglemmelser — og listes her
 | # | Hull | Tiltak | Prioritet
 
 | 1
-| Ktor-timeren er en summary uten histogram-buckets. Latens kan ikke aggregeres på tvers av poder.
-| Konfigurér `MicrometerMetrics` med `distributionStatisticConfig` og `percentilesHistogram`, slik at `histogram_quantile()` kan brukes. Gjelder alle tre Kotlin-appene.
-| Høy
-
-| 2
 | `skribenten-web` BFF eksponerer ingen metrikker.
 | Legg til `prometheus`-blokk i `.nais/nais.yaml` og et `/metrics`-endepunkt med `prom-client`.
 | Høy
 
-| 3
+| 2
 | Ingen metrikker på nedstrøms kall fra skribenten-backend. Vi kan ikke skille «PEN er nede» fra «SAF er nede» uten å lese logger.
 | Instrumentér Ktor-klientene med `MicrometerMetrics`, tagget med tjenestenavn og statuskode.
 | Høy
 
-| 4
+| 3
 | `/isReady` i brevbaker og pdf-bygger returnerer alltid `200` uten å sjekke noe. En pod som ikke kan nå pdf-bygger tas aldri ut av rotasjon.
 | Vurdér reell readiness-sjekk i brevbaker mot pdf-bygger. Må balanseres mot risikoen for at hele deployment tas ut av rotasjon samtidig ved en forbigående nedstrøms feil.
 | Middels
 
-| 5
+| 4
 | pdf-bygger har ingen domenemetrikker. Typst-feil og kompileringstid er kun synlig i logg.
 | Legg til teller for typst-resultat (suksess/kompileringsfeil/eksekveringsfeil) og timer for kompileringstid.
 | Middels
 
-| 6
+| 5
 | Retry-logikken i brevbaker mot pdf-bygger er usynlig i metrikker. Vi ser ikke at systemet sliter før det feiler helt.
 | Legg til teller for antall retries og for oppbrukte retries.
 | Middels
 
-| 7
+| 6
 | Ingen metrikker på database og connection pool i skribenten-backend.
 | Bind HikariCP-metrikker til meter-registeret.
 | Middels

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/Metrics.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/Metrics.kt
@@ -4,15 +4,67 @@ import io.ktor.server.application.*
 import io.ktor.server.metrics.micrometer.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.micrometer.core.instrument.config.MeterFilter
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 object Metrics {
     val prometheusRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 
+    // Brevbaker kaller pdf-bygger og bruker derfor sekunder, ikke millisekunder, på /letter-rutene.
+    // Ytterpunktene styrer hvor micrometer genererer automatiske buckets.
+    // Høyest observerte svartid i prod er 8,5s (/letter/redigerbar/pdf), så taket har god margin.
+    // Nedre grense er beholdt selv om /templates-rutene ligger på 2-7ms: de alarmerer vi ikke på,
+    // og et gulv på 10ms ville kostet 18 ekstra buckets per rute.
+    private val forventetLavest = 100.milliseconds
+    private val forventetHoyest = 60.seconds
+
+    // SLO-grenser vi vil kunne alarmere eksakt på. Må være sortert.
+    // De to øverste ligger bevisst over forventetHoyest: kall mot pdf-bygger avbrytes først av
+    // withTimeoutOrNull(300s) i PensjonPdfByggerService, og uten disse ville alt mellom 60s og
+    // 300s havnet i +Inf. Grenser over ytterpunktet tas med av micrometer uten at det genereres
+    // tett bucket-oppløsning i et område vi sjelden er i.
+    private val latencyBuckets = listOf(
+        100.milliseconds,
+        250.milliseconds,
+        500.milliseconds,
+        1.seconds,
+        2.seconds,
+        5.seconds,
+        10.seconds,
+        20.seconds,
+        30.seconds,
+        60.seconds,
+        120.seconds,
+        300.seconds,
+    ).map { it.inWholeNanoseconds.toDouble() }
+
     fun Application.configureMetrics() {
+        // Ktor tagger hver request med address=<podnavn>:<port>. Det er redundant med labelene
+        // nais legger på ved scraping, og gir nye tidsserier for hver deploy.
+        prometheusRegistry.config().meterFilter(MeterFilter.ignoreTags("address"))
+
         install(MicrometerMetrics) {
             registry = prometheusRegistry
+            // Ktor eksporterer som standard latens som en summary med klientside-kvantiler, og de
+            // kan ikke aggregeres på tvers av poder - en p99 fra én pod sier ingenting om p99 for
+            // tjenesten. Når vi setter bucket-grenser eksporteres metrikken i stedet som et ekte
+            // histogram, slik at histogram_quantile() kan brukes i alarmer og dashboards.
+            //
+            // percentilesHistogram gir et tett sett med buckets innenfor min/max, slik at
+            // histogram_quantile() blir presis uansett hvor latensen faktisk legger seg.
+            // serviceLevelObjectives kommer i tillegg til disse, og gir oss eksakte grenser å
+            // alarmere mot ("andel raskere enn 2s"). Uten min/max ville micrometer generert 69
+            // buckets per rute og statuskode, som blir unødvendig mange tidsserier.
+            distributionStatisticConfig = DistributionStatisticConfig.Builder()
+                .percentilesHistogram(true)
+                .minimumExpectedValue(forventetLavest.inWholeNanoseconds.toDouble())
+                .maximumExpectedValue(forventetHoyest.inWholeNanoseconds.toDouble())
+                .serviceLevelObjectives(*latencyBuckets.toDoubleArray())
+                .build()
         }
         routing {
             get("/metrics") {

--- a/pensjon/brevbaker/src/test/kotlin/no/nav/pensjon/brev/routing/MetricsRouteTest.kt
+++ b/pensjon/brevbaker/src/test/kotlin/no/nav/pensjon/brev/routing/MetricsRouteTest.kt
@@ -1,0 +1,71 @@
+package no.nav.pensjon.brev.routing
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import no.nav.pensjon.brev.testBrevbakerApp
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MetricsRouteTest {
+
+    // NB: må ankres på skilletegnet, ellers matcher regexet slutten av throwable="n/a".
+    private fun grenseFra(bucket: String): String? =
+        Regex("""[,{]le="([^"]+)"""").find(bucket)?.groupValues?.get(1)
+
+    private suspend fun io.ktor.client.HttpClient.scrapeAfterRequest(): List<String> {
+        get("/isAlive")
+        val metrikker = get("/metrics").bodyAsText().lines()
+            .filter { it.startsWith("ktor_http_server_requests_seconds") }
+        // Uten denne ville assertFalse-testene under passert selv om scrapingen ikke ga noe.
+        assertTrue(metrikker.isNotEmpty()) { "Fant ingen ktor_http_server_requests_seconds-metrikker" }
+        return metrikker
+    }
+
+    @Test
+    fun `latens rapporteres som histogram-buckets slik at de kan aggregeres paa tvers av poder`() =
+        testBrevbakerApp(isIntegrationTest = false) { client ->
+            val metrikker = client.scrapeAfterRequest()
+
+            val buckets = metrikker.filter { it.startsWith("ktor_http_server_requests_seconds_bucket") }
+            assertTrue(buckets.isNotEmpty()) { "Forventet histogram-buckets, fikk:\n${metrikker.joinToString("\n")}" }
+
+            // Grensene oppgis i nanosekunder til Micrometer, men skal rapporteres i sekunder.
+            // Slår dette feil er sannsynligvis tidsenheten på serviceLevelObjectives feil.
+            listOf("0.1", "0.25", "0.5", "1.0", "2.0", "5.0", "10.0", "20.0", "30.0", "60.0", "120.0", "300.0").forEach { grense ->
+                assertTrue(buckets.any { it.contains("le=\"$grense\"") }) {
+                    "Manglet bucket le=\"$grense\". Fant:\n${buckets.joinToString("\n")}"
+                }
+            }
+
+            // percentilesHistogram gir flere buckets enn SLO-grensene alene, men uten min- og
+            // maksgrense genererer micrometer 69 buckets per rute og statuskode.
+            val grenser = buckets.mapNotNull { grenseFra(it) }.distinct()
+            assertTrue(grenser.size in 20..60) {
+                "Forventet et klamret sett med buckets, fant ${grenser.size} grenser: $grenser"
+            }
+        }
+
+    @Test
+    fun `scrapen inneholder ingen klientside-kvantiler som ikke kan aggregeres`() =
+        testBrevbakerApp(isIntegrationTest = false) { client ->
+            val metrikker = client.scrapeAfterRequest()
+
+            // Kvantilene forsvinner fordi metrikken eksporteres som histogram når
+            // serviceLevelObjectives er satt, ikke fordi vi lar være å sette percentiles.
+            // Testen sikrer at scrapen faktisk er fri for dem, uansett årsak.
+            assertFalse(metrikker.any { it.contains("quantile=\"") }) {
+                "Forventet ingen klientside-kvantiler, fant:\n${metrikker.filter { it.contains("quantile=") }.joinToString("\n")}"
+            }
+        }
+
+    @Test
+    fun `address-tagen er fjernet siden nais allerede gir oss pod som label`() =
+        testBrevbakerApp(isIntegrationTest = false) { client ->
+            val metrikker = client.scrapeAfterRequest()
+
+            assertFalse(metrikker.any { it.contains("address=\"") }) {
+                "Forventet ingen address-tag, fant:\n${metrikker.filter { it.contains("address=") }.joinToString("\n")}"
+            }
+        }
+}

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/MetricsRouteTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/MetricsRouteTest.kt
@@ -1,0 +1,72 @@
+package no.nav.pensjon.brev.skribenten
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.testApplication
+import no.nav.pensjon.brev.skribenten.Metrics.configureMetrics
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MetricsRouteTest {
+
+    // NB: må ankres på skilletegnet, ellers matcher regexet slutten av throwable="n/a".
+    private fun grenseFra(bucket: String): String? =
+        Regex("""[,{]le="([^"]+)"""").find(bucket)?.groupValues?.get(1)
+
+    // Vi installerer kun metrikkene, ikke hele appen, slik at testen slipper database og
+    // innlogging. Tom konfigurasjon er nødvendig fordi application.conf ellers lastes og krever
+    // miljøvariabler som DB_PASSWORD.
+    private fun withScrape(block: (List<String>) -> Unit) = testApplication {
+        environment { config = MapApplicationConfig() }
+        application { configureMetrics() }
+
+        // Første kall gir noe å måle, siden metrikken for et kall først registreres når det er
+        // ferdig og dermed ikke rekker å bli med i sin egen scrape.
+        client.get("/metrics")
+        val metrikker = client.get("/metrics").bodyAsText().lines()
+            .filter { it.startsWith("ktor_http_server_requests_seconds") }
+        // Uten denne ville assertFalse-testene under passert selv om scrapingen ikke ga noe.
+        assertTrue(metrikker.isNotEmpty()) { "Fant ingen ktor_http_server_requests_seconds-metrikker" }
+        block(metrikker)
+    }
+
+    @Test
+    fun `latens rapporteres som histogram-buckets slik at de kan aggregeres paa tvers av poder`() =
+        withScrape { metrikker ->
+            val buckets = metrikker.filter { it.startsWith("ktor_http_server_requests_seconds_bucket") }
+            assertTrue(buckets.isNotEmpty()) { "Forventet histogram-buckets, fikk:\n${metrikker.joinToString("\n")}" }
+
+            // Grensene oppgis i nanosekunder til Micrometer, men skal rapporteres i sekunder.
+            // Slår dette feil er sannsynligvis tidsenheten på serviceLevelObjectives feil.
+            listOf("0.05", "0.1", "0.25", "0.5", "1.0", "2.0", "5.0", "10.0", "30.0", "60.0", "120.0").forEach { grense ->
+                assertTrue(buckets.any { it.contains("le=\"$grense\"") }) {
+                    "Manglet bucket le=\"$grense\". Fant:\n${buckets.joinToString("\n")}"
+                }
+            }
+
+            // percentilesHistogram gir flere buckets enn SLO-grensene alene, men uten min- og
+            // maksgrense genererer micrometer 69 buckets per rute og statuskode.
+            val grenser = buckets.mapNotNull { grenseFra(it) }.distinct()
+            assertTrue(grenser.size in 20..60) {
+                "Forventet et klamret sett med buckets, fant ${grenser.size} grenser: $grenser"
+            }
+        }
+
+    @Test
+    fun `scrapen inneholder ingen klientside-kvantiler som ikke kan aggregeres`() =
+        withScrape { metrikker ->
+            assertFalse(metrikker.any { it.contains("quantile=\"") }) {
+                "Forventet ingen klientside-kvantiler, fant:\n${metrikker.filter { it.contains("quantile=") }.joinToString("\n")}"
+            }
+        }
+
+    @Test
+    fun `address-tagen er fjernet siden nais allerede gir oss pod som label`() =
+        withScrape { metrikker ->
+            assertFalse(metrikker.any { it.contains("address=\"") }) {
+                "Forventet ingen address-tag, fant:\n${metrikker.filter { it.contains("address=") }.joinToString("\n")}"
+            }
+        }
+}


### PR DESCRIPTION
Lukker hull 1 i [alarmstrategien](https://github.com/navikt/pensjonsbrev/blob/main/docs/modules/ROOT/pages/alarmstrategi.adoc): latensmetrikken kunne ikke brukes til alarmer.

## Problemet

Ktor eksporterer som standard `ktor_http_server_requests_seconds` som en **summary med klientside-kvantiler** (p50/p90/p95/p99). Slike kvantiler regnes ut per pod og kan ikke aggregeres — en p99 fra én pod sier ingenting om p99 for tjenesten. Det gjorde `histogram_quantile()` ubrukelig, og latensalarmene måtte derfor bruke gjennomsnitt.

## Løsningen

Når vi setter bucket-grenser, rendrer Prometheus-eksportøren metrikken som et ekte histogram med `_bucket`-serier, og kvantilene forsvinner. To mekanismer kombineres:

- `percentilesHistogram(true)` gir et tett sett med buckets, slik at `histogram_quantile()` blir presis uansett hvor latensen legger seg.
- `serviceLevelObjectives` kommer i tillegg, og gir eksakte grenser å alarmere mot («andel raskere enn 2s»).

`minimumExpectedValue`/`maximumExpectedValue` klamrer settet til appens faktiske område. Uten klamring genererer micrometer **69 buckets** per rute og statuskode — unødvendig mange tidsserier, spesielt i pdf-bygger som skalerer opp til mange poder.

I tillegg fjernes `address`-tagen, som Ktor setter til `<podnavn>:<port>`. Den er redundant med labelene nais legger på ved scraping, og gir nye tidsserier ved hver deploy.

## Valg av grenser

Grensene er kalibrert mot observert latens i prod (Grafana, 30-dagers vindu).

De **øverste** grensene er bevisst forankret i timeoutene i koden, ikke i observerte tall: et kall som går til timeout skal havne innenfor histogrammet og ikke i `+Inf`, ellers er halen usynlig akkurat når vi trenger den.

| App | Område | Øverste grense | Forankring |
|---|---|---|---|
| pensjon-brevbaker | 100 ms – 60 s | 300 s | `withTimeoutOrNull(300s)` i `PensjonPdfByggerService` |
| pensjon-pdf-bygger | 100 ms – 60 s | 300 s | Samme kall sett fra motsatt side |
| skribenten-backend | 50 ms – 60 s | 120 s | `requestTimeout = 60s` mot brevbaker, med margin for ruter som gjør flere kall |

SLO-grenser over `maximumExpectedValue` tas med av micrometer uten at det genereres tett bucket-oppløsning i et område vi sjelden er i — de to øverste koster derfor kun **2 ekstra buckets**, mot 13 om vi hadde hevet selve taket.

De **nedre** grensene er beholdt selv om enkelte metadataruter (`/templates/*`, `/land`, `/me/userinfo`) ligger på 2–8 ms. Vi alarmerer ikke på dem, og et gulv på 10 ms ville kostet **18 ekstra buckets** per rute.

### Forbehold om datagrunnlaget

To begrensninger er verdt å kjenne til, og er dokumentert i strategien:

- Ingen store batcher hadde kjørt innenfor retensjonsperioden.
- p95 og p99 er **identiske for samtlige ruter** — trafikkvolumet (~4 req/min) er for lavt til at Micrometers per-pod-estimator skiller dem.

Halen er derfor sannsynligvis underestimert, noe som taler for å beholde romslige tak.

## Dokumentasjon

`alarmstrategi.adoc` er oppdatert: merknaden om at `histogram_quantile()` ikke kan brukes er erstattet med hvordan den brukes, inkludert en konkret spørring og en forklaring av hva p95 betyr. De to latensalarmene for brevbaker og pdf-bygger går fra gjennomsnitt til **p95**. Hull 1 er fjernet og de øvrige renummerert.

Det er også lagt inn en `[NOTE]` om at ni skribenten-ruter har observert maks svartid på nøyaktig 60,x s — `requestTimeout` mot brevbaker som allerede i dag slår inn i prod. `/external/api/v1/brev` og `/sak/{saksId}` ligger på 91 s og 76 s. Ikke et hull i alarmdekningen, men verdt å vite: halen på disse rutene er avkortet av timeouten, og økt feilrate kan like gjerne skyldes treghet nedstrøms som feil hos oss.

## Testing

`MetricsRouteTest` i alle tre appene (3 tester hver, 9/9 grønne) verifiserer at:

- eksakte `le`-grenser finnes — fanger opp enhetsfeil, siden `serviceLevelObjectives` for en Timer forventer **nanosekunder**
- antall grenser ligger i 20..60 — fanger opp at klamringen fjernes
- ingen `quantile="..."`-serier finnes
- ingen `address`-tag finnes

Testene sikrer seg mot vakuum-pass ved å kreve at metrikklisten ikke er tom.

> [!NOTE]
> Endres en timeout i koden, må den øverste bucket-grensen følge med. Endres bucket-grensene, må `le`-listene i alle tre testene oppdateres.
