### PR TITLE
Stopp requesten når tokenvalidering feiler

### DIFF
--- a/skribenten-web/bff/src/tokenValidation.ts
+++ b/skribenten-web/bff/src/tokenValidation.ts
@@ -12,6 +12,7 @@ export const verifyToken = async (request: Request, response: Response, next: Ne
   if (!validation.ok) {
     console.error("Invalid token validation", validation);
     response.status(403).send();
+    return;
   }
 
   next();


### PR DESCRIPTION
`verifyToken` sendte `403` ved ugyldig token, men kalte deretter `next()` likevel. Middleware bakenfor ble derfor kjørt selv om autentiseringen hadde feilet.

```diff
   if (!validation.ok) {
     console.error("Invalid token validation", validation);
     response.status(403).send();
+    return;
   }
```

## Verifisering

Kjørte samme probe mot den faktiske koden før og etter, med et ugyldig token og en handler bak `verifyToken` som teller egne kall:

| | uten token | ugyldig token |
|---|---|---|
| **Før** | `401`, handler nådd **0** ganger | `403`, handler nådd **1** gang |
| **Etter** | `401`, handler nådd **0** ganger | `403`, handler nådd **0** ganger |

Klienten fikk `403` i begge tilfeller, så feilen var usynlig utenfra.

## Hvor alvorlig var det?

I praksis ble requesten neppe proxyet videre. Neste ledd er OBO-middlewaren i `apiProxy.ts`, som forsøker en tokenveksling med det samme ugyldige tokenet og feiler.

Men det betyr at sikkerhetsgrensen hvilte på at en **annen og urelatert sjekk** feilet, ikke på selve autentiseringsbeslutningen. Et token som `validateToken` avviser, men som OBO-vekslingen ville akseptert, ville sluppet gjennom. I tillegg utførte hver forespørsel med ugyldig token en unødvendig tokenveksling mot Azure AD, og forsøket på å svare `403` en gang til traff et svar som allerede var sendt.

## Om returstil

Jeg vurderte konvensjonen `return response.status(x).send()` / `return next()` som brukes i enkelte andre apper, men den passer ikke her:

- `send()` returnerer `Response`, mens funksjonen er annotert `Promise<void>` → `TS2322`.
- Å utvide til `Promise<void | Response>` får filen til å kompilere, men brekker `server.use(verifyToken)` i `server.ts` med `TS2769` — Express' overload-oppløsning godtar ikke en middleware som returnerer `Response`.

Konvensjonen ville uansett ikke forhindret denne feilen, som var en *manglende* `return`, ikke feil returstil.

`apiProxy.ts` har samme mønster, men der er kontrollflyten allerede korrekt — den er ikke rørt.

`npm run check-types` og `npm run lint` (biome) er grønne.
