### PR TITLE
Hold helsesjekker utenfor metrikkene

### DIFF
--- a/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/Metrics.kt
+++ b/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/Metrics.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.brev.pdfbygger
 
 import io.ktor.server.application.*
 import io.ktor.server.metrics.micrometer.*
+import io.ktor.server.request.path
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.micrometer.core.instrument.config.MeterFilter
@@ -13,6 +14,20 @@ import kotlin.time.Duration.Companion.seconds
 
 object Metrics {
     private val prometheusRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+    // Helsesjekker og metrikkendepunktet kalles av kubernetes og prometheus uavhengig av last
+    // (~0,23 req/s per pod). De holdes derfor utenfor både access-loggen og metrikkene:
+    //  - De fortynner nevneren i feilrate-alarmer. Med 6 poder i prod utgjør de ~99 % av
+    //    trafikken ved normal last, slik at en alarm på 5 % feilrate aldri kunne utløst - ikke
+    //    engang om samtlige ekte kall feilet. pdf-bygger har lite trafikk mellom batchene, så
+    //    dette er normaltilstanden og ikke et sjeldent hjørnetilfelle.
+    //  - Hver rute koster ~58 tidsserier fordi den får hele bucket-settet, for en latens som er
+    //    konstant og under millisekundet. Det slår ekstra hardt ut her, siden pdf-bygger
+    //    skalerer opp til 150 poder.
+    private val ikkeObserverteStier = setOf("/isAlive", "/isReady", "/metrics")
+
+    // Både CallLogging og MicrometerMetrics tar med kallet når predikatet er true.
+    fun skalObserveres(call: ApplicationCall): Boolean = call.request.path() !in ikkeObserverteStier
 
     // Kompilering med typst er CPU-tung, og de tyngste brevene bruker flere sekunder.
     // Ytterpunktene styrer hvor micrometer genererer automatiske buckets.
@@ -47,6 +62,7 @@ object Metrics {
 
         install(MicrometerMetrics) {
             registry = prometheusRegistry
+            filter(::skalObserveres)
             // Ktor eksporterer som standard latens som en summary med klientside-kvantiler, og de
             // kan ikke aggregeres på tvers av poder - en p99 fra én pod sier ingenting om p99 for
             // tjenesten. Når vi setter bucket-grenser eksporteres metrikken i stedet som et ekte

--- a/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/PdfByggerApp.kt
+++ b/brevbaker/pdf-bygger/src/main/kotlin/no/nav/pensjon/brev/pdfbygger/PdfByggerApp.kt
@@ -13,7 +13,6 @@ import io.ktor.server.plugins.callid.generate
 import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.statuspages.StatusPages
-import io.ktor.server.request.path
 import io.ktor.server.request.receive
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.*
@@ -63,10 +62,7 @@ internal fun Application.setUp(typstCompileService: TypstCompileService) {
     install(CallLogging) {
         callIdMdc("x_correlationId")
         disableDefaultColors()
-        val ignorePaths = setOf("/isAlive", "/isReady", "/metrics")
-        filter {
-            !ignorePaths.contains(it.request.path())
-        }
+        filter(Metrics::skalObserveres)
         mdc("x_response_code") { it.response.status()?.value?.toString() }
     }
 

--- a/brevbaker/pdf-bygger/src/test/kotlin/no/nav/pensjon/brev/pdfbygger/MetricsRouteTest.kt
+++ b/brevbaker/pdf-bygger/src/test/kotlin/no/nav/pensjon/brev/pdfbygger/MetricsRouteTest.kt
@@ -17,12 +17,35 @@ class MetricsRouteTest {
     private fun withScrape(block: (List<String>) -> Unit) = testApplication {
         environment { config = ApplicationConfig(null) }
 
-        client.get("/isAlive")
+        // Må være en rute som faktisk instrumenteres. Helsesjekkene filtreres bort, mens en
+        // ukjent sti registreres som route="n/a".
+        client.get("/finnes-ikke")
         val metrikker = client.get("/metrics").bodyAsText().lines()
             .filter { it.startsWith("ktor_http_server_requests_seconds") }
         // Uten denne ville assertFalse-testene under passert selv om scrapingen ikke ga noe.
         assertTrue(metrikker.isNotEmpty()) { "Fant ingen ktor_http_server_requests_seconds-metrikker" }
         block(metrikker)
+    }
+
+    @Test
+    fun `helsesjekker og metrikkendepunktet instrumenteres ikke`() = testApplication {
+        environment { config = ApplicationConfig(null) }
+
+        client.get("/isAlive")
+        client.get("/isReady")
+        client.get("/finnes-ikke")
+
+        val metrikker = client.get("/metrics").bodyAsText().lines()
+            .filter { it.startsWith("ktor_http_server_requests_seconds") }
+        assertTrue(metrikker.isNotEmpty()) { "Fant ingen ktor_http_server_requests_seconds-metrikker" }
+
+        // Ved normal last i prod utgjør disse ~99 % av trafikken. Blir de tatt med, kan en alarm
+        // på 5 % feilrate aldri utløse - ikke engang om samtlige ekte kall feiler.
+        listOf("/isAlive", "/isReady", "/metrics").forEach { sti ->
+            assertFalse(metrikker.any { it.contains("route=\"$sti\"") }) {
+                "Forventet ingen metrikker for $sti, fant:\n${metrikker.filter { it.contains("route=\"$sti\"") }.joinToString("\n")}"
+            }
+        }
     }
 
     @Test

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/BrevbakerAppModule.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/BrevbakerAppModule.kt
@@ -43,10 +43,7 @@ fun Application.brevbakerModule(
     install(CallLogging) {
         callIdMdc("x_correlationId")
         disableDefaultColors()
-        val ignorePaths = setOf("/isAlive", "/isReady", "/metrics")
-        filter {
-            !ignorePaths.contains(it.request.path())
-        }
+        filter(Metrics::skalObserveres)
         mdc("x_response_code") { it.response.status()?.value?.toString() }
         mdc("x_brevkode") { it.useBrevkodeFromCallContext() }
     }

--- a/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/Metrics.kt
+++ b/pensjon/brevbaker/src/main/kotlin/no/nav/pensjon/brev/Metrics.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.brev
 
 import io.ktor.server.application.*
 import io.ktor.server.metrics.micrometer.*
+import io.ktor.server.request.path
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.micrometer.core.instrument.config.MeterFilter
@@ -13,6 +14,20 @@ import kotlin.time.Duration.Companion.seconds
 
 object Metrics {
     val prometheusRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+    // Helsesjekker og metrikkendepunktet kalles av kubernetes og prometheus uavhengig av last
+    // (~0,25 req/s per pod). De holdes derfor utenfor både access-loggen og metrikkene:
+    //  - De fortynner nevneren i feilrate-alarmer. I prod utgjør de ~79 % av trafikken ved
+    //    normal last, slik at en alarm på 5 % feilrate først ville utløst når ~25 % av de ekte
+    //    kallene feilet. Fortynningen er verst når trafikken er lav - altså nettopp når en
+    //    stanset batch gir få ekte kall å måle på.
+    //  - Hver rute koster ~58 tidsserier fordi den får hele bucket-settet, for en latens som er
+    //    konstant og under millisekundet.
+    // /ping_authorized er også en helsesjekk, bare bak autentisering.
+    private val ikkeObserverteStier = setOf("/isAlive", "/isReady", "/metrics", "/ping_authorized")
+
+    // Både CallLogging og MicrometerMetrics tar med kallet når predikatet er true.
+    fun skalObserveres(call: ApplicationCall): Boolean = call.request.path() !in ikkeObserverteStier
 
     // Brevbaker kaller pdf-bygger og bruker derfor sekunder, ikke millisekunder, på /letter-rutene.
     // Ytterpunktene styrer hvor micrometer genererer automatiske buckets.
@@ -49,6 +64,7 @@ object Metrics {
 
         install(MicrometerMetrics) {
             registry = prometheusRegistry
+            filter(::skalObserveres)
             // Ktor eksporterer som standard latens som en summary med klientside-kvantiler, og de
             // kan ikke aggregeres på tvers av poder - en p99 fra én pod sier ingenting om p99 for
             // tjenesten. Når vi setter bucket-grenser eksporteres metrikken i stedet som et ekte

--- a/pensjon/brevbaker/src/test/kotlin/no/nav/pensjon/brev/routing/MetricsRouteTest.kt
+++ b/pensjon/brevbaker/src/test/kotlin/no/nav/pensjon/brev/routing/MetricsRouteTest.kt
@@ -14,13 +14,34 @@ class MetricsRouteTest {
         Regex("""[,{]le="([^"]+)"""").find(bucket)?.groupValues?.get(1)
 
     private suspend fun io.ktor.client.HttpClient.scrapeAfterRequest(): List<String> {
-        get("/isAlive")
+        // Må være en rute som faktisk instrumenteres. Helsesjekkene filtreres bort, mens en
+        // ukjent sti registreres som route="n/a" og krever ingen innlogging.
+        get("/finnes-ikke")
         val metrikker = get("/metrics").bodyAsText().lines()
             .filter { it.startsWith("ktor_http_server_requests_seconds") }
         // Uten denne ville assertFalse-testene under passert selv om scrapingen ikke ga noe.
         assertTrue(metrikker.isNotEmpty()) { "Fant ingen ktor_http_server_requests_seconds-metrikker" }
         return metrikker
     }
+
+    @Test
+    fun `helsesjekker og metrikkendepunktet instrumenteres ikke`() =
+        testBrevbakerApp(isIntegrationTest = false) { client ->
+            client.get("/isAlive")
+            client.get("/isReady")
+            client.get("/ping_authorized")
+
+            val metrikker = client.scrapeAfterRequest()
+
+            // Ved normal last i prod utgjør disse ~79 % av trafikken. Blir de tatt med, fortynner
+            // de nevneren i feilrate-alarmene så kraftig at ~25 % av de ekte kallene må feile før
+            // en 5 %-alarm utløser.
+            listOf("/isAlive", "/isReady", "/metrics", "/ping_authorized").forEach { sti ->
+                assertFalse(metrikker.any { it.contains("route=\"$sti\"") }) {
+                    "Forventet ingen metrikker for $sti, fant:\n${metrikker.filter { it.contains("route=\"$sti\"") }.joinToString("\n")}"
+                }
+            }
+        }
 
     @Test
     fun `latens rapporteres som histogram-buckets slik at de kan aggregeres paa tvers av poder`() =

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Metrics.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/Metrics.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.brev.skribenten
 
 import io.ktor.server.application.*
 import io.ktor.server.metrics.micrometer.*
+import io.ktor.server.request.path
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.micrometer.core.instrument.config.MeterFilter
@@ -13,6 +14,22 @@ import kotlin.time.Duration.Companion.seconds
 
 object Metrics {
     private val prometheusRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+    // Helsesjekker og metrikkendepunktet kalles av kubernetes og prometheus uavhengig av last
+    // (~0,25 req/s per pod). De holdes derfor utenfor både access-loggen og metrikkene:
+    //  - De fortynner nevneren i feilrate-alarmer. I prod utgjør de ~42 % av trafikken ved
+    //    normal last, slik at en alarm på 5 % feilrate først ville utløst når ~9 % av de ekte
+    //    kallene feilet. Andelen stiger mot 100 % utenfor kontortid, når saksbehandlerne er
+    //    borte og probene er den eneste trafikken.
+    //  - Hver rute koster ~58 tidsserier fordi den får hele bucket-settet, for en latens som er
+    //    konstant og under millisekundet.
+    // At /isReady faller ut som signal er greit: svarer den 503, tas poden ut av rotasjon, og det
+    // fanges av kube_deployment_status_replicas_available. Den kilden dekker i tillegg tilfellet
+    // der appen er så låst at den ikke rekker å svare på /metrics i det hele tatt.
+    private val ikkeObserverteStier = setOf("/isAlive", "/isReady", "/metrics")
+
+    // Både CallLogging og MicrometerMetrics tar med kallet når predikatet er true.
+    fun skalObserveres(call: ApplicationCall): Boolean = call.request.path() !in ikkeObserverteStier
 
     // Skribenten er en interaktiv saksbehandlerflate, så vi er interessert i lavere latens enn i
     // brevbaker. Ytterpunktene styrer hvor micrometer genererer automatiske buckets.
@@ -49,6 +66,7 @@ object Metrics {
 
         install(MicrometerMetrics) {
             registry = prometheusRegistry
+            filter(::skalObserveres)
             // Ktor eksporterer som standard latens som en summary med klientside-kvantiler, og de
             // kan ikke aggregeres på tvers av poder - en p99 fra én pod sier ingenting om p99 for
             // tjenesten. Når vi setter bucket-grenser eksporteres metrikken i stedet som et ekte

--- a/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
+++ b/skribenten-backend/src/main/kotlin/no/nav/pensjon/brev/skribenten/SkribentenApp.kt
@@ -52,10 +52,7 @@ fun Application.skribentenApp() {
     install(CallLogging) {
         callIdMdc("x_correlationId")
         disableDefaultColors()
-        val ignorePaths = setOf("/isAlive", "/isReady", "/metrics")
-        filter {
-            !ignorePaths.contains(it.request.path())
-        }
+        filter(Metrics::skalObserveres)
         mdc("x_userId") { call ->
             call.principal<JwtUserPrincipal>()?.navIdent?.id
         }

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/MetricsRouteTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/MetricsRouteTest.kt
@@ -22,14 +22,36 @@ class MetricsRouteTest {
         environment { config = MapApplicationConfig() }
         application { configureMetrics() }
 
-        // Første kall gir noe å måle, siden metrikken for et kall først registreres når det er
-        // ferdig og dermed ikke rekker å bli med i sin egen scrape.
-        client.get("/metrics")
+        // Må være en rute som faktisk instrumenteres. /metrics filtreres nå bort, mens en ukjent
+        // sti registreres som route="n/a".
+        client.get("/finnes-ikke")
         val metrikker = client.get("/metrics").bodyAsText().lines()
             .filter { it.startsWith("ktor_http_server_requests_seconds") }
         // Uten denne ville assertFalse-testene under passert selv om scrapingen ikke ga noe.
         assertTrue(metrikker.isNotEmpty()) { "Fant ingen ktor_http_server_requests_seconds-metrikker" }
         block(metrikker)
+    }
+
+    @Test
+    fun `helsesjekker og metrikkendepunktet instrumenteres ikke`() = testApplication {
+        environment { config = MapApplicationConfig() }
+        application { configureMetrics() }
+
+        client.get("/isAlive")
+        client.get("/isReady")
+        client.get("/finnes-ikke")
+
+        val metrikker = client.get("/metrics").bodyAsText().lines()
+            .filter { it.startsWith("ktor_http_server_requests_seconds") }
+        assertTrue(metrikker.isNotEmpty()) { "Fant ingen ktor_http_server_requests_seconds-metrikker" }
+
+        // Ved normal last i prod utgjør disse ~42 % av trafikken, og andelen stiger mot 100 %
+        // utenfor kontortid. Blir de tatt med, fortynner de nevneren i feilrate-alarmene.
+        listOf("/isAlive", "/isReady", "/metrics").forEach { sti ->
+            assertFalse(metrikker.any { it.contains("route=\"$sti\"") }) {
+                "Forventet ingen metrikker for $sti, fant:\n${metrikker.filter { it.contains("route=\"$sti\"") }.joinToString("\n")}"
+            }
+        }
     }
 
     @Test

--- a/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/MetricsRouteTest.kt
+++ b/skribenten-backend/src/test/kotlin/no/nav/pensjon/brev/skribenten/MetricsRouteTest.kt
@@ -3,8 +3,10 @@ package no.nav.pensjon.brev.skribenten
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import no.nav.pensjon.brev.skribenten.Metrics.configureMetrics
+import no.nav.pensjon.brev.skribenten.routes.healthRoute
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -35,7 +37,14 @@ class MetricsRouteTest {
     @Test
     fun `helsesjekker og metrikkendepunktet instrumenteres ikke`() = testApplication {
         environment { config = MapApplicationConfig() }
-        application { configureMetrics() }
+        // healthRoute() leser bare et AtomicBoolean-flagg, så den kan installeres uten database.
+        // Vi bruker de ekte rutene her med vilje: hadde vi latt /isAlive og /isReady være
+        // uregistrerte, ville de blitt 404 og fått route="n/a", og assert-ene under ville passert
+        // uten å bevise noe som helst.
+        application {
+            configureMetrics()
+            routing { healthRoute() }
+        }
 
         client.get("/isAlive")
         client.get("/isReady")


### PR DESCRIPTION
## Hva

Helsesjekk- og metrikkendepunktene (`/isAlive`, `/isReady`, `/metrics`, samt `/ping_authorized` i brevbaker) instrumenteres ikke lenger av `MicrometerMetrics`.

Filteret som allerede fantes i `CallLogging` er ekstrahert til `Metrics.skalObserveres(call)` og gjenbrukes nå av begge plugins, i alle tre Ktor-appene.

## Hvorfor

### 1. Sondetrafikk fortynner nevneren i alle feilrate-alarmer

Vi er i ferd med å implementere alarmene fra `alarmstrategi.adoc`. En typisk regel er «over 5 % 5xx». Med sondene inkludert er andelen av trafikken som er sonder, ved normal last i prod:

| App | Sondeandel | Reell feilrate som kreves for å utløse 5 %-alarm |
|---|---|---|
| pensjon-brevbaker | 79 % | 24 % |
| pensjon-pdf-bygger | 99 % | 496 % (umulig) |
| skribenten-backend | 42 % | 9 % |

Sondene svarer alltid 200, så de er ren fortynning. Merk at andelen er **høyest ved lav trafikk** — altså nøyaktig i situasjonen der en stoppet batch gir få reelle kall å måle på. Under batchlast faller andelen til 6–32 %.

(Tallene er regnet ut fra prod-trafikktall kombinert med målt sonderate på ca. 0,25 req/s per pod.)

### 2. Kardinalitet

Hver instrumentert rute koster ca. 58 tidsserier (55 histogram-bøtter + `_count`/`_sum` + `requests_active`-bidrag). Sonderutene sto for **174–186 tidsserier per pod** uten å gi noen informasjon: `/isAlive` bruker i snitt 1,28 ms mot en nedre bøttegrense på 100 ms, så samtlige bøtter er identiske med `_count`.

### 3. Konsistens

`CallLogging` filtrerte allerede bort de samme stiene. Nå er det én definisjon i stedet for to som kan komme i utakt.

## Bonus: `ktor_http_server_requests_active` blir brukbar

Filteret i `MicrometerMetrics` gater ikke bare timeren, men også `active?.incrementAndGet()` (se Ktor 3.5.1 `MicrometerMetrics.kt`). Denne måleren har ingen `route`-tag, så et `MeterFilter.deny` på registry-nivå ville ikke hjulpet. Etter denne endringen teller den faktisk reelt pågående arbeid.

## Om tapt signal

Vi mister muligheten til å alarmere på 503 fra `/isReady`. Det er greit — `kube_deployment_status_replicas_available` fra Nais dekker det samme bedre, og er allerede tenkt brukt i strategien.

## Testing

Alle tre `MetricsRouteTest` er oppdatert: skrape-hjelperen treffer nå `/finnes-ikke` i stedet for `/isAlive`, og hver app har fått en ny regresjonstest `helsesjekker og metrikkendepunktet instrumenteres ikke`. 4/4 grønne per app.

Negativ kontroll utført: fjernet `filter(::skalObserveres)` fra brevbaker, og den nye testen feilet som forventet.
