### PR TITLE
Eksponer prometheus-metrikker fra skribenten-web BFF

### DIFF
--- a/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/Metrics.kt
+++ b/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/Metrics.kt
@@ -18,10 +18,10 @@ object Metrics {
     // Ytterpunktene styrer hvor micrometer genererer automatiske buckets.
     // Høyest observerte svartid i prod er 7,2s (/produserBrev), så taket har god margin.
     private val forventetLavest = 100.milliseconds
-    private val forventetHoyest = 60.seconds
+    private val forventetHoeyest = 60.seconds
 
     // SLO-grenser vi vil kunne alarmere eksakt på. Må være sortert.
-    // De to øverste ligger bevisst over forventetHoyest: brevbaker venter i inntil 300s på et
+    // De to øverste ligger bevisst over forventetHoeyest: brevbaker venter i inntil 300s på et
     // svar herfra, og uten disse ville alt mellom 60s og 300s havnet i +Inf. Grenser over
     // ytterpunktet tas med av micrometer uten at det genereres tett bucket-oppløsning i et
     // område vi sjelden er i.
@@ -61,7 +61,7 @@ object Metrics {
             distributionStatisticConfig = DistributionStatisticConfig.Builder()
                 .percentilesHistogram(true)
                 .minimumExpectedValue(forventetLavest.inWholeNanoseconds.toDouble())
-                .maximumExpectedValue(forventetHoyest.inWholeNanoseconds.toDouble())
+                .maximumExpectedValue(forventetHoeyest.inWholeNanoseconds.toDouble())
                 .serviceLevelObjectives(*latencyBuckets.toDoubleArray())
                 .build()
         }

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -275,7 +275,7 @@ Kritiske alarmer gjelder i praksis kontortid.
 ====
 Ved kalibrering av bucket-grensene så vi at ni ruter har en observert maksimal svartid på nøyaktig 60,x sekunder.
 Det er `requestTimeout` på 60s mot brevbaker som slår inn — altså kall som allerede i dag går til timeout i prod.
-`/external/api/v1/brev` og `/sak/{saksId}` ligger enda høyere, på henholdsvis 91s og 76s, som tyder på ruter der flere kall gjøres etter hverandre.
+`/external/api/v1/brev` og `/sak/\{saksId}` ligger enda høyere, på henholdsvis 91s og 76s, som tyder på ruter der flere kall gjøres etter hverandre.
 
 Dette er ikke et hull i alarmdekningen, men verdt å kjenne til: en latensalarm på disse rutene vil se en hale som er avkortet av timeouten, og en økning i feilrate kan like gjerne skyldes treghet nedstrøms som feil hos oss.
 ====

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -446,6 +446,10 @@ Utløp er derfor normal drift og ikke en feiltilstand.
 Arbeidet med denne strategien avdekket flere mangler i instrumenteringen.
 Disse er bevisste, prioriterte oppgaver — ikke forglemmelser — og listes her slik at alarmdekningen kan forbedres stegvis.
 
+Ingen av de gjenstående hullene er blokkerende for alarmene i tabellene over.
+De to som var det, er lukket: latensmetrikken eksporteres nå som histogram, og skribenten-web eksponerer metrikker.
+Det som står igjen forbedrer *feilsøkingen* når en alarm har gått — det gjør oss raskere til å finne årsaken, ikke flinkere til å oppdage at noe er galt.
+
 [cols="1,3,3,1", options="header"]
 |===
 | # | Hull | Tiltak | Prioritet
@@ -453,7 +457,7 @@ Disse er bevisste, prioriterte oppgaver — ikke forglemmelser — og listes her
 | 1
 | Ingen metrikker på nedstrøms kall fra skribenten-backend. Vi kan ikke skille «PEN er nede» fra «SAF er nede» uten å lese logger.
 | Instrumentér Ktor-klientene med et eget metrikk-plugin. Ktor 3.5 har ingen klientside-metrikkplugin, men alle klientene går gjennom `HttpClientFactory.lagHttpClient`, så instrumenteringen kan legges ett sted.
-| Høy
+| Middels
 
 | 2
 | `/isReady` i brevbaker og pdf-bygger returnerer alltid `200` uten å sjekke noe. En pod som ikke kan nå pdf-bygger tas aldri ut av rotasjon.

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -126,6 +126,25 @@ Halen er derfor sannsynligvis underestimert, noe som taler for å beholde romsli
 Ligger p95 mellom to bucket-grenser, interpolerer `histogram_quantile()` lineært — verdien blir derfor grovere jo grovere grensene er.
 ====
 
+`skribenten-web` er ikke en Ktor-app, men BFF-en eksponerer tilsvarende metrikker på `/internal/metrics` via `prom-client`:
+
+[cols="2,3", options="header"]
+|===
+| Metrikk | Merknad
+
+| `http_server_request_duration_seconds_*`
+| Histogram med `method`, `route` og `status_code`. `route` er en grov klassifisering — `proxy`, `bff-api`, `static`, `probe` — ikke faktisk sti.
+
+| `nodejs_eventloop_lag_seconds`
+| Viktigste metningssignal for Node. En blokkert event loop gjør appen uresponsiv uten at CPU ser unormal ut.
+
+| `nodejs_heap_size_used_bytes`, `nodejs_gc_duration_seconds`
+| Minnebruk og GC. Fanger minnelekkasjer før de ender i podrestarter.
+
+| `process_cpu_seconds_total`, `process_resident_memory_bytes`
+| Standard prosessmetrikker.
+|===
+
 === Plattformmetrikker fra nais
 
 nais leverer i tillegg hele settet av Kubernetes-metrikker, uten at vi trenger å instrumentere noe selv.
@@ -160,7 +179,7 @@ Disse er spesielt verdifulle for oss fordi de dekker feilmoduser applikasjonen *
 | Prometheus klarer ikke å scrape applikasjonen.
 
 | Ingress-metrikker (`nginx_ingress_controller_requests`)
-| Trafikk og statuskoder sett fra utsiden. *Eneste metrikkilde for skribenten-web*, se <<hull, Kjente hull>>.
+| Trafikk og statuskoder sett fra utsiden. Fanger også feil som aldri når applikasjonen, f.eks. i Wonderwall eller ingress-kontrolleren.
 |===
 
 Fordi plattformmetrikkene er like for alle fire applikasjonene, definerer vi dem én gang som <<felles, felles plattformalarmer>> i stedet for å gjenta dem per app.
@@ -296,11 +315,29 @@ React-SPA servert av en Node/Express-BFF, med Wonderwall-sidecar for autentiseri
 
 [WARNING]
 ====
-BFF-en har *ikke* `prometheus`-blokk i `.nais/nais.yaml` og eksponerer ingen metrikker.
-Health-endepunktene `/internal/health/liveness` og `/internal/health/readiness` returnerer alltid `200` uten å sjekke noe.
+BFF-en eksponerte tidligere ingen metrikker.
+Den har nå `prometheus`-blokk i `.nais/nais.yaml` og et `/internal/metrics`-endepunkt basert på `prom-client`.
 
-Vi har derfor i praksis ingen applikasjonssignaler for denne appen, og må inntil videre alarmere via plattform- og ingress-metrikker.
+Health-endepunktene `/internal/health/liveness` og `/internal/health/readiness` returnerer fortsatt alltid `200` uten å sjekke noe.
+BFF-en har ingen oppstartsavhengigheter den må ha kontakt med, så det er mindre alvorlig her enn i backend-appene — men readiness sier ikke noe om at proxyen faktisk virker.
 ====
+
+[NOTE]
+====
+`observability.autoInstrumentation` er slått på med `runtime: nodejs`, og NAIS utleder RED-metrikker fra spans (`traces_spanmetrics_*` i Mimir).
+De er *ikke* tilstrekkelige til alarmer for denne appen, av tre grunner vi har verifisert mot prod:
+
+* *Ingen `http_route`.* Spans navngis kun med HTTP-metoden (`GET`, `POST`), fordi BFF-en monterer alt med `server.use(...)` og proxy-middleware i stedet for deklarerte Express-ruter. `http.route` blir derfor aldri satt, og proxytrafikk kan ikke skilles fra statiske filer.
+* *`http_response_status_code` er tom* for alle SERVER-spans, så 5xx-rate kan ikke måles derfra.
+* *Bucket-grensene stopper på 5s.* De settes av Tempos metrics-generator og kan ikke konfigureres fra appen. Kall gjennom proxyen når 60s og mer, så hele den interessante halen havner i `+Inf`.
+
+Sampling er ikke et problem — `OTEL_TRACES_SAMPLER` er `parentbased_always_on` — men de tre punktene over gjør at vi eksponerer vårt eget histogram med grenser vi styrer selv.
+Span-metrikkene er fortsatt nyttige til feilsøking og til å se sammenhengen mellom appene, inkludert Wonderwall.
+====
+
+Rutelabelen i `http_server_request_duration_seconds` er bevisst grov — `proxy`, `bff-api`, `static` og `probe` — fordi rå sti ville gitt en ny tidsserie per saks- og brev-id.
+skribenten-backend har allerede latens per rute, så det er der man finner ut *hvilket* endepunkt som er tregt.
+BFF-ens histogram svarer på om proxylaget som helhet er tregt, inkludert OBO-veksling og nettverk.
 
 [cols="3,1,3", options="header"]
 |===
@@ -308,11 +345,23 @@ Vi har derfor i praksis ingen applikasjonssignaler for denne appen, og må innti
 
 | Ingress: andel 5xx over 5 % i 10 min
 | `critical`
-| Eneste tilgjengelige mål på om saksbehandlerne faktisk får opp applikasjonen.
+| Måler om saksbehandlerne faktisk får opp applikasjonen, også når feilen ligger i Wonderwall eller ingress og aldri når BFF-en.
+
+| Feilrate: andel 5xx på `route="proxy"` over 5 % i 10 min
+| `critical`
+| Skiller feil i proxylaget fra feil i utlevering av statiske filer. Sammen med ingress-alarmen lokaliserer den feilen til BFF-en eller til laget foran.
 
 | Færre enn 2 tilgjengelige poder i over 5 min
 | `critical`
 | Appen er fastlåst til `min: 2, max: 2` og har ingen autoskalering å falle tilbake på. Én tapt pod halverer kapasiteten umiddelbart.
+
+| p95 responstid på `route="proxy"` over terskel i 15 min
+| `warning`
+| Fanger treghet slik saksbehandleren opplever den, inkludert OBO-veksling og nettverk mot skribenten-backend. Ligger den høyt mens backend ser frisk ut, er det BFF-en eller auth-hoppet som er tregt.
+
+| `nodejs_eventloop_lag_seconds` over terskel i 5 min
+| `warning`
+| En blokkert event loop gjør appen treg eller helt uresponsiv *uten* at container-CPU ser unormal ut. Dette er den klassiske feilmodusen for Node, og signalet finnes ikke i plattformmetrikkene.
 
 | Trafikken faller til null i kontortid
 | `warning`
@@ -320,7 +369,7 @@ Vi har derfor i praksis ingen applikasjonssignaler for denne appen, og må innti
 
 | Podrestarter
 | `warning`
-| Uten applikasjonsmetrikker er restarter et av få signaler vi har på at noe er galt i BFF-en.
+| Ofte første synlige tegn på at prosessen dør, f.eks. ved minnelekkasje. Se også `nodejs_heap_size_used_bytes`.
 |===
 
 [[felles]]
@@ -402,31 +451,26 @@ Disse er bevisste, prioriterte oppgaver — ikke forglemmelser — og listes her
 | # | Hull | Tiltak | Prioritet
 
 | 1
-| `skribenten-web` BFF eksponerer ingen metrikker.
-| Legg til `prometheus`-blokk i `.nais/nais.yaml` og et `/metrics`-endepunkt med `prom-client`.
+| Ingen metrikker på nedstrøms kall fra skribenten-backend. Vi kan ikke skille «PEN er nede» fra «SAF er nede» uten å lese logger.
+| Instrumentér Ktor-klientene med et eget metrikk-plugin. Ktor 3.5 har ingen klientside-metrikkplugin, men alle klientene går gjennom `HttpClientFactory.lagHttpClient`, så instrumenteringen kan legges ett sted.
 | Høy
 
 | 2
-| Ingen metrikker på nedstrøms kall fra skribenten-backend. Vi kan ikke skille «PEN er nede» fra «SAF er nede» uten å lese logger.
-| Instrumentér Ktor-klientene med `MicrometerMetrics`, tagget med tjenestenavn og statuskode.
-| Høy
-
-| 3
 | `/isReady` i brevbaker og pdf-bygger returnerer alltid `200` uten å sjekke noe. En pod som ikke kan nå pdf-bygger tas aldri ut av rotasjon.
 | Vurdér reell readiness-sjekk i brevbaker mot pdf-bygger. Må balanseres mot risikoen for at hele deployment tas ut av rotasjon samtidig ved en forbigående nedstrøms feil.
 | Middels
 
-| 4
+| 3
 | pdf-bygger har ingen domenemetrikker. Typst-feil og kompileringstid er kun synlig i logg.
 | Legg til teller for typst-resultat (suksess/kompileringsfeil/eksekveringsfeil) og timer for kompileringstid.
 | Middels
 
-| 5
+| 4
 | Retry-logikken i brevbaker mot pdf-bygger er usynlig i metrikker. Vi ser ikke at systemet sliter før det feiler helt.
 | Legg til teller for antall retries og for oppbrukte retries.
 | Middels
 
-| 6
+| 5
 | Ingen metrikker på database og connection pool i skribenten-backend.
 | Bind HikariCP-metrikker til meter-registeret.
 | Middels

--- a/docs/modules/ROOT/pages/alarmstrategi.adoc
+++ b/docs/modules/ROOT/pages/alarmstrategi.adoc
@@ -313,15 +313,6 @@ Dette er ikke et hull i alarmdekningen, men verdt å kjenne til: en latensalarm 
 
 React-SPA servert av en Node/Express-BFF, med Wonderwall-sidecar for autentisering.
 
-[WARNING]
-====
-BFF-en eksponerte tidligere ingen metrikker.
-Den har nå `prometheus`-blokk i `.nais/nais.yaml` og et `/internal/metrics`-endepunkt basert på `prom-client`.
-
-Health-endepunktene `/internal/health/liveness` og `/internal/health/readiness` returnerer fortsatt alltid `200` uten å sjekke noe.
-BFF-en har ingen oppstartsavhengigheter den må ha kontakt med, så det er mindre alvorlig her enn i backend-appene — men readiness sier ikke noe om at proxyen faktisk virker.
-====
-
 [NOTE]
 ====
 `observability.autoInstrumentation` er slått på med `runtime: nodejs`, og NAIS utleder RED-metrikker fra spans (`traces_spanmetrics_*` i Mimir).

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/Metrics.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/Metrics.kt
@@ -20,10 +20,10 @@ object Metrics {
     // Nedre grense er beholdt selv om /templates-rutene ligger på 2-7ms: de alarmerer vi ikke på,
     // og et gulv på 10ms ville kostet 18 ekstra buckets per rute.
     private val forventetLavest = 100.milliseconds
-    private val forventetHoyest = 60.seconds
+    private val forventetHoeyest = 60.seconds
 
     // SLO-grenser vi vil kunne alarmere eksakt på. Må være sortert.
-    // De to øverste ligger bevisst over forventetHoyest: kall mot pdf-bygger avbrytes først av
+    // De to øverste ligger bevisst over forventetHoeyest: kall mot pdf-bygger avbrytes først av
     // withTimeoutOrNull(300s) i PensjonPdfByggerService, og uten disse ville alt mellom 60s og
     // 300s havnet i +Inf. Grenser over ytterpunktet tas med av micrometer uten at det genereres
     // tett bucket-oppløsning i et område vi sjelden er i.
@@ -62,7 +62,7 @@ object Metrics {
             distributionStatisticConfig = DistributionStatisticConfig.Builder()
                 .percentilesHistogram(true)
                 .minimumExpectedValue(forventetLavest.inWholeNanoseconds.toDouble())
-                .maximumExpectedValue(forventetHoyest.inWholeNanoseconds.toDouble())
+                .maximumExpectedValue(forventetHoeyest.inWholeNanoseconds.toDouble())
                 .serviceLevelObjectives(*latencyBuckets.toDoubleArray())
                 .build()
         }

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Metrics.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Metrics.kt
@@ -21,10 +21,10 @@ object Metrics {
     // Nedre grense er beholdt selv om metadatarutene (/land, /me/userinfo) ligger på 2-8ms: de
     // alarmerer vi ikke på, og et gulv på 10ms ville kostet 18 ekstra buckets per rute.
     private val forventetLavest = 50.milliseconds
-    private val forventetHoyest = 60.seconds
+    private val forventetHoeyest = 60.seconds
 
     // SLO-grenser vi vil kunne alarmere eksakt på. Må være sortert.
-    // Den øverste ligger bevisst over forventetHoyest: i prod er høyest observerte svartid 91s
+    // Den øverste ligger bevisst over forventetHoeyest: i prod er høyest observerte svartid 91s
     // (/external/api/v1/brev), altså over timeouten mot brevbaker, så uten denne ville halen
     // havnet i +Inf. Grenser over ytterpunktet tas med av micrometer uten at det genereres tett
     // bucket-oppløsning i et område vi sjelden er i.
@@ -62,7 +62,7 @@ object Metrics {
             distributionStatisticConfig = DistributionStatisticConfig.Builder()
                 .percentilesHistogram(true)
                 .minimumExpectedValue(forventetLavest.inWholeNanoseconds.toDouble())
-                .maximumExpectedValue(forventetHoyest.inWholeNanoseconds.toDouble())
+                .maximumExpectedValue(forventetHoeyest.inWholeNanoseconds.toDouble())
                 .serviceLevelObjectives(*latencyBuckets.toDoubleArray())
                 .build()
         }

--- a/skribenten-web/bff/.nais/nais.yaml
+++ b/skribenten-web/bff/.nais/nais.yaml
@@ -24,7 +24,8 @@ spec:
     initialDelay: 5
   prometheus:
     enabled: true
-    path: /internal/metrics
+    path: "/internal/metrics"
+    port: "8080"
   observability:
     autoInstrumentation:
       enabled: true

--- a/skribenten-web/bff/.nais/nais.yaml
+++ b/skribenten-web/bff/.nais/nais.yaml
@@ -22,6 +22,9 @@ spec:
   readiness:
     path: /internal/health/readiness
     initialDelay: 5
+  prometheus:
+    enabled: true
+    path: /internal/metrics
   observability:
     autoInstrumentation:
       enabled: true

--- a/skribenten-web/bff/package-lock.json
+++ b/skribenten-web/bff/package-lock.json
@@ -16,7 +16,8 @@
         "express": "5.2.1",
         "http-proxy-middleware": "^4.1.1",
         "jwt-decode": "4.0.0",
-        "morgan": "^1.11.0"
+        "morgan": "^1.11.0",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.1",

--- a/skribenten-web/bff/package.json
+++ b/skribenten-web/bff/package.json
@@ -21,7 +21,8 @@
     "express": "5.2.1",
     "http-proxy-middleware": "^4.1.1",
     "jwt-decode": "4.0.0",
-    "morgan": "^1.11.0"
+    "morgan": "^1.11.0",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.1",

--- a/skribenten-web/bff/src/metrics.ts
+++ b/skribenten-web/bff/src/metrics.ts
@@ -1,0 +1,66 @@
+import { type Express, type NextFunction, type Request, type Response } from "express";
+import { collectDefaultMetrics, Histogram, Registry } from "prom-client";
+
+const register = new Registry();
+
+// Gir blant annet nodejs_eventloop_lag_seconds, nodejs_heap_size_used_bytes og
+// nodejs_gc_duration_seconds. Event loop lag er hovedgrunnen til at vi samler disse: en blokkert
+// event loop gjør appen treg eller helt uresponsiv uten at container-CPU ser unormal ut, så
+// signalet finnes verken i plattformmetrikkene fra nais eller i de trace-utledede metrikkene.
+collectDefaultMetrics({ register });
+
+// BFF-en proxyer mot skribenten-backend, som har 60s requestTimeout mot brevbaker. Grensene går
+// derfor til 120s, slik at et kall som går til timeout havner innenfor histogrammet og ikke i
+// +Inf. Det er også grunnen til at vi ikke kan nøye oss med de trace-utledede metrikkene fra
+// auto-instrumenteringen: Tempo sine bucket-grenser stopper på 5s og kan ikke konfigureres herfra.
+const svartid = new Histogram({
+  name: "http_server_request_duration_seconds",
+  help: "Svartid for forespørsler til BFF-en, i sekunder",
+  labelNames: ["method", "route", "status_code"],
+  buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120],
+  registers: [register],
+});
+
+/**
+ * Grupperer forespørsler i et fast, lite sett med verdier. Rå sti kan ikke brukes som label -
+ * `/bff/skribenten-backend/sak/12345/brev/678` ville gitt en ny tidsserie per saks- og brev-id.
+ *
+ * Oppdelingen er bevisst grov: skribenten-backend eksponerer allerede latens per rute, så det er
+ * der man finner ut *hvilket* endepunkt som er tregt. BFF-ens oppgave er å vise om proxylaget som
+ * helhet er tregt eller feiler, inkludert OBO-veksling og nettverk.
+ */
+export function klassifiserRute(sti: string): string {
+  if (sti.startsWith("/bff/skribenten-backend")) {
+    return "proxy";
+  }
+  if (sti.startsWith("/bff/api")) {
+    return "bff-api";
+  }
+  if (sti.startsWith("/internal")) {
+    return "probe";
+  }
+  return "static";
+}
+
+const maalSvartid = (request: Request, response: Response, next: NextFunction): void => {
+  const stopp = svartid.startTimer();
+  // "close" fyres både når svaret er ferdig sendt og når klienten kobler fra underveis. "finish"
+  // ville mistet avbrutte forespørsler, og det er nettopp de trege vi er mest interessert i.
+  response.once("close", () => {
+    stopp({
+      method: request.method,
+      route: klassifiserRute(request.path),
+      status_code: response.statusCode,
+    });
+  });
+  next();
+};
+
+export function setupMetrics(server: Express) {
+  server.use(maalSvartid);
+
+  server.get("/internal/metrics", async (_request, response) => {
+    response.set("Content-Type", register.contentType);
+    response.end(await register.metrics());
+  });
+}

--- a/skribenten-web/bff/src/metrics.ts
+++ b/skribenten-web/bff/src/metrics.ts
@@ -47,10 +47,14 @@ const maalSvartid = (request: Request, response: Response, next: NextFunction): 
   // "close" fyres både når svaret er ferdig sendt og når klienten kobler fra underveis. "finish"
   // ville mistet avbrutte forespørsler, og det er nettopp de trege vi er mest interessert i.
   response.once("close", () => {
+    // Ved avbrudd står response.statusCode igjen på standardverdien 200, siden vi aldri rakk å
+    // sette den. Uten dette ville trege kall brukeren ga opp sett ut som vellykkede 2xx i
+    // histogrammet. 499 er samme konvensjon som nginx bruker for "client closed request".
+    const avbrutt = !response.writableEnded;
     stopp({
       method: request.method,
       route: klassifiserRute(request.path),
-      status_code: response.statusCode,
+      status_code: avbrutt ? 499 : response.statusCode,
     });
   });
   next();

--- a/skribenten-web/bff/src/server.ts
+++ b/skribenten-web/bff/src/server.ts
@@ -5,12 +5,17 @@ import { setupSkribentenBackendApiProxy } from "./apiProxy.js";
 import { setupStaticRoutes } from "./frontendRoute.js";
 import { internalRoutes } from "./internalRoutes.js";
 import { setupLogging } from "./logging.js";
+import { setupMetrics } from "./metrics.js";
 import { verifyToken } from "./tokenValidation.js";
 
 const server = express();
 
 // Restricts the server to only accept UTF-8 encoding of bodies
 server.use(express.urlencoded({ extended: true }));
+
+// Må registreres før verifyToken, som ellers svarer 401 på scrapet fra prometheus. Ligger først
+// slik at målingen omfatter alle forespørsler, også de som håndteres av setupActuators.
+setupMetrics(server);
 
 setupActuators(server);
 setupLogging(server);


### PR DESCRIPTION
Lukker hull 1 i [alarmstrategien](https://github.com/navikt/pensjonsbrev/blob/main/docs/modules/ROOT/pages/alarmstrategi.adoc): `skribenten-web` BFF eksponerte ingen metrikker, og var dermed den eneste av de fire applikasjonene vi ikke hadde applikasjonssignaler for.

BFF-en er samtidig proxy for **all** trafikk fra frontend til skribenten-backend. Det er derfor her vi ser svartiden slik saksbehandleren faktisk opplever den — inkludert OBO-veksling og nettverk, som ingen av de andre appene kan måle.

## Hvorfor ikke bare bruke auto-instrumenteringen?

`observability.autoInstrumentation` er allerede slått på med `runtime: nodejs`, og NAIS utleder RED-metrikker fra spans (`traces_spanmetrics_*` i Mimir). Det var det første jeg undersøkte, siden en egen metrikk-kilde ellers ville vært unødvendig duplisering.

De er verifisert mot prod og er **ikke** tilstrekkelige:

| Funn | Konsekvens |
|---|---|
| `span_name` er kun HTTP-metoden (`GET`, `POST`) — ingen `http_route` | BFF-en monterer alt med `server.use(...)` og proxy-middleware i stedet for deklarerte Express-ruter, så `http.route` blir aldri satt. Proxytrafikk kan ikke skilles fra statiske filer. |
| `http_response_status_code` er tom for alle SERVER-spans | 5xx-rate kan ikke måles derfra. |
| Bucket-grensene stopper på **5s** | Settes av Tempos metrics-generator, kan ikke konfigureres fra appen. Kall gjennom proxyen når 60s og mer, så hele halen havner i `+Inf`. |

Sampling er *ikke* et problem — `OTEL_TRACES_SAMPLER` er `parentbased_always_on`.

Den manglende ruteoppdelingen er den viktigste: statiske filer er mange og raske, og ville dominert histogrammet fullstendig. En p95 over all trafikk ville ligget på noen få millisekunder og knapt beveget seg selv om hvert eneste backend-kall ble tregt — alarmen ville sett frisk ut mens saksbehandlerne satt fast.

Span-metrikkene beholdes til feilsøking, og er fortsatt nyttige for å se sammenhengen mellom appene (også Wonderwall har egne serier).

## Hva som er lagt til

`prom-client` med eget register på `/internal/metrics`:

- **`http_server_request_duration_seconds`** — histogram med `method`, `route`, `status_code`. Grenser opp til **120s**, som matcher `requestTimeout` på 60s fra skribenten-backend mot brevbaker, slik at et kall som går til timeout havner innenfor histogrammet.
- **`collectDefaultMetrics()`** — gir blant annet `nodejs_eventloop_lag_seconds`. En blokkert event loop gjør appen treg eller helt uresponsiv **uten** at container-CPU ser unormal ut. Det er den klassiske feilmodusen for Node, og signalet finnes verken i plattformmetrikkene fra nais eller i span-metrikkene.

### Rutelabelen er bevisst grov

`proxy`, `bff-api`, `static`, `probe`. Rå sti er utelukket — `/bff/skribenten-backend/sak/12345/brev/678` ville gitt en ny tidsserie per saks- og brev-id.

skribenten-backend eksponerer allerede latens per rute, så det er der man finner ut *hvilket* endepunkt som er tregt. BFF-ens histogram svarer på om proxylaget som helhet er tregt.

### To detaljer verdt å merke seg

**Middlewaren måler på `close`, ikke `finish`.** `finish` ville mistet forespørsler klienten avbryter underveis — og det er nettopp de trege som ellers ville forsvunnet fra histogrammet, altså de vi vil alarmere på.

**Endepunktet registreres før `verifyToken`**, som ellers ville svart `401` på scrapet. NAIS legger automatisk `prometheus.path` til Wonderwalls `autoLoginIgnorePaths`, så endepunktet er lesbart uten innlogging fra `intern.nav.no`. Det er et bevisst valg: innholdet er driftsdata uten persondata.

## Verifisering

BFF-en har ingen testrammeverk, så jeg verifiserte med et engangsskript mot den bygde `dist/`:

- klassifisering av alle fire rutetypene
- labels og statuskoder, inkludert 500
- 14 bucket-grenser, nøyaktig som spesifisert
- `nodejs_eventloop_lag_seconds`, `nodejs_heap_size_used_bytes`, `nodejs_gc_duration_seconds` og `process_cpu_seconds_total` til stede
- tellerne står på **1** per serie, som bekrefter at `close` ikke dobbelttelles sammen med `finish`

`npm run check-types` og `npm run lint` (biome) er grønne. Antora-bygget av dokumentasjonen er uten advarsler.

## Øvrige endringer

- **Fikser en feil fra #3549:** `{saksId}` ble tolket av AsciiDoc som en attributtreferanse og forsvant fra rendret HTML. Backticks beskytter ikke mot dette. Oppdaget av antora-bygget.
- **Fullfører omdøpingen `forventetHoyest` → `forventetHoeyest`** — kommentarene refererte fortsatt til det gamle navnet.
- Alarmtabellen for skribenten-web er utvidet med feilrate og p95 på `route="proxy"` samt event loop lag. Hull 1 er fjernet og de øvrige renummerert.
- Tiltaket for nedstrøms-metrikker er presisert: Ktor 3.5 har **ingen** klientside-metrikkplugin (verifisert mot `ktor-bom`), så det må skrives et eget — men alle klientene går gjennom `HttpClientFactory.lagHttpClient`, så det kan legges ett sted.
